### PR TITLE
Let users store and remove their own playlists via the local backend.

### DIFF
--- a/mopidy/backend/__init__.py
+++ b/mopidy/backend/__init__.py
@@ -59,6 +59,9 @@ class Backend(object):
     def has_playlists(self):
         return self.playlists is not None
 
+    def has_stored_playlists(self):
+        return self.has_playlists() and self.playlists.provides_store
+
 
 class LibraryProvider(object):
     """
@@ -228,9 +231,10 @@ class PlaylistsProvider(object):
 
     pykka_traversable = True
 
-    def __init__(self, backend):
+    def __init__(self, backend, provides_store=False):
         self.backend = backend
         self._playlists = []
+        self.provides_store = provides_store
 
     @property
     def playlists(self):
@@ -250,6 +254,22 @@ class PlaylistsProvider(object):
         See :meth:`mopidy.core.PlaylistsController.create`.
 
         *MUST be implemented by subclass.*
+        """
+        raise NotImplementedError
+
+    def create_stored(self, name, tracks):
+        """
+        See :meth:`mopidy.core.PlaylistsController.create_stored`.
+
+        *MUST be implemented by subclass when :attr:`provides_store` is True.*
+        """
+        raise NotImplementedError
+
+    def rm_stored(self, name):
+        """
+        See :meth:`mopidy.core.PlaylistsController.rm_stored`.
+
+        *MUST be implemented by subclass when :attr:`provides_store` is True.*
         """
         raise NotImplementedError
 

--- a/mopidy/backend/dummy.py
+++ b/mopidy/backend/dummy.py
@@ -86,6 +86,22 @@ class DummyPlaylistsProvider(backend.PlaylistsProvider):
         self._playlists.append(playlist)
         return playlist
 
+    def create_stored(self, name, tracks):
+        self.rm_stored(name)
+        playlist = Playlist(name=name,
+                            uri='dummy:stored:%s' % name,
+                            tracks=tracks)
+        self._playlists.append(playlist)
+        return playlist
+
+    def rm_stored(self, name):
+        new_playlists = filter(lambda p: p.name != name, self._playlists)
+        if len(new_playlists) < len(self._playlists):
+            self._playlists = new_playlists
+            return True
+        else:
+            return False
+
     def delete(self, uri):
         playlist = self.lookup(uri)
         if playlist:

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -3,6 +3,8 @@ from __future__ import unicode_literals
 import collections
 import itertools
 
+import logging
+
 import pykka
 
 from mopidy import audio, backend, mixer
@@ -13,6 +15,8 @@ from mopidy.core.playback import PlaybackController
 from mopidy.core.playlists import PlaylistsController
 from mopidy.core.tracklist import TracklistController
 from mopidy.utils import versioning
