### PR TITLE
Properly encode localised mixer names before log

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -222,7 +222,8 @@ class Audio(pykka.ThreadingActor):
             self._mixer_track.min_volume, self._mixer_track.max_volume)
         logger.info(
             'Audio mixer set to "%s" using track "%s"',
-            mixer.get_factory().get_name(), track.label)
+            str(mixer.get_factory().get_name()).decode('utf-8'),
+            str(track.label).decode('utf-8'))
 
     def _select_mixer_track(self, mixer, track_label):
         # Ignore tracks without volumes, then look for track with


### PR DESCRIPTION
Mixer names in localized environment can contain non-ASCII characters. Handle them correctly before sending messages to logger.

How to reproduce:

```
$ LC_MESSAGES=sk_SK.UTF-8 mopidy
...(snip)…
INFO     Starting Mopidy core
Traceback (most recent call last):
  File "/usr/lib/python2.7/logging/__init__.py", line 850, in emit
    msg = self.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 723, in format
    return fmt.format(record)
  File "/usr/lib/python2.7/logging/__init__.py", line 464, in format
    record.message = record.getMessage()
  File "/usr/lib/python2.7/logging/__init__.py", line 328, in getMessage
    msg = msg % self.args
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 5: ordinal not in range(128)
Logged from file actor.py, line 196
INFO     Starting Mopidy frontends: MpdFrontend, HttpFrontend, MprisFrontend
...(snip)…
```

With fix you'll get:

```
$ LC_MESSAGES=sk_SK.UTF-8 mopidy
…
INFO     Starting Mopidy core
INFO     Audio mixer set to "alsamixer" using track "Hlavný"
INFO     Starting Mopidy frontends: MpdFrontend, HttpFrontend, MprisFrontend
```
