### PR TITLE
Add PlaybackState enum

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -16,6 +16,9 @@ Playback controller
 Manages playback, with actions like play, pause, stop, next, previous,
 seek, and volume control.
 
+.. autoclass:: mopidy.core.PlaybackState
+    :members:
+
 .. autoclass:: mopidy.core.PlaybackController
     :members:
 

--- a/mopidy/backends/spotify/playback.py
+++ b/mopidy/backends/spotify/playback.py
@@ -3,6 +3,7 @@ import logging
 from spotify import Link, SpotifyError
 
 from mopidy.backends.base import BasePlaybackProvider
+from mopidy.core import PlaybackState
 
 logger = logging.getLogger('mopidy.backends.spotify.playback')
 
@@ -11,7 +12,7 @@ class SpotifyPlaybackProvider(BasePlaybackProvider):
         return self.backend.audio.pause_playback()
 
     def play(self, track):
-        if self.backend.playback.state == self.backend.playback.PLAYING:
+        if self.backend.playback.state == PlaybackState.PLAYING:
             self.backend.spotify.session.play(0)
         if track.uri is None:
             return False

--- a/mopidy/core/__init__.py
+++ b/mopidy/core/__init__.py
@@ -1,4 +1,4 @@
 from .current_playlist import CurrentPlaylistController
 from .library import LibraryController
-from .playback import PlaybackController
+from .playback import PlaybackController, PlaybackState
 from .stored_playlists import StoredPlaylistsController

--- a/mopidy/frontends/mpd/protocol/playback.py
+++ b/mopidy/frontends/mpd/protocol/playback.py
@@ -1,4 +1,4 @@
-from mopidy import core
+from mopidy.core import PlaybackState
 from mopidy.frontends.mpd.protocol import handle_request
 from mopidy.frontends.mpd.exceptions import (MpdArgError, MpdNoExistError,
     MpdNotImplemented)
