### PR TITLE
docs: Append to /etc/modules, not overwrite

### DIFF
--- a/docs/installation/raspberrypi.rst
+++ b/docs/installation/raspberrypi.rst
@@ -113,7 +113,7 @@ squeeze distribution.
    - Add ``ipv6`` to ``/etc/modules`` to ensure the IPv6 kernel module is
      loaded on boot::
 
-         echo ipv6 | sudo tee /etc/modules
+         echo ipv6 | sudo tee -a /etc/modules
 
 8. Installing Mopidy and its dependencies from `apt.mopidy.com
    <http://apt.mopidy.com/>`_, as described in :ref:`installation`. In short::
@@ -189,7 +189,7 @@ software packages, as Wheezy is going to be the next release of Debian.
    - Add ``ipv6`` to ``/etc/modules`` to ensure the IPv6 kernel module is
      loaded on boot::
 
-         echo ipv6 | sudo tee /etc/modules
+         echo ipv6 | sudo tee -a /etc/modules
 
 8. Installing Mopidy and its dependencies from `apt.mopidy.com
    <http://apt.mopidy.com/>`_, as described in :ref:`installation`. In short::


### PR DESCRIPTION
Fixes the snd_bcm2835 module not being loaded and therefore sound output not working
