### PR TITLE
audio: Make get_volume able to return all levels 

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -393,10 +393,8 @@ class Audio(pykka.ThreadingActor):
         mixer_scale = (
             self._mixer_track.min_volume, self._mixer_track.max_volume)
 
-        volume_set_scaled = self._rescale(
-            self._volume_set, old=internal_scale, new=mixer_scale)
-
-        if self._volume_set is not None and volume_set_scaled == avg_volume:
+        if self._volume_set is not None and self._rescale(self._volume_set,
+                old=internal_scale, new=mixer_scale) == avg_volume:
             return self._volume_set
         else:
             return self._rescale(


### PR DESCRIPTION
If max volume on the selected track is below 100, each volume level in mopidy will not have a corresponding level on the track. That means that if I try to set the volume to e.g. 43, it may be set to 44, and the next time I get the volume I receive 44. If my applications changes the volume by one level at a time, it would try to set it to 43 again, and so it would be stuck on 44.

This commit stores the volume set, and when the volume is fetched, it checks if the stored value still corresponds to the value from the mixer. If it does, it returns the stored value. If not, it returns the value from the mixer.
