### PR TITLE
Guess what setting you meant based on levenshtein.

### DIFF
--- a/mopidy/utils/settings.py
+++ b/mopidy/utils/settings.py
@@ -202,6 +202,7 @@ def did_you_mean(setting, defaults):
     if not defaults:
         return None
 
+    setting = setting.upper()
     candidates = [(levenshtein(setting, d), d) for d in defaults]
     candidates.sort()
 

--- a/tests/utils/settings_test.py
+++ b/tests/utils/settings_test.py
@@ -217,3 +217,27 @@ class FormatSettingListTest(unittest.TestCase):
         self.assert_("""FRONTEND: 
   (u'mopidy.frontends.mpd.MpdFrontend',
    u'mopidy.frontends.lastfm.LastfmFrontend')""" in result, result)
+
+
+class DidYouMeanTest(unittest.TestCase):
+    def testSuggestoins(self):
+        defaults = {
+            'MPD_SERVER_HOSTNAME': '::',
+            'MPD_SERVER_PORT': 6600,
+            'SPOTIFY_BITRATE': 160,
+        }
+
+        suggestion = setting_utils.did_you_mean('spotify_bitrate', defaults)
+        self.assertEqual(suggestion, 'SPOTIFY_BITRATE')
+
+        suggestion = setting_utils.did_you_mean('SPOTIFY_BITROTE', defaults)
+        self.assertEqual(suggestion, 'SPOTIFY_BITRATE')
+
+        suggestion = setting_utils.did_you_mean('SPITIFY_BITROT', defaults)
+        self.assertEqual(suggestion, 'SPOTIFY_BITRATE')
+
+        suggestion = setting_utils.did_you_mean('SPTIFY_BITROT', defaults)
+        self.assertEqual(suggestion, 'SPOTIFY_BITRATE')
+
+        suggestion = setting_utils.did_you_mean('SPTIFY_BITRO', defaults)
+        self.assertEqual(suggestion, None)


### PR DESCRIPTION
Silly little hack inspired by the wonderful error messages clang provides.
