### PR TITLE
mpd: Allow bad 'search' requests

### DIFF
--- a/mopidy/frontends/mpd/protocol/music_db.py
+++ b/mopidy/frontends/mpd/protocol/music_db.py
@@ -334,7 +334,7 @@ def rescan(context, uri=None):
 
 @handle_request(
     r'^search (?P<mpd_query>("?([Aa]lbum|[Aa]rtist|[Dd]ate|[Ff]ile[name]*|'
-    r'[Tt]itle|[Aa]ny)"? "[^"]+"\s?)+)$')
+    r'[Tt]itle|[Aa]ny)"? "[^"]*"\s?)+)$')
 def search(context, mpd_query):
     """
     *musicpd.org, music database section:*

--- a/tests/frontends/mpd/protocol/music_db_test.py
+++ b/tests/frontends/mpd/protocol/music_db_test.py
@@ -337,12 +337,20 @@ class MusicDatabaseSearchTest(protocol.BaseTestCase):
         self.sendRequest('search album "analbum"')
         self.assertInResponse('OK')
 
+    def test_search_album_without_filter_value(self):
+        self.sendRequest('search "album" ""')
+        self.assertInResponse('OK')
+
     def test_search_artist(self):
         self.sendRequest('search "artist" "anartist"')
         self.assertInResponse('OK')
 
     def test_search_artist_without_quotes(self):
         self.sendRequest('search artist "anartist"')
+        self.assertInResponse('OK')
+
+    def test_search_artist_without_filter_value(self):
+        self.sendRequest('search "artist" ""')
         self.assertInResponse('OK')
 
     def test_search_filename(self):
@@ -353,12 +361,20 @@ class MusicDatabaseSearchTest(protocol.BaseTestCase):
         self.sendRequest('search filename "afilename"')
         self.assertInResponse('OK')
 
+    def test_search_filename_without_filter_value(self):
+        self.sendRequest('search "filename" ""')
+        self.assertInResponse('OK')
+
     def test_search_file(self):
         self.sendRequest('search "file" "afilename"')
         self.assertInResponse('OK')
 
     def test_search_file_without_quotes(self):
         self.sendRequest('search file "afilename"')
+        self.assertInResponse('OK')
+
+    def test_search_file_without_filter_value(self):
+        self.sendRequest('search "file" ""')
         self.assertInResponse('OK')
 
     def test_search_title(self):
@@ -369,12 +385,20 @@ class MusicDatabaseSearchTest(protocol.BaseTestCase):
         self.sendRequest('search title "atitle"')
         self.assertInResponse('OK')
 
+    def test_search_title_without_filter_value(self):
+        self.sendRequest('search "title" ""')
+        self.assertInResponse('OK')
+
     def test_search_any(self):
         self.sendRequest('search "any" "anything"')
         self.assertInResponse('OK')
 
     def test_search_any_without_quotes(self):
         self.sendRequest('search any "anything"')
+        self.assertInResponse('OK')
+
+    def test_search_any_without_filter_value(self):
+        self.sendRequest('search "any" ""')
         self.assertInResponse('OK')
 
     def test_search_date(self):
@@ -387,6 +411,10 @@ class MusicDatabaseSearchTest(protocol.BaseTestCase):
 
     def test_search_date_with_capital_d_and_incomplete_date(self):
         self.sendRequest('search Date "2005"')
+        self.assertInResponse('OK')
+
+    def test_search_date_without_filter_value(self):
+        self.sendRequest('search "date" ""')
         self.assertInResponse('OK')
 
     def test_search_else_should_fail(self):


### PR DESCRIPTION
This causes an unrelated test failure that I can't manage to figure out. I need an additional set of eye balls on this.
