### PR TITLE
spotify: Only return available tracks from lookups

### DIFF
--- a/mopidy/backends/spotify/library.py
+++ b/mopidy/backends/spotify/library.py
@@ -87,7 +87,7 @@ class SpotifyLibraryProvider(base.BaseLibraryProvider):
             if track.availability() == 1:
                 return [SpotifyTrack(track=track)]
             else:
-                return None
+                return []
         else:
             return [SpotifyTrack(uri=uri)]
 


### PR DESCRIPTION
The lookup methods for Spotify now returns all tracks. Many of these may be unavailable, so now they are added but skipped when you try to play them. This commits filters out unavailable tracks from the lookup methods.

I'm not sure this is exactly the right way to fix it. If a track isn't loaded, the track is reported as not available. It seems like all the tracks are loaded when an artist- or album-browse is loaded, so generally, this should be safe. However, if the wait times out, _lookup_track will return the track and the other lookup methods will not return any tracks, regardless of the availability.
