### PR TITLE
Fix time position in playback ended trigger

### DIFF
--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -343,7 +343,8 @@ class PlaybackController(object):
             return
         listener.CoreListener.send(
             'track_playback_ended',
-            tl_track=self.current_tl_track, time_position=time_position_before_stop)
+            tl_track=self.current_tl_track,
+            time_position=time_position_before_stop)
 
     def _trigger_playback_state_changed(self, old_state, new_state):
         logger.debug('Triggering playback state change event')


### PR DESCRIPTION
When using mopidy with the scrobbler plugin, I noticed that my tracks were not being scrobbled on last.fm. Turns out, scrobbling only happens after listening to the track for a certain amount of time. However, the scrobbler listener was always receiving 0 as the current time position which caused it to never scrobble a track.

This was happening because the time position was queried after stopping the track - at which point the time position is reset to 0. Saving the time position before calling stop and passing that value to the listener in the trigger fixes this.

Unfortunately I am no experienced Python developer (I'm a Rubyist :) ) and don't know how to write a test for this. Seems to me this would require a fair amount of mocking. However, I verified that I did not break any existing tests nor have given flake8 cause to complain. I also did manual testing on my machine and now my tracks are being happily scrobbled.

For the reference, I was using mopidy with ncmpcpp and listening to music from spotify, in case this issue is in any way specific to the setup.

edit:
Fixed some style issues :)
