### PR TITLE
Allow custom settings that begin with 'CUSTOM_'

### DIFF
--- a/mopidy/utils/settings.py
+++ b/mopidy/utils/settings.py
@@ -170,7 +170,7 @@ def validate_settings(defaults, settings):
                 u'Deprecated setting, please set the value via the GStreamer '
                 u'bin in OUTPUT.')
 
-        elif setting not in defaults:
+        elif setting not in defaults and not setting.startswith('CUSTOM_'):
             errors[setting] = u'Unknown setting.'
             suggestion = did_you_mean(setting, defaults)
 


### PR DESCRIPTION
When extending the core functionality of Mopidy, it's desirable to be able to use the settings system. This change allows you define any additional settings your extension requires, as long as they begin with the 'CUSTOM_' prefix.
