### PR TITLE
local: Add friendly help if no local library cache found

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -121,6 +121,10 @@ Feature release.
 
 **Local backend**
 
+- The JSON local library backend now logs a friendly message telling you about
+  ``mopidy local scan`` if you don't have a local library cache. (Fixes:
+  :issue:`711`)
+
 - The ``local scan`` command now use multiple threads to walk the file system
   and check files' modification time. This speeds up scanning, escpecially
   when scanning remote file systems over e.g. NFS.

--- a/mopidy/local/json.py
+++ b/mopidy/local/json.py
@@ -20,6 +20,14 @@ logger = logging.getLogger(__name__)
 
 # TODO: move to load and dump in models?
 def load_library(json_file):
+    if not os.path.isfile(json_file):
+        logger.info(
+            'No local library metadata cache found at %s. Please run '
+            '`mopidy local scan` to index your local music library. '
+            'If you do not have a local music collection, you can disable the '
+            'local backend to hide this message.',
+            json_file)
+        return {}
     try:
         with gzip.open(json_file, 'rb') as fp:
             return json.load(fp, object_hook=models.model_json_decoder)


### PR DESCRIPTION
Fixes #711

Example output before:

```
INFO     Loaded 0 local playlists from /home/jodal/.local/share/mopidy/local/playlists
WARNING  Loading JSON local library failed: [Errno 2] No such file or directory:
'/home/jodal/.local/share/mopidy/local/library.json.gz'
INFO     Loaded 0 local tracks using json
```

Example output now:

```
INFO     Loaded 0 local playlists from /home/jodal/.local/share/mopidy/local/playlists
INFO     No local library metadata cache found at
/home/jodal/.local/share/mopidy/local/library.json.gz. Please run `mopidy local scan` to
index your local music library. If you do not have a local music collection, you can disable
the local backend to hide this message.
INFO     Loaded 0 local tracks using json
```
