### PR TITLE
Adds SPOTIFY_AUTOLOAD_PLAYLIST setting.

### DIFF
--- a/mopidy/backends/spotify/session_manager.py
+++ b/mopidy/backends/spotify/session_manager.py
@@ -156,6 +156,15 @@ class SpotifySessionManager(BaseThread, PyspotifySessionManager):
         playlists = filter(None, playlists)
         self.backend.stored_playlists.playlists = playlists
         logger.debug(u'Refreshed %d stored playlist(s)', len(playlists))
+        try:
+            playlist = self.backend.stored_playlists.\
+                    get(name=settings.SPOTIFY_AUTOLOAD_PLAYLIST).get()
+            self.backend.current_playlist.append(playlist.tracks)
+            logger.info(u'Loaded {0}'.\
+                    format(settings.SPOTIFY_AUTOLOAD_PLAYLIST))
+        except LookupError:
+            logger.info(u"No such playlist {0}".\
+                    format(settings.SPOTIFY_AUTOLOAD_PLAYLIST))
 
     def search(self, query, queue):
         """Search method used by Mopidy backend"""

--- a/mopidy/settings.py
+++ b/mopidy/settings.py
@@ -187,3 +187,9 @@ SPOTIFY_PASSWORD = u''
 #:
 #:     SPOTIFY_BITRATE = 160
 SPOTIFY_BITRATE = 160
+
+#: Playlist to load on startup
+#:
+#: Used by :mod:'mopidy.backends.spotify'.
+SPOTIFY_AUTOLOAD_PLAYLIST = u''
+


### PR DESCRIPTION
Adds `SPOTIFY_AUTOLOAD_PLAYLIST` to `settings.py` and uses a similar call to that in `frontends.mpd.protocol.stored_playlist.load()` in `backends.spotify.session_manager.refresh_stored_playlists()`.
