### PR TITLE
local: Add file ext blacklist (fixes #516).

### DIFF
--- a/docs/ext/local.rst
+++ b/docs/ext/local.rst
@@ -52,9 +52,9 @@ Configuration values
     Number of milliseconds before giving up scanning a file and moving on to
     the next file.
 
-.. confval:: local/scan_blacklist_extensions
+.. confval:: local/excluded_file_extensions
 
-    File extensions to ignore when scanning the media directory.
+    File extensions to exclude when scanning the media directory.
 
 
 Usage

--- a/mopidy/backends/local/__init__.py
+++ b/mopidy/backends/local/__init__.py
@@ -23,7 +23,7 @@ class Extension(ext.Extension):
         schema['tag_cache_file'] = config.Path()
         schema['scan_timeout'] = config.Integer(
             minimum=1000, maximum=1000*60*60)
-        schema['scan_blacklist_extensions'] = config.List(optional=True)
+        schema['excluded_file_extensions'] = config.List(optional=True)
         return schema
 
     def validate_environment(self):

--- a/mopidy/backends/local/ext.conf
+++ b/mopidy/backends/local/ext.conf
@@ -4,7 +4,7 @@ media_dir = $XDG_MUSIC_DIR
 playlists_dir = $XDG_DATA_DIR/mopidy/local/playlists
 tag_cache_file = $XDG_DATA_DIR/mopidy/local/tag_cache
 scan_timeout = 1000
-scan_blacklist_extensions =
+excluded_file_extensions =
   .jpeg
   .jpg
   .png

--- a/mopidy/scanner.py
+++ b/mopidy/scanner.py
@@ -71,7 +71,7 @@ def main():
     local_updater = updaters.values()[0](config)  # TODO: switch to actor?
 
     media_dir = config['local']['media_dir']
-    blacklist_extensions = config['local']['scan_blacklist_extensions']
+    excluded_extensions = config['local']['excluded_file_extensions']
 
     uris_library = set()
     uris_update = set()
@@ -93,8 +93,8 @@ def main():
 
     logging.info('Checking %s for new or modified tracks.', media_dir)
     for uri in path.find_uris(config['local']['media_dir']):
-        if os.path.splitext(path.uri_to_path(uri))[1] in blacklist_extensions:
-            logging.debug('Skipped %s: File extension blacklisted.', uri)
+        if os.path.splitext(path.uri_to_path(uri))[1] in excluded_extensions:
+            logging.debug('Skipped %s: File extension excluded.', uri)
             continue
 
         if uri not in uris_library:


### PR DESCRIPTION
Adds a new local/scan_blacklist_extensions config value for controlling file
extensions to ignore.
