### PR TITLE
network: Respond to messages before closing connections

### DIFF
--- a/mopidy/utils/network.py
+++ b/mopidy/utils/network.py
@@ -267,7 +267,8 @@ class Connection(object):
             return True
 
         if not data:
-            self.stop('Client most likely disconnected.')
+            self.actor_ref.tell({'close': True})
+            self.disable_recv()
             return True
 
         try:
@@ -348,6 +349,10 @@ class LineProtocol(pykka.ThreadingActor):
 
     def on_receive(self, message):
         """Handle messages with new data from server."""
+        if 'close' in message:
+            self.connection.stop('Client most likely disconnected.')
+            return
+
         if 'received' not in message:
             return
 

--- a/tests/utils/network/test_connection.py
+++ b/tests/utils/network/test_connection.py
@@ -416,7 +416,8 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertTrue(network.Connection.recv_callback(
             self.mock, sentinel.fd, gobject.IO_IN))
-        self.mock.stop.assert_called_once_with(any_unicode)
+        self.mock.actor_ref.tell.assert_called_once_with({'close': True})
+        self.mock.disable_recv.assert_called_once_with()
 
     def test_recv_callback_recoverable_error(self):
         self.mock.sock = Mock(spec=socket.SocketType)

--- a/tests/utils/network/test_lineprotocol.py
+++ b/tests/utils/network/test_lineprotocol.py
@@ -8,6 +8,8 @@ import unittest
 
 from mopidy.utils import network
 
+from tests import any_unicode
+
 
 class LineProtocolTest(unittest.TestCase):
     def setUp(self):
@@ -32,6 +34,14 @@ class LineProtocolTest(unittest.TestCase):
 
         network.LineProtocol.__init__(self.mock, sentinel.connection)
         self.assertEqual(delimiter, self.mock.delimiter)
+
+    def test_on_receive_close_calls_stop(self):
+        self.mock.connection = Mock(spec=network.Connection)
+        self.mock.recv_buffer = ''
+        self.mock.parse_lines.return_value = []
+
+        network.LineProtocol.on_receive(self.mock, {'close': True})
+        self.mock.connection.stop.assert_called_once_with(any_unicode)
 
     def test_on_receive_no_new_lines_adds_to_recv_buffer(self):
         self.mock.connection = Mock(spec=network.Connection)


### PR DESCRIPTION
Now, a connection is closed immediately if it can't receive more messages from the client. If some messages are received, but not processed yet, and they want to respond to the client, this fails. The client never gets the response, because the connection has been closed.

This makes a connection tell the actor to stop the connection, instead of stopping it itself. That means that first, the messages that hasn't been processed yet, will be processed. After that, the connection will be closed.

E.g. it makes this work:

```
$ echo status | nc localhost 6600
```
