### PR TITLE
Add caveat about static in sound test file.

### DIFF
--- a/docs/installation/raspberrypi.rst
+++ b/docs/installation/raspberrypi.rst
@@ -210,6 +210,10 @@ software packages, as Wheezy is going to be the next release of Debian.
 
        aplay /usr/share/sounds/alsa/Front_Center.wav
 
+   If you hear a voice saying "Front Center," then your sound is working. Don't 
+   be concerned if this test sound includes static, output from Mopidy will not.
+   Test your sound with gstreamer to determine sound quality.
+
    To make the change to analog output stick, you can add the ``amixer`` command
    to e.g. ``/etc/rc.local``, which will be executed when the system is
    booting.


### PR DESCRIPTION
Add a note saying that the purpose of the "aplay ... Front_Center.wav" line is merely to test whether the sound works or not, rather than to test its quality. That is, hearing static in the Front_Center.wav file is expected behavior and not indicative of a sound problem.

Anecdotally, I had very static-y sound from the aplay command, which prompted me to incorrectly believe that my sound would not work with Mopidy. As it turns out, the sound works fine using Mopidy or gstreamer. This note will hopefully keep other Mopidy users from thinking their sound is broken when it is not. (I ended up installing armhf version and trying to use despotify, which didn't work, before coming back to Mopidy.)