+
+logger = logging.getLogger(__name__)
 
 
 class Core(
@@ -104,6 +108,7 @@ class Backends(list):
         self.with_library_browse = collections.OrderedDict()
         self.with_playback = collections.OrderedDict()
         self.with_playlists = collections.OrderedDict()
+        self.stored_playlists = None
 
         backends_by_scheme = {}
         name = lambda b: b.actor_ref.actor_class.__name__
@@ -113,6 +118,13 @@ class Backends(list):
             has_library_browse = b.has_library_browse().get()
             has_playback = b.has_playback().get()
             has_playlists = b.has_playlists().get()
+            if b.has_stored_playlists().get():
+                if self.stored_playlists is None:
+                    self.stored_playlists = b
+                else:
+                    logger.warn(
+                        "Ignoring playlist storage for backend %s",
+                        name(b))
 
             for scheme in b.uri_schemes.get():
                 assert scheme not in backends_by_scheme, (

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -58,6 +58,38 @@ class PlaylistsController(object):
         listener.CoreListener.send('playlist_changed', playlist=playlist)
         return playlist
 
+    def create_stored(self, name):
+        """
+        Create a playlist of tracks that the user can modify like a traditional
+        mpc playlist as opposed to a playlist created by :meth:`create` which
+        is immutable. Returns True if playlist could be created.
+
+        :param name: name of the new playlist
+        :rtype: boolean
+        """
+        stored = self.backends.stored_playlists
+        if stored:
+            tracks = self.core.tracklist.tracks
+            playlist = stored.playlists.create_stored(name, tracks).get()
+            listener.CoreListener.send('playlist_changed', playlist=playlist)
+            return True
+        else:
+            return False
+
+    def rm_stored(self, name):
+        """
+        Remove a playlist created with create_stored. Returns True if playlist
+        could be removed.
+
+        :param name: name of the playlist to erase.
+        :rtype: boolean
+        """
+        stored = self.backends.stored_playlists
+        if stored:
+            return stored.playlists.rm_stored(name).get()
+        else:
+            return False
+
     def delete(self, uri):
         """
         Delete playlist identified by the URI.

--- a/mopidy/local/json.py
+++ b/mopidy/local/json.py
@@ -56,6 +56,18 @@ def write_library(json_file, data):
             os.remove(tmp.name)
 
 
+def create_stored_playlist(file_path, data):
+    playlist_json = json.dumps(data, cls=models.ModelJSONEncoder,
+                               indent=2, separators=(',', ': '))
+    with open(file_path, 'w') as fp:
+        fp.write(playlist_json)
+
+
+def load_stored_playlist(file_path):
+    with open(file_path, 'r') as fp:
+        return json.load(fp, object_hook=models.model_json_decoder)
+
+
 class _BrowseCache(object):
     encoding = sys.getfilesystemencoding()
     splitpath_re = re.compile(r'([^/]+)')

--- a/mopidy/mpd/protocol/stored_playlists.py
+++ b/mopidy/mpd/protocol/stored_playlists.py
@@ -206,7 +206,8 @@ def rm(context, name):
 
         Removes the playlist ``NAME.m3u`` from the playlist directory.
     """
-    raise exceptions.MpdNotImplemented  # TODO
+    if not context.core.playlists.rm_stored(name).get():
+        raise exceptions.MpdNotImplemented
 
 
 @protocol.commands.add('save')
@@ -219,4 +220,5 @@ def save(context, name):
         Saves the current playlist to ``NAME.m3u`` in the playlist
         directory.
     """
-    raise exceptions.MpdNotImplemented  # TODO
+    if not context.core.playlists.create_stored(name).get():
+        raise exceptions.MpdNotImplemented

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -13,6 +13,7 @@ class CoreLibraryTest(unittest.TestCase):
         dummy1_root = Ref.directory(uri='dummy1:directory', name='dummy1')
         self.backend1 = mock.Mock()
         self.backend1.uri_schemes.get.return_value = ['dummy1']
+        self.backend1.actor_ref.actor_class.__name__ = 'dummy1'
         self.library1 = mock.Mock(spec=backend.LibraryProvider)
         self.library1.root_directory.get.return_value = dummy1_root
         self.backend1.library = self.library1
@@ -20,6 +21,7 @@ class CoreLibraryTest(unittest.TestCase):
         dummy2_root = Ref.directory(uri='dummy2:directory', name='dummy2')
         self.backend2 = mock.Mock()
         self.backend2.uri_schemes.get.return_value = ['dummy2', 'du2']
+        self.backend2.actor_ref.actor_class.__name__ = 'dummy2'
         self.library2 = mock.Mock(spec=backend.LibraryProvider)
         self.library2.root_directory.get.return_value = dummy2_root
         self.backend2.library = self.library2
@@ -27,6 +29,7 @@ class CoreLibraryTest(unittest.TestCase):
         # A backend without the optional library provider
         self.backend3 = mock.Mock()
         self.backend3.uri_schemes.get.return_value = ['dummy3']
+        self.backend3.actor_ref.actor_class.__name__ = 'dummy3'
         self.backend3.has_library().get.return_value = False
         self.backend3.has_library_browse().get.return_value = False
 

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -12,6 +12,7 @@ class CorePlaybackTest(unittest.TestCase):
     def setUp(self):
         self.backend1 = mock.Mock()
         self.backend1.uri_schemes.get.return_value = ['dummy1']
+        self.backend1.actor_ref.actor_class.__name__ = 'dummy1'
         self.playback1 = mock.Mock(spec=backend.PlaybackProvider)
         self.playback1.get_time_position().get.return_value = 1000
         self.playback1.reset_mock()
@@ -19,6 +20,7 @@ class CorePlaybackTest(unittest.TestCase):
 
         self.backend2 = mock.Mock()
         self.backend2.uri_schemes.get.return_value = ['dummy2']
+        self.backend2.actor_ref.actor_class.__name__ = 'dummy2'
         self.playback2 = mock.Mock(spec=backend.PlaybackProvider)
         self.playback2.get_time_position().get.return_value = 2000
         self.playback2.reset_mock()
@@ -27,6 +29,7 @@ class CorePlaybackTest(unittest.TestCase):
         # A backend without the optional playback provider
         self.backend3 = mock.Mock()
         self.backend3.uri_schemes.get.return_value = ['dummy3']
+        self.backend3.actor_ref.actor_class.__name__ = 'dummy3'
         self.backend3.has_playback().get.return_value = False
 
         self.tracks = [

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -12,17 +12,20 @@ class PlaylistsTest(unittest.TestCase):
     def setUp(self):
         self.backend1 = mock.Mock()
         self.backend1.uri_schemes.get.return_value = ['dummy1']
+        self.backend1.actor_ref.actor_class.__name__ = 'dummy1'
         self.sp1 = mock.Mock(spec=backend.PlaylistsProvider)
         self.backend1.playlists = self.sp1
 
         self.backend2 = mock.Mock()
         self.backend2.uri_schemes.get.return_value = ['dummy2']
+        self.backend2.actor_ref.actor_class.__name__ = 'dummy2'
         self.sp2 = mock.Mock(spec=backend.PlaylistsProvider)
         self.backend2.playlists = self.sp2
 
         # A backend without the optional playlists provider
         self.backend3 = mock.Mock()
         self.backend3.uri_schemes.get.return_value = ['dummy3']
+        self.backend3.actor_ref.actor_class.__name__ = 'dummy3'
         self.backend3.has_playlists().get.return_value = False
         self.backend3.playlists = None
 

--- a/tests/mpd/protocol/test_stored_playlists.py
+++ b/tests/mpd/protocol/test_stored_playlists.py
@@ -212,3 +212,29 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
     def test_save(self):
         self.sendRequest('save "name"')
         self.assertEqualResponse('ACK [0@0] {save} Not implemented')
+
+    def test_save_stored(self):
+        # add stored track
+        tracks = [Track(uri='dummy:a'), Track(uri='local:a')]
+        self.backend.playlists.provides_store = True
+        self.core.backends.get().stored_playlists = self.backend
+        tracks = self.core.tracklist.add(tracks)
+        self.sendRequest('save "name"')
+        self.assertEqualResponse('OK')
+        playlist = self.backend.playlists.lookup("dummy:stored:name").get()
+        self.assertNotEqual(playlist, None)
+        self.assertEqual(len(playlist.tracks), 2)
+
+    def test_rm_stored(self):
+        # then delete it
+        tracks = [Track(uri='dummy:a')]
+        self.backend.playlists.provides_store = True
+        self.core.backends.get().stored_playlists = self.backend
+        tracks = self.core.tracklist.add(tracks)
+        self.sendRequest('save "name"')
+        self.assertEqualResponse('OK')
+
+        self.sendRequest('rm "name"')
+        self.assertEqualResponse('OK')
+        playlist = self.backend.playlists.lookup("dummy:stored:name").get()
+        self.assertEqual(playlist, None)


### PR DESCRIPTION
This stores the user-created playlists as json together with the m3u files. When using "rm" only the json files may be removed the m3u files are preserved.

It also lets users save over the top of the playlist with new tracks.
