### PR TITLE
Fixes support for MPD find/search by filename

### DIFF
--- a/mopidy/backends/local/library.py
+++ b/mopidy/backends/local/library.py
@@ -59,7 +59,7 @@ class LocalLibraryProvider(base.BaseLibraryProvider):
                     result_tracks = filter(album_filter, result_tracks)
                 elif field == 'artist':
                     result_tracks = filter(artist_filter, result_tracks)
-                elif field == 'uri':
+                elif field == 'uri' or field == 'filename':
                     result_tracks = filter(uri_filter, result_tracks)
                 elif field == 'any':
                     result_tracks = filter(any_filter, result_tracks)
@@ -93,7 +93,7 @@ class LocalLibraryProvider(base.BaseLibraryProvider):
                     result_tracks = filter(album_filter, result_tracks)
                 elif field == 'artist':
                     result_tracks = filter(artist_filter, result_tracks)
-                elif field == 'uri':
+                elif field == 'uri' or field == 'filename':
                     result_tracks = filter(uri_filter, result_tracks)
                 elif field == 'any':
                     result_tracks = filter(any_filter, result_tracks)

--- a/tests/backends/base/library.py
+++ b/tests/backends/base/library.py
@@ -79,6 +79,15 @@ class LibraryControllerTest(object):
         result = self.library.find_exact(album=['album2'])
         self.assertEqual(result, Playlist(tracks=self.tracks[1:2]))
 
+    def test_find_exact_filename(self):
+        track_1_filename = 'file://' + path_to_data_dir('uri1')
+        result = self.library.find_exact(filename=track_1_filename)
+        self.assertEqual(result, Playlist(tracks=self.tracks[:1]))
+
+        track_2_filename = 'file://' + path_to_data_dir('uri2')
+        result = self.library.find_exact(filename=track_2_filename)
+        self.assertEqual(result, Playlist(tracks=self.tracks[1:2]))
+
     def test_find_exact_wrong_type(self):
         test = lambda: self.library.find_exact(wrong=['test'])
         self.assertRaises(LookupError, test)
@@ -135,6 +144,13 @@ class LibraryControllerTest(object):
         self.assertEqual(result, Playlist(tracks=self.tracks[:1]))
 
         result = self.library.search(uri=['RI2'])
+        self.assertEqual(result, Playlist(tracks=self.tracks[1:2]))
+
+    def test_search_filename(self):
+        result = self.library.search(filename=['RI1'])
+        self.assertEqual(result, Playlist(tracks=self.tracks[:1]))
+
+        result = self.library.search(filename=['RI2'])
         self.assertEqual(result, Playlist(tracks=self.tracks[1:2]))
 
     def test_search_any(self):


### PR DESCRIPTION
Just a small patch to get my feet wet working on Mopidy :)

Extends `find_exact` and `search` in mopidy.backends.local.library
to support the `filename` query field. This field can get passed in
from the MPD frontend and would break with a `LookupError` when used.
This patch fixes the issue and introduces two new tests to cover the
added functionality.
