### PR TITLE
Fix for updates to pyspotify

### DIFF
--- a/mopidy/backends/spotify/session_manager.py
+++ b/mopidy/backends/spotify/session_manager.py
@@ -46,7 +46,6 @@ class SpotifySessionManager(process.BaseThread, PyspotifySessionManager):
         self.backend_ref = backend_ref
 
         self.connected = threading.Event()
-        self.session = None
 
         self.container_manager = None
         self.playlist_manager = None
@@ -64,7 +63,6 @@ class SpotifySessionManager(process.BaseThread, PyspotifySessionManager):
             return
 
         logger.info('Connected to Spotify')
-        self.session = session
 
         logger.debug(
             'Preferred Spotify bitrate is %s kbps',


### PR DESCRIPTION
Pyspotify now creates the session in
`pyspotify.SpotifySessionManager.__init__` (rather than in `.connect`) -
see [here](https://github.com/mopidy/pyspotify/commit/483f7574303dc7afed491244fc382ce49add64c4#L1R39).  Therefore it seems best not to set `self.session = None`
in `mopidy.SpotifySessionManager.__init__` or `self.session = session`
in `.logged_in`.