@@ -104,11 +104,9 @@ def pause(context, state=None):
     - Calls ``pause`` without any arguments to toogle pause.
     """
     if state is None:
-        if (context.backend.playback.state.get() ==
-                core.PlaybackController.PLAYING):
+        if (context.backend.playback.state.get() == PlaybackState.PLAYING):
             context.backend.playback.pause()
-        elif (context.backend.playback.state.get() ==
-                core.PlaybackController.PAUSED):
+        elif (context.backend.playback.state.get() == PlaybackState.PAUSED):
             context.backend.playback.resume()
     elif int(state):
         context.backend.playback.pause()
@@ -185,11 +183,9 @@ def playpos(context, songpos):
         raise MpdArgError(u'Bad song index', command=u'play')
 
 def _play_minus_one(context):
-    if (context.backend.playback.state.get() ==
-            core.PlaybackController.PLAYING):
+    if (context.backend.playback.state.get() == PlaybackState.PLAYING):
         return # Nothing to do
-    elif (context.backend.playback.state.get() ==
-            core.PlaybackController.PAUSED):
+    elif (context.backend.playback.state.get() == PlaybackState.PAUSED):
         return context.backend.playback.resume().get()
     elif context.backend.playback.current_cp_track.get() is not None:
         cp_track = context.backend.playback.current_cp_track.get()

--- a/mopidy/frontends/mpd/protocol/status.py
+++ b/mopidy/frontends/mpd/protocol/status.py
@@ -1,6 +1,6 @@
 import pykka.future
 
-from mopidy import core
+from mopidy.core import PlaybackState
 from mopidy.frontends.mpd.exceptions import MpdNotImplemented
 from mopidy.frontends.mpd.protocol import handle_request
 from mopidy.frontends.mpd.translator import track_to_mpd_format
@@ -194,8 +194,8 @@ def status(context):
     if futures['playback.current_cp_track'].get() is not None:
         result.append(('song', _status_songpos(futures)))
         result.append(('songid', _status_songid(futures)))
-    if futures['playback.state'].get() in (core.PlaybackController.PLAYING,
-            core.PlaybackController.PAUSED):
+    if futures['playback.state'].get() in (PlaybackState.PLAYING,
+            PlaybackState.PAUSED):
         result.append(('time', _status_time(futures)))
         result.append(('elapsed', _status_time_elapsed(futures)))
         result.append(('bitrate', _status_bitrate(futures)))
@@ -239,11 +239,11 @@ def _status_songpos(futures):
 
 def _status_state(futures):
     state = futures['playback.state'].get()
-    if state == core.PlaybackController.PLAYING:
+    if state == PlaybackState.PLAYING:
         return u'play'
-    elif state == core.PlaybackController.STOPPED:
+    elif state == PlaybackState.STOPPED:
         return u'stop'
-    elif state == core.PlaybackController.PAUSED:
+    elif state == PlaybackState.PAUSED:
         return u'pause'
 
 def _status_time(futures):

--- a/mopidy/frontends/mpris/objects.py
+++ b/mopidy/frontends/mpris/objects.py
@@ -14,8 +14,9 @@ except ImportError as import_error:
 
 from pykka.registry import ActorRegistry
 
-from mopidy import core, settings
+from mopidy import settings
 from mopidy.backends.base import Backend
+from mopidy.core import PlaybackState
 from mopidy.utils.process import exit_process
 
 # Must be done before dbus.SessionBus() is called
@@ -197,11 +198,11 @@ class MprisObject(dbus.service.Object):
             logger.debug(u'%s.PlayPause not allowed', PLAYER_IFACE)
             return
         state = self.backend.playback.state.get()
-        if state == core.PlaybackController.PLAYING:
+        if state == PlaybackState.PLAYING:
             self.backend.playback.pause().get()
-        elif state == core.PlaybackController.PAUSED:
+        elif state == PlaybackState.PAUSED:
             self.backend.playback.resume().get()
-        elif state == core.PlaybackController.STOPPED:
+        elif state == PlaybackState.STOPPED:
             self.backend.playback.play().get()
 
     @dbus.service.method(dbus_interface=PLAYER_IFACE)
@@ -219,7 +220,7 @@ class MprisObject(dbus.service.Object):
             logger.debug(u'%s.Play not allowed', PLAYER_IFACE)
             return
         state = self.backend.playback.state.get()
-        if state == core.PlaybackController.PAUSED:
+        if state == PlaybackState.PAUSED:
             self.backend.playback.resume().get()
         else:
             self.backend.playback.play().get()
@@ -286,11 +287,11 @@ class MprisObject(dbus.service.Object):
 
     def get_PlaybackStatus(self):
         state = self.backend.playback.state.get()
-        if state == core.PlaybackController.PLAYING:
+        if state == PlaybackState.PLAYING:
             return 'Playing'
-        elif state == core.PlaybackController.PAUSED:
+        elif state == PlaybackState.PAUSED:
             return 'Paused'
-        elif state == core.PlaybackController.STOPPED:
+        elif state == PlaybackState.STOPPED:
             return 'Stopped'
 
     def get_LoopStatus(self):

--- a/mopidy/models.py
+++ b/mopidy/models.py
@@ -1,5 +1,6 @@
 from collections import namedtuple
 
+
 class ImmutableObject(object):
     """
     Superclass for immutable objects whose fields can only be modified via the

--- a/tests/backends/base/current_playlist.py
+++ b/tests/backends/base/current_playlist.py
@@ -2,6 +2,7 @@ import mock
 import random
 
 from mopidy import audio
+from mopidy.core import PlaybackState
 from mopidy.models import CpTrack, Playlist, Track
 
 from tests.backends.base import populate_playlist
@@ -71,9 +72,9 @@ class CurrentPlaylistControllerTest(object):
     @populate_playlist
     def test_clear_when_playing(self):
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
         self.controller.clear()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     def test_get_by_uri_returns_unique_match(self):
         track = Track(uri='a')
@@ -134,13 +135,13 @@ class CurrentPlaylistControllerTest(object):
         self.playback.play()
         track = self.playback.current_track
         self.controller.append(self.controller.tracks[1:2])
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
         self.assertEqual(self.playback.current_track, track)
 
     @populate_playlist
     def test_append_preserves_stopped_state(self):
         self.controller.append(self.controller.tracks[1:2])
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.assertEqual(self.playback.current_track, None)
 
     def test_index_returns_index_of_track(self):

