### PR TITLE
Add generic JSON-RPC 2.0 object wrapper

### DIFF
--- a/mopidy/utils/jsonrpc.py
+++ b/mopidy/utils/jsonrpc.py
@@ -187,10 +187,12 @@ class JsonRpcWrapper(object):
 
         # The mounted object contains the callable
 
-        if '.' in method_path:
-            mount, method_name = method_path.rsplit('.', 1)
-        else:
-            mount, method_name = '', method_path
+        if '.' not in method_path:
+            raise JsonRpcMethodNotFoundError(
+                data='Could not find object mount in method name "%s"' % (
+                    method_path))
+
+        mount, method_name = method_path.rsplit('.', 1)
 
         if method_name.startswith('_'):
             raise JsonRpcMethodNotFoundError(

--- a/tests/utils/jsonrpc_test.py
+++ b/tests/utils/jsonrpc_test.py
@@ -387,6 +387,21 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         self.assertEqual(
             error['data'], '"params", if given, must be an array or an object')
 
+    def test_method_on_without_object_causes_unknown_method_error(self):
+        request = {
+            'jsonrpc': '2.0',
+            'method': 'bogus',
+            'id': 1,
+        }
+        response = self.jrw.handle_data(request)
+
+        error = response['error']
+        self.assertEqual(error['code'], -32601)
+        self.assertEqual(error['message'], 'Method not found')
+        self.assertEqual(
+            error['data'],
+            'Could not find object mount in method name "bogus"')
+
     def test_method_on_unknown_object_causes_unknown_method_error(self):
         request = {
             'jsonrpc': '2.0',
@@ -417,7 +432,7 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
     def test_private_method_causes_unknown_method_error(self):
         request = {
             'jsonrpc': '2.0',
-            'method': '_secret',
+            'method': 'core._secret',
             'id': 1,
         }
         response = self.jrw.handle_data(request)


### PR DESCRIPTION
This can wrap multiple objects, which can be both plain objects and Pykka actors. To my knowledge, everything in the spec is supported.
