### PR TITLE
Wrong module path for StreamBackend example in settings.BACKENDS doc string

### DIFF
--- a/mopidy/settings.py
+++ b/mopidy/settings.py
@@ -20,7 +20,7 @@ from __future__ import unicode_literals
 #:     BACKENDS = (
 #:         u'mopidy.backends.local.LocalBackend',
 #:         u'mopidy.backends.spotify.SpotifyBackend',
-#:         u'mopidy.backends.spotify.StreamBackend',
+#:         u'mopidy.backends.stream.StreamBackend',
 #:     )
 BACKENDS = (
     'mopidy.backends.local.LocalBackend',


### PR DESCRIPTION
Just a typo in the `BACKENDS` doc string I noticed when creating a new settings file.  

For my future reference: with something as trivial as this, is it more convenient to do a pull request or just comment on the original offending commit?
