### PR TITLE
stream: Allow for blacklisting of metadata lookups against URI patterns.

### DIFF
--- a/docs/ext/stream.rst
+++ b/docs/ext/stream.rst
@@ -42,3 +42,10 @@ See :ref:`config` for general help on configuring Mopidy.
 .. confval:: stream/timeout
 
     Number of milliseconds before giving up looking up stream metadata.
+
+.. confval:: stream/metadata_blacklist
+
+    List of URI globs to not fetch metadata from before playing. This feature
+    is typically needed for play once URIs provided by certain streaming
+    providers. Regular POSIX glob semantics apply, so ``http://*.example.com/*``
+    would match all example.com sub-domains.

--- a/mopidy/stream/__init__.py
+++ b/mopidy/stream/__init__.py
@@ -19,6 +19,7 @@ class Extension(ext.Extension):
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
         schema['protocols'] = config.List()
+        schema['metadata_blacklist'] = config.List()
         schema['timeout'] = config.Integer(
             minimum=1000, maximum=1000 * 60 * 60)
         return schema

--- a/mopidy/stream/ext.conf
+++ b/mopidy/stream/ext.conf
@@ -9,3 +9,4 @@ protocols =
     rtmps
     rtsp
 timeout = 5000
+metadata_blacklist =


### PR DESCRIPTION
Fixes #660
