### PR TITLE
spotify: Add proxy support

### DIFF
--- a/mopidy/backends/spotify/actor.py
+++ b/mopidy/backends/spotify/actor.py
@@ -31,9 +31,14 @@ class SpotifyBackend(pykka.ThreadingActor, base.Backend):
         # Fail early if settings are not present
         username = settings.SPOTIFY_USERNAME
         password = settings.SPOTIFY_PASSWORD
+        proxy = settings.SPOTIFY_PROXY_HOST
+        proxy_username = settings.SPOTIFY_PROXY_USERNAME
+        proxy_password = settings.SPOTIFY_PROXY_PASSWORD
 
         self.spotify = SpotifySessionManager(
-            username, password, audio=audio, backend_ref=self.actor_ref)
+            username, password, audio=audio, backend_ref=self.actor_ref,
+            proxy=proxy, proxy_username=proxy_username,
+            proxy_password=proxy_password)
 
     def on_start(self):
         logger.info('Mopidy uses SPOTIFY(R) CORE')

--- a/mopidy/backends/spotify/session_manager.py
+++ b/mopidy/backends/spotify/session_manager.py
@@ -33,8 +33,12 @@ class SpotifySessionManager(process.BaseThread, PyspotifySessionManager):
     appkey_file = os.path.join(os.path.dirname(__file__), 'spotify_appkey.key')
     user_agent = 'Mopidy %s' % versioning.get_version()
 
-    def __init__(self, username, password, audio, backend_ref):
-        PyspotifySessionManager.__init__(self, username, password)
+    def __init__(self, username, password, audio, backend_ref, proxy=None,
+                 proxy_username=None, proxy_password=None):
+        PyspotifySessionManager.__init__(
+            self, username, password, proxy=proxy,
+            proxy_username=proxy_username,
+            proxy_password=proxy_password)
         process.BaseThread.__init__(self)
         self.name = 'SpotifyThread'
 

--- a/mopidy/settings.py
+++ b/mopidy/settings.py
@@ -218,3 +218,45 @@ SPOTIFY_PASSWORD = ''
 #:
 #:     SPOTIFY_BITRATE = 160
 SPOTIFY_BITRATE = 160
+
+#: Spotify proxy host
+#:
+#: Example::
+#:
+#:     SPOTIFY_PROXY_HOST = u'protocol://host:port'
+#:
+#: Used by :mod:`mopidy.backends.spotify`
+#:
+#: Default ::
+#:
+#:     SPOTIFY_PROXY_HOST = None
+#:
+SPOTIFY_PROXY_HOST = None
+
+#: Spotify proxy username
+#:
+#: Example::
+#:
+#:     SPOTIFY_PROXY_HOST = u'username'
+#:
+#: Used by :mod:`mopidy.backends.spotify`
+#:
+#: Default ::
+#:
+#:     SPOTIFY_PROXY_USERNAME = None
+#:
+SPOTIFY_PROXY_USERNAME = None
+
+#: Spotify proxy password
+#:
+#: Example::
+#:
+#:     SPOTIFY_PROXY_HOST = u'password'
+#:
+#: Used by :mod:`mopidy.backends.spotify`
+#:
+#: Default ::
+#:
+#:     SPOTIFY_PROXY_PASSWORD = None
+#:
+SPOTIFY_PROXY_PASSWORD = None


### PR DESCRIPTION
Hi,
This commit will allow to use mopidy via my recent change in pyspotify.

Call to SpotifySessionManager uses now "proxy", "proxy_username" and "proxy_password" arguments introduce in Pyspotify by commit https://github.com/mopidy/pyspotify/commit/36c1cd8933fa3915176ab80e0dae6b2515abd7b4

I have added  three options in settings.py : 

SPOTIFY_PROXY_HOST
SPOTIFY_PROXY_USERNAME
SPOTIFY_PROXY_PASSWORD
