### PR TITLE
debian: add 'showconfig' subcommand to the init script

### DIFF
--- a/debian/mopidy.init
+++ b/debian/mopidy.init
@@ -111,8 +111,11 @@ case "$1" in
                 ;;
         esac
         ;;
+    showconfig)
+        $DAEMON $DAEMON_ARGS config
+        ;;
     *)
-        echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload}" >&2
+        echo "Usage: $SCRIPTNAME {start|stop|status|restart|force-reload|showconfig}" >&2
         exit 3
         ;;
 esac


### PR DESCRIPTION
so the effective config can easily be dumped with 

``` bash
$ service mopidy showconfig
```