--- a/tests/backends/base/playback.py
+++ b/tests/backends/base/playback.py
@@ -3,6 +3,7 @@ import random
 import time
 
 from mopidy import audio
+from mopidy.core import PlaybackState
 from mopidy.models import Track
 
 from tests import unittest
@@ -26,21 +27,21 @@ class PlaybackControllerTest(object):
             'First song needs to be at least 2000 miliseconds'
 
     def test_initial_state_is_stopped(self):
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     def test_play_with_empty_playlist(self):
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     def test_play_with_empty_playlist_return_value(self):
         self.assertEqual(self.playback.play(), None)
 
     @populate_playlist
     def test_play_state(self):
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @populate_playlist
     def test_play_return_value(self):
@@ -48,9 +49,9 @@ class PlaybackControllerTest(object):
 
     @populate_playlist
     def test_play_track_state(self):
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.playback.play(self.current_playlist.cp_tracks[-1])
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @populate_playlist
     def test_play_track_return_value(self):
@@ -70,7 +71,7 @@ class PlaybackControllerTest(object):
         track = self.playback.current_track
         self.playback.pause()
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
         self.assertEqual(track, self.playback.current_track)
 
     @populate_playlist
@@ -81,7 +82,7 @@ class PlaybackControllerTest(object):
         track = self.playback.current_track
         self.playback.pause()
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
         self.assertEqual(track, self.playback.current_track)
 
     @populate_playlist
@@ -106,12 +107,12 @@ class PlaybackControllerTest(object):
     def test_current_track_after_completed_playlist(self):
         self.playback.play(self.current_playlist.cp_tracks[-1])
         self.playback.on_end_of_track()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.assertEqual(self.playback.current_track, None)
 
         self.playback.play(self.current_playlist.cp_tracks[-1])
         self.playback.next()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.assertEqual(self.playback.current_track, None)
 
     @populate_playlist
@@ -141,17 +142,17 @@ class PlaybackControllerTest(object):
         self.playback.next()
         self.playback.stop()
         self.playback.previous()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_previous_at_start_of_playlist(self):
         self.playback.previous()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.assertEqual(self.playback.current_track, None)
 
     def test_previous_for_empty_playlist(self):
         self.playback.previous()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.assertEqual(self.playback.current_track, None)
 
     @populate_playlist
@@ -185,20 +186,20 @@ class PlaybackControllerTest(object):
     @populate_playlist
     def test_next_does_not_trigger_playback(self):
         self.playback.next()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_next_at_end_of_playlist(self):
         self.playback.play()
 
         for i, track in enumerate(self.tracks):
-            self.assertEqual(self.playback.state, self.playback.PLAYING)
+            self.assertEqual(self.playback.state, PlaybackState.PLAYING)
             self.assertEqual(self.playback.current_track, track)
             self.assertEqual(self.playback.current_playlist_position, i)
 
             self.playback.next()
 
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_next_until_end_of_playlist_and_play_from_start(self):
@@ -208,15 +209,15 @@ class PlaybackControllerTest(object):
             self.playback.next()
 
         self.assertEqual(self.playback.current_track, None)
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
         self.assertEqual(self.playback.current_track, self.tracks[0])
 
     def test_next_for_empty_playlist(self):
         self.playback.next()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_next_skips_to_next_track_on_failure(self):
@@ -321,20 +322,20 @@ class PlaybackControllerTest(object):
     @populate_playlist
     def test_end_of_track_does_not_trigger_playback(self):
         self.playback.on_end_of_track()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_end_of_track_at_end_of_playlist(self):
         self.playback.play()
 
         for i, track in enumerate(self.tracks):
-            self.assertEqual(self.playback.state, self.playback.PLAYING)
+            self.assertEqual(self.playback.state, PlaybackState.PLAYING)
             self.assertEqual(self.playback.current_track, track)
             self.assertEqual(self.playback.current_playlist_position, i)
 
             self.playback.on_end_of_track()
 
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_end_of_track_until_end_of_playlist_and_play_from_start(self):
@@ -344,15 +345,15 @@ class PlaybackControllerTest(object):
             self.playback.on_end_of_track()
 
         self.assertEqual(self.playback.current_track, None)
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
         self.assertEqual(self.playback.current_track, self.tracks[0])
 
     def test_end_of_track_for_empty_playlist(self):
         self.playback.on_end_of_track()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_end_of_track_skips_to_next_track_on_failure(self):
