### PR TITLE
Improve scan performance for remote filesystems

### DIFF
--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -65,8 +65,8 @@ class ScanCommand(commands.Command):
         scan_timeout = config['local']['scan_timeout']
         flush_threshold = config['local']['scan_flush_threshold']
         excluded_file_extensions = config['local']['excluded_file_extensions']
-        excluded_file_extensions = set(
-            file_ext.lower() for file_ext in excluded_file_extensions)
+        excluded_file_extensions = tuple(
+            bytes(file_ext.lower()) for file_ext in excluded_file_extensions)
 
         library = _get_library(args, config)
 
@@ -96,9 +96,8 @@ class ScanCommand(commands.Command):
         for abspath in file_mtimes:
             relpath = os.path.relpath(abspath, media_dir)
             uri = translator.path_to_local_track_uri(relpath)
-            file_extension = os.path.splitext(relpath)[1]
 
-            if file_extension.lower() in excluded_file_extensions:
+            if relpath.lower().endswith(excluded_file_extensions):
                 logger.debug('Skipped %s: File extension excluded.', uri)
                 continue
 

--- a/mopidy/local/ext.conf
+++ b/mopidy/local/ext.conf
@@ -7,6 +7,7 @@ playlists_dir = $XDG_DATA_DIR/mopidy/local/playlists
 scan_timeout = 1000
 scan_flush_threshold = 1000
 excluded_file_extensions =
+  .directory
   .html
   .jpeg
   .jpg

--- a/mopidy/utils/path.py
+++ b/mopidy/utils/path.py
@@ -182,24 +182,6 @@ def _find(root, thread_count=10, hidden=True, relative=False):
     return results, errors
 
 
-def find_files(path):
-    """
-    Finds all files within a path.
-
-    Directories and files with names starting with ``.`` is ignored.
-
-    :returns: yields the full path to files as bytestrings
-    """
-    if isinstance(path, unicode):
-        path = path.encode('utf-8')
-
-    if os.path.isfile(path):
-        return iter([])
-
-    results, errors = _find(path, hidden=False, relative=True)
-    return results.iterkeys()
-
-
 def find_mtimes(root):
     results, errors = _find(root, hidden=False, relative=False)
     return dict((f, int(st.st_mtime)) for f, st in results.iteritems())

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -283,7 +283,7 @@ class ScannerTest(unittest.TestCase):
 
     def find(self, path):
         media_dir = path_to_data_dir(path)
-        for path in path_lib.find_files(media_dir):
+        for path in path_lib.find_mtimes(media_dir):
             yield os.path.join(media_dir, path)
 
     def scan(self, paths):

--- a/tests/utils/test_path.py
+++ b/tests/utils/test_path.py
@@ -210,31 +210,6 @@ class ExpandPathTest(unittest.TestCase):
             path.expand_path(b'/tmp/$XDG_INVALID_DIR/foo'))
 
 
-class FindFilesTest(unittest.TestCase):
-    def find(self, value):
-        return list(path.find_files(path_to_data_dir(value)))
-
-    def test_basic_dir(self):
-        self.assert_(self.find(''))
-
-    def test_nonexistant_dir(self):
-        self.assertEqual(self.find('does-not-exist'), [])
-
-    def test_file(self):
-        self.assertEqual([], self.find('blank.mp3'))
-
-    def test_files(self):
-        files = self.find('find')
-        expected = [b'foo/bar/file', b'foo/file', b'baz/file']
-        self.assertItemsEqual(expected, files)
-
-    def test_names_are_bytestrings(self):
-        is_bytes = lambda f: isinstance(f, bytes)
-        for name in self.find(''):
-            self.assert_(
-                is_bytes(name), '%s is not bytes object' % repr(name))
-
-
 class FindMTimesTest(unittest.TestCase):
     maxDiff = None
 


### PR DESCRIPTION
Old state this was 80s or so, new code completes in 14s for the same find operation and is not slowed further by later having to re-stat the same files for the mtimes.

Should further improve #614
