### PR TITLE
mpd: Support playlists in browse

### DIFF
--- a/mopidy/mpd/dispatcher.py
+++ b/mopidy/mpd/dispatcher.py
@@ -295,7 +295,8 @@ class MpdContext(object):
 
         for part in path_parts:
             for ref in self.core.library.browse(uri).get():
-                if ref.type == ref.DIRECTORY and ref.name == part:
+                if ((ref.type == ref.DIRECTORY or ref.type == ref.PLAYLIST) and
+                        ref.name == part):
                     uri = ref.uri
                     break
             else:
@@ -309,7 +310,7 @@ class MpdContext(object):
             base_path, future = path_and_futures.pop()
             for ref in future.get():
                 path = '/'.join([base_path, ref.name.replace('/', '')])
-                if ref.type == ref.DIRECTORY:
+                if ref.type == ref.DIRECTORY or ref.type == ref.PLAYLIST:
                     yield (path, None)
                     if recursive:
                         path_and_futures.append(


### PR DESCRIPTION
Playlists are containers similar to directories. Treat them equally to support playlists when browsing.

I started on developing an extension to implement Spotifys browse feature. On the mpd side, this would be browsed with the standard browse feature. However, it provides Spotify playlists, not tracks. Therefore this change, so playlists can be represented in the browse view as well.

Note that the playlists are exposed as directories now. They could be exposed as standard playlists, but I would rather expose them as directories. Primarily because ncmpcpp allows you to view the content of directories without adding them, but only allows you to view the content of playlists through the playlist editor. The playlists in the playlist editor are only the playlists from /, so these will not show there.
