### PR TITLE
Rename tests

### DIFF
--- a/tests/backends/local/library_test.py
+++ b/tests/backends/local/library_test.py
@@ -11,7 +11,7 @@ from mopidy.models import Track, Album, Artist
 from tests import path_to_data_dir
 
 
-class LocalLibraryControllerTest(unittest.TestCase):
+class LocalLibraryProviderTest(unittest.TestCase):
     artists = [Artist(name='artist1'), Artist(name='artist2'), Artist()]
 
     albums = [

--- a/tests/backends/local/playback_test.py
+++ b/tests/backends/local/playback_test.py
@@ -19,7 +19,7 @@ from tests.backends.local import generate_song, populate_tracklist
 # TODO Test 'playlist repeat', e.g. repeat=1,single=0
 
 
-class LocalPlaybackControllerTest(unittest.TestCase):
+class LocalPlaybackProviderTest(unittest.TestCase):
     config = {
         'local': {
             'media_dir': path_to_data_dir(''),

--- a/tests/backends/local/playlists_test.py
+++ b/tests/backends/local/playlists_test.py
@@ -15,7 +15,7 @@ from tests import path_to_data_dir
 from tests.backends.local import generate_song
 
 
-class LocalPlaylistsControllerTest(unittest.TestCase):
+class LocalPlaylistsProviderTest(unittest.TestCase):
     backend_class = actor.LocalBackend
     config = {
         'local': {

--- a/tests/backends/local/tracklist_test.py
+++ b/tests/backends/local/tracklist_test.py
@@ -14,7 +14,7 @@ from tests import path_to_data_dir
 from tests.backends.local import generate_song, populate_tracklist
 
 
-class LocalTracklistControllerTest(unittest.TestCase):
+class LocalTracklistProviderTest(unittest.TestCase):
     config = {
         'local': {
             'media_dir': path_to_data_dir(''),


### PR DESCRIPTION
When the local and core tests where merged, we could start considering that we are testing the providers, and not the controllers. Just to have clear the change.
