### PR TITLE
Log out from spotify when shutting down

### DIFF
--- a/mopidy/backends/spotify/__init__.py
+++ b/mopidy/backends/spotify/__init__.py
@@ -85,6 +85,9 @@ class SpotifyBackend(ThreadingActor, Backend):
         logger.info(u'Mopidy uses SPOTIFY(R) CORE')
         self.spotify = self._connect()
 
+    def on_stop(self):
+        self.spotify.logout()
+
     def _connect(self):
         from .session_manager import SpotifySessionManager
 

--- a/mopidy/backends/spotify/session_manager.py
+++ b/mopidy/backends/spotify/session_manager.py
@@ -160,3 +160,8 @@ class SpotifySessionManager(BaseThread, PyspotifySessionManager):
         self.connected.wait()
         self.session.search(query, callback, track_count=100,
             album_count=0, artist_count=0)
+
+    def logout(self):
+        """Log out from spotify"""
+        logger.debug(u'Logging out from spotify')
+        self.session.logout()


### PR DESCRIPTION
This seems to make my start-up faster, as suggested by "bok".
