### PR TITLE
Check configured static_dir and fall back to default if non-existing

### DIFF
--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -2,6 +2,7 @@ from __future__ import unicode_literals
 
 import json
 import logging
+import os
 import threading
 
 import pykka
@@ -61,13 +62,20 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
         handlers.WebSocketHandler.broadcast(message)
 
     def _get_request_handlers(self):
+        static_dir = self.config['http']['static_dir']
         request_handlers = []
 
         request_handlers.extend(self._get_app_request_handlers())
         request_handlers.extend(self._get_static_request_handlers())
 
         # Either default Mopidy or user defined path to files
-        if self.config['http']['static_dir']:
+        if (static_dir and not os.path.exists(static_dir)):
+            logger.warning(
+                'Configured http/static_dir does not exist: %s\n'
+                '  Falling back to default http handler', static_dir)
+            static_dir = None
+
+        if static_dir:
             request_handlers.append((r'/(.*)', handlers.StaticFileHandler, {
                 'path': self.config['http']['static_dir'],
                 'default_filename': 'index.html',


### PR DESCRIPTION
Make sure the 'static_dir' actually exists and has an index.html file inside it before using it. If the tests fail, fall back to using the default.

Signed-off-by: Lasse Bigum lasse@bigum.org
