### PR TITLE
Create a Track proxy for spotify (Fixes #72)

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -68,6 +68,9 @@ v0.8 (in development)
   cleanup code would wait for an response that would never come inside the
   event loop, blocking everything else.
 
+- Created a Spotify track proxy that will switch to using loaded data as soon
+  as it becomes available. Fixes :issue:`72`.
+
 
 v0.7.3 (2012-08-11)
 ===================

--- a/mopidy/backends/spotify/library.py
+++ b/mopidy/backends/spotify/library.py
@@ -11,6 +11,7 @@ logger = logging.getLogger('mopidy.backends.spotify.library')
 
 
 class SpotifyTrack(Track):
+    """Proxy object for unloaded Spotify tracks."""
     def __init__(self, uri):
         self._spotify_track = Link.from_string(uri).as_track()
         self._unloaded_track = Track(uri=uri, name=u'[loading...]')
@@ -34,15 +35,15 @@ class SpotifyTrack(Track):
     def __repr__(self):
         return self._proxy.__repr__()
 
-    def __hash__(self):  # hash on just uri for consistency?
+    def __hash__(self):
         return hash(self._proxy.uri)
 
-    def __eq__(self, other): # compare on just uri for consistency?
+    def __eq__(self, other):
         if not isinstance(other, Track):
             return False
         return self._proxy.uri == other.uri
 
-    def copy(self, **values): # is it okay to return a plain track?
+    def copy(self, **values):
         return self._proxy.copy(**values)
 
 


### PR DESCRIPTION
Implemented the idea I had for fixing #72.  Testing with each of the following commands in quick succession gives:

```
$ mpc add spotify:track:5ZS8rDF1FrYyhbZM99BPpn 
$ mpc playlist                                 
[loading...]
$ mpc playlist
Ringo Starr - Yellow Submarine
```

If accessing the thread object like this is thread safe we should be good to go. Alternative would simply be to only store `_uri` and `_track` and just re-create the spotify track per access until it is loaded.