@@ -534,13 +535,13 @@ class PlaybackControllerTest(object):
         self.playback.play()
         current_track = self.playback.current_track
         self.backend.current_playlist.append([self.tracks[2]])
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
         self.assertEqual(self.playback.current_track, current_track)
 
     @populate_playlist
     def test_on_current_playlist_change_when_stopped(self):
         self.backend.current_playlist.append([self.tracks[2]])
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.assertEqual(self.playback.current_track, None)
 
     @populate_playlist
@@ -549,26 +550,26 @@ class PlaybackControllerTest(object):
         self.playback.pause()
         current_track = self.playback.current_track
         self.backend.current_playlist.append([self.tracks[2]])
-        self.assertEqual(self.playback.state, self.backend.playback.PAUSED)
+        self.assertEqual(self.playback.state, PlaybackState.PAUSED)
         self.assertEqual(self.playback.current_track, current_track)
 
     @populate_playlist
     def test_pause_when_stopped(self):
         self.playback.pause()
-        self.assertEqual(self.playback.state, self.playback.PAUSED)
+        self.assertEqual(self.playback.state, PlaybackState.PAUSED)
 
     @populate_playlist
     def test_pause_when_playing(self):
         self.playback.play()
         self.playback.pause()
-        self.assertEqual(self.playback.state, self.playback.PAUSED)
+        self.assertEqual(self.playback.state, PlaybackState.PAUSED)
 
     @populate_playlist
     def test_pause_when_paused(self):
         self.playback.play()
         self.playback.pause()
         self.playback.pause()
-        self.assertEqual(self.playback.state, self.playback.PAUSED)
+        self.assertEqual(self.playback.state, PlaybackState.PAUSED)
 
     @populate_playlist
     def test_pause_return_value(self):
@@ -578,20 +579,20 @@ class PlaybackControllerTest(object):
     @populate_playlist
     def test_resume_when_stopped(self):
         self.playback.resume()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_resume_when_playing(self):
         self.playback.play()
         self.playback.resume()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @populate_playlist
     def test_resume_when_paused(self):
         self.playback.play()
         self.playback.pause()
         self.playback.resume()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @populate_playlist
     def test_resume_return_value(self):
@@ -624,12 +625,12 @@ class PlaybackControllerTest(object):
 
     def test_seek_on_empty_playlist_updates_position(self):
         self.playback.seek(0)
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_seek_when_stopped_triggers_play(self):
         self.playback.seek(0)
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @populate_playlist
     def test_seek_when_playing(self):
@@ -666,7 +667,7 @@ class PlaybackControllerTest(object):
         self.playback.play()
         self.playback.pause()
         self.playback.seek(0)
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @unittest.SkipTest
     @populate_playlist
@@ -686,7 +687,7 @@ class PlaybackControllerTest(object):
     def test_seek_beyond_end_of_song_for_last_track(self):
         self.playback.play(self.current_playlist.cp_tracks[-1])
         self.playback.seek(self.current_playlist.tracks[-1].length * 100)
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @unittest.SkipTest
     @populate_playlist
@@ -702,25 +703,25 @@ class PlaybackControllerTest(object):
         self.playback.seek(-1000)
         position = self.playback.time_position
         self.assert_(position >= 0, position)
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @populate_playlist
     def test_stop_when_stopped(self):
         self.playback.stop()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_stop_when_playing(self):
         self.playback.play()
         self.playback.stop()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     @populate_playlist
     def test_stop_when_paused(self):
         self.playback.play()
         self.playback.pause()
         self.playback.stop()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     def test_stop_return_value(self):
         self.playback.play()
@@ -810,7 +811,7 @@ class PlaybackControllerTest(object):
     def test_end_of_playlist_stops(self):
         self.playback.play(self.current_playlist.cp_tracks[-1])
         self.playback.on_end_of_track()
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
 
     def test_repeat_off_by_default(self):
         self.assertEqual(self.playback.repeat, False)
