### PR TITLE
Allow configuring independently audio and mute

### DIFF
--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -23,6 +23,8 @@ _logging_schema['config_file'] = Path(optional=True)
 _loglevels_schema = LogLevelConfigSchema('loglevels')
 
 _audio_schema = ConfigSchema('audio')
+_audio_schema['mute'] = String()
+_audio_schema['volume'] = String()
 _audio_schema['mixer'] = String()
 _audio_schema['mixer_track'] = String(optional=True)
 _audio_schema['output'] = String()

--- a/mopidy/config/default.conf
+++ b/mopidy/config/default.conf
@@ -9,6 +9,8 @@ pykka = info
 
 [audio]
 mixer = software
+mute = hardware
+volume = hardware
 mixer_track =
 output = autoaudiosink
 visualizer =


### PR DESCRIPTION
We started switching to software mixing a while ago to prepare for a switch to gstreamer1.X.

But as I have been testing on some devices, it seems like volume handling is prefered in software, but mute is in the mixer (as some mixers implement such as switching off the speaker to avoid interference).

This PR is meant to provide the ability to switch some or all stuff to mixer using config:

```
mixer = autoaudiomixer
volume = software
```

As an example of the config needed to do what mentioned.
