### PR TITLE
Uniquify spotify playlist names

### DIFF
--- a/mopidy/backends/spotify/translator.py
+++ b/mopidy/backends/spotify/translator.py
@@ -9,6 +9,7 @@ from mopidy.models import Artist, Album, Track, Playlist
 artist_cache = {}
 album_cache = {}
 track_cache = {}
+playlist_names = {}
 
 
 def to_mopidy_artist(spotify_artist):
@@ -77,6 +78,13 @@ def to_mopidy_playlist(spotify_playlist):
         return
     if spotify_playlist.owner().canonical_name() != settings.SPOTIFY_USERNAME:
         name += ' by ' + spotify_playlist.owner().canonical_name()
+    if name in playlist_names:
+        if uri not in playlist_names[name]:
+            playlist_names[name][uri] = len(playlist_names[name])
+        if playlist_names[name][uri] > 0:
+            name += '[' + str(playlist_names[name][uri]) + ']'
+    else:
+        playlist_names[name] = { uri : 0 }
     return Playlist(
         uri=uri,
         name=name,


### PR DESCRIPTION
Implements https://github.com/mopidy/mopidy/issues/114#issuecomment-15396025
- Appends the playlist owner to those playlists owned by other users i.e. followed playlists
  - Left playlists owned by the current Spotify user alone - presumably they shouldn't appear any different to LocalBackend playlists
- Appends an incrementing number to playlists with the same name
  - First occurrence of a name is unchanged
  - Looking again I've realised this isn't the place to do this when dealing with multiple backends, perhaps I should remove this bit?
