### PR TITLE
Fix scan with multiple track artists and add tests

### DIFF
--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -145,8 +145,8 @@ def audio_data_to_track(data):
     track_kwargs['length'] = data[gst.TAG_DURATION] // gst.MSECOND
     track_kwargs['album'] = Album(**album_kwargs)
 
-    if ('name' in artist_kwargs and
-            type(artist_kwargs['name']) is list):
+    if ('name' in artist_kwargs
+            and not isinstance(artist_kwargs['name'], basestring)):
         track_kwargs['artists'] = [Artist(name=artist)
                                    for artist in artist_kwargs['name']]
     else:

--- a/tests/audio/scan_test.py
+++ b/tests/audio/scan_test.py
@@ -79,8 +79,8 @@ class TranslatorTest(unittest.TestCase):
             self.album['artists'] = [Artist(**self.albumartist)]
         self.track['album'] = Album(**self.album)
 
-        if ('name' in self.artist and
-                type(self.artist['name']) is list):
+        if ('name' in self.artist
+                and not isinstance(self.artist['name'], basestring)):
             self.track['artists'] = [Artist(name=artist)
                                      for artist in self.artist['name']]
         else:


### PR DESCRIPTION
The new scanner removed some code to just return the first item for all keys.
This PR does a proper fix for the case where there are multiple artists.
