### PR TITLE
local: Temporary workaround for issue #527

### DIFF
--- a/mopidy/backends/local/playlists.py
+++ b/mopidy/backends/local/playlists.py
@@ -51,12 +51,10 @@ class LocalPlaylistsProvider(base.BasePlaylistsProvider):
 
             tracks = []
             for track_uri in parse_m3u(m3u, self._media_dir):
-                try:
-                    # TODO: We must use core.library.lookup() to support tracks
-                    # from other backends
+                result = self.backend.library.lookup(track_uri)
+                if result:
                     tracks += self.backend.library.lookup(track_uri)
-                except LookupError as ex:
-                    # TODO: this is just a quick workaround for issue #527.
+                else:
                     tracks.append(Track(uri=track_uri))
 
             playlist = Playlist(uri=uri, name=name, tracks=tracks)

--- a/tests/backends/local/playlists_test.py
+++ b/tests/backends/local/playlists_test.py
@@ -201,6 +201,18 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
         self.assertNotIn(playlist1, self.core.playlists.playlists)
         self.assertIn(playlist2, self.core.playlists.playlists)
 
-    @unittest.SkipTest
     def test_playlist_with_unknown_track(self):
-        pass
+        track = Track(uri='file:///dev/null')
+        playlist = self.core.playlists.create('test')
+        playlist = playlist.copy(tracks=[track])
+        playlist = self.core.playlists.save(playlist)
+
+        backend = self.backend_class(config=self.config, audio=self.audio)
+
+        self.assert_(backend.playlists.playlists)
+        self.assertEqual(
+            'local:playlist:test', backend.playlists.playlists[0].uri)
+        self.assertEqual(
+            playlist.name, backend.playlists.playlists[0].name)
+        self.assertEqual(
+            track.uri, backend.playlists.playlists[0].tracks[0].uri)


### PR DESCRIPTION
Adds a fallback to `Track(uri=uri` when track lookup fails for playlists. This
means we can at least load metadata less tracks giving users functioning
playlists, instead of only supporting `local:track:...` style URIs.

Issue is not fixed, but this is sufficient to reduce priority until we get to
the larger planed refactor for this and other core API issues.
