### PR TITLE
HTTP: Redirect /app to /app/

### DIFF
--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -84,6 +84,10 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
     def _get_app_request_handlers(self):
         result = []
         for app in self.apps:
+            result.append((
+                r'/%s' % app['name'],
+                handlers.AddSlashHandler
+            ))
             request_handlers = app['factory'](self.config, self.core)
             for handler in request_handlers:
                 handler = list(handler)
@@ -96,7 +100,11 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
         result = []
         for static in self.statics:
             result.append((
-                r'/%s/?(.*)' % static['name'],
+                r'/%s' % static['name'],
+                handlers.AddSlashHandler
+            ))
+            result.append((
+                r'/%s/(.*)' % static['name'],
                 handlers.StaticFileHandler,
                 {
                     'path': static['path'],

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -23,7 +23,7 @@ def mopidy_app_factory(config, core):
         (r'/rpc', JsonRpcHandler, {
             'core': core,
         }),
-        (r'/?(.*)', StaticFileHandler, {
+        (r'/(.*)', StaticFileHandler, {
             'path': os.path.join(os.path.dirname(__file__), 'data'),
             'default_filename': 'mopidy.html'
         }),
@@ -143,3 +143,10 @@ class StaticFileHandler(tornado.web.StaticFileHandler):
         self.set_header('Cache-Control', 'no-cache')
         self.set_header(
             'X-Mopidy-Version', mopidy.__version__.encode('utf-8'))
+
+
+class AddSlashHandler(tornado.web.RequestHandler):
+
+    @tornado.web.addslash
+    def prepare(self):
+        return super(AddSlashHandler, self).prepare()


### PR DESCRIPTION
Unbreaks serving of `/mopidy.css` which ended up as a lookup for the `.css` file in the app mounted at `/mopidy`.
