### PR TITLE
workaround for mopidy/mopidy#62 - appends folder names to playlist

### DIFF
--- a/mopidy/backends/spotify/session_manager.py
+++ b/mopidy/backends/spotify/session_manager.py
@@ -180,10 +180,10 @@ class SpotifySessionManager(process.BaseThread, PyspotifySessionManager):
             if spotify_playlist.type() == 'folder_end':
                 folders.pop()
             playlists.append(translator.to_mopidy_playlist(
-                spotify_playlist, folders,
+                spotify_playlist, folders=folders,
                 bitrate=self.bitrate, username=self.username))
         playlists.append(translator.to_mopidy_playlist(
-            self.session.starred(), None,
+            self.session.starred(),
             bitrate=self.bitrate, username=self.username))
         playlists = filter(None, playlists)
         self.backend.playlists.playlists = playlists

--- a/mopidy/backends/spotify/translator.py
+++ b/mopidy/backends/spotify/translator.py
@@ -67,7 +67,7 @@ def to_mopidy_track(spotify_track, bitrate=None):
     return track_cache[uri]
 
 
-def to_mopidy_playlist(spotify_playlist, spotify_folders, bitrate=None, username=None):
+def to_mopidy_playlist(spotify_playlist, folders=None, bitrate=None, username=None):
     if spotify_playlist is None or spotify_playlist.type() != 'playlist':
         return
     try:
@@ -78,8 +78,8 @@ def to_mopidy_playlist(spotify_playlist, spotify_folders, bitrate=None, username
     if not spotify_playlist.is_loaded():
         return Playlist(uri=uri, name='[loading...]')
     name = spotify_playlist.name()
-    if spotify_folders:
-        folder_names = '/'.join(folder.name() for folder in spotify_folders)
+    if folders:
+        folder_names = '/'.join(folder.name() for folder in folders)
         name = folder_names + '/' + name
     tracks = [
         to_mopidy_track(spotify_track, bitrate=bitrate)


### PR DESCRIPTION
Doesn't expose the structure in any way, but just appends the names to the start of the playlist.