@@ -835,9 +836,9 @@ class PlaybackControllerTest(object):
         for _ in self.tracks:
             self.playback.next()
         self.assertNotEqual(self.playback.track_at_next, None)
-        self.assertEqual(self.playback.state, self.playback.STOPPED)
+        self.assertEqual(self.playback.state, PlaybackState.STOPPED)
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     @populate_playlist
     def test_random_until_end_of_playlist_with_repeat(self):

--- a/tests/backends/local/playback_test.py
+++ b/tests/backends/local/playback_test.py
@@ -2,6 +2,7 @@ import sys
 
 from mopidy import settings
 from mopidy.backends.local import LocalBackend
+from mopidy.core import PlaybackState
 from mopidy.models import Track
 from mopidy.utils.path import path_to_uri
 
@@ -39,14 +40,14 @@ class LocalPlaybackControllerTest(PlaybackControllerTest, unittest.TestCase):
     def test_play_mp3(self):
         self.add_track('blank.mp3')
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     def test_play_ogg(self):
         self.add_track('blank.ogg')
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)
 
     def test_play_flac(self):
         self.add_track('blank.flac')
         self.playback.play()
-        self.assertEqual(self.playback.state, self.playback.PLAYING)
+        self.assertEqual(self.playback.state, PlaybackState.PLAYING)

--- a/tests/frontends/mpd/protocol/playback_test.py
+++ b/tests/frontends/mpd/protocol/playback_test.py
@@ -1,12 +1,13 @@
-from mopidy import core
+from mopidy.core import PlaybackState
 from mopidy.models import Track
 
 from tests import unittest
 from tests.frontends.mpd import protocol
 
-PAUSED = core.PlaybackController.PAUSED
-PLAYING = core.PlaybackController.PLAYING
-STOPPED = core.PlaybackController.STOPPED
+
+PAUSED = PlaybackState.PAUSED
+PLAYING = PlaybackState.PLAYING
+STOPPED = PlaybackState.STOPPED
 
 
 class PlaybackOptionsHandlerTest(protocol.BaseTestCase):

--- a/tests/frontends/mpd/status_test.py
+++ b/tests/frontends/mpd/status_test.py
@@ -1,14 +1,15 @@
-from mopidy import core
 from mopidy.backends import dummy
+from mopidy.core import PlaybackState
 from mopidy.frontends.mpd import dispatcher
 from mopidy.frontends.mpd.protocol import status
 from mopidy.models import Track
 
 from tests import unittest
 
-PAUSED = core.PlaybackController.PAUSED
-PLAYING = core.PlaybackController.PLAYING
-STOPPED = core.PlaybackController.STOPPED
+
+PAUSED = PlaybackState.PAUSED
+PLAYING = PlaybackState.PLAYING
+STOPPED = PlaybackState.STOPPED
 
 # FIXME migrate to using protocol.BaseTestCase instead of status.stats
 # directly?

--- a/tests/frontends/mpris/player_interface_test.py
+++ b/tests/frontends/mpris/player_interface_test.py
@@ -2,8 +2,9 @@ import sys
 
 import mock
 
-from mopidy import core, OptionalDependencyError
+from mopidy import OptionalDependencyError
 from mopidy.backends.dummy import DummyBackend
+from mopidy.core import PlaybackState
 from mopidy.models import Album, Artist, Track
 
 try:
@@ -13,9 +14,9 @@ except OptionalDependencyError:
 
 from tests import unittest
 
-PLAYING = core.PlaybackController.PLAYING
-PAUSED = core.PlaybackController.PAUSED
-STOPPED = core.PlaybackController.STOPPED
+PLAYING = PlaybackState.PLAYING
+PAUSED = PlaybackState.PAUSED
+STOPPED = PlaybackState.STOPPED
 
 
 @unittest.skipUnless(sys.platform.startswith('linux'), 'requires Linux')


### PR DESCRIPTION
I found it odd having to import `mopidy.core.PlaybackController` all over the code base just to get hold of the three playback state constants.
