### PR TITLE
Set template_path for ClientListHandler.

### DIFF
--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -151,6 +151,7 @@ class ClientListHandler(tornado.web.RequestHandler):
     def initialize(self, apps, statics):
         self.apps = apps
         self.statics = statics
+        self.settings['template_path'] = os.path.dirname(__file__)
 
     def get(self):
         set_mopidy_headers(self)


### PR DESCRIPTION
The new Tornado `ClientListHandler` does not set a `template_path` but relies on implicit default (module) directory for resolving the `data/client.html` template. Now, if an HTTP extension sets its own `template_path`, this seems to override the `ClientListHandler`'s template path, too:

```
Traceback (most recent call last):
  File "/home/tkemmer/lib/python2.7/site-packages/tornado-3.2.2-py2.7-linux-x86_64.egg/tornado/web.py", line 1346, in _when_complete
    callback()
  File "/home/tkemmer/lib/python2.7/site-packages/tornado-3.2.2-py2.7-linux-x86_64.egg/tornado/web.py", line 1367, in _execute_method
    self._when_complete(method(*self.path_args, **self.path_kwargs),
  File "/home/tkemmer/src/mopidy/mopidy/http/handlers.py", line 165, in get
    self.render('data/clients.html', apps=sorted(list(names)))
  File "/home/tkemmer/lib/python2.7/site-packages/tornado-3.2.2-py2.7-linux-x86_64.egg/tornado/web.py", line 666, in render
    html = self.render_string(template_name, **kwargs)
  File "/home/tkemmer/lib/python2.7/site-packages/tornado-3.2.2-py2.7-linux-x86_64.egg/tornado/web.py", line 770, in render_string
    t = loader.load(template_name)
  File "/home/tkemmer/lib/python2.7/site-packages/tornado-3.2.2-py2.7-linux-x86_64.egg/tornado/template.py", line 343, in load
    self.templates[name] = self._create_template(name)
  File "/home/tkemmer/lib/python2.7/site-packages/tornado-3.2.2-py2.7-linux-x86_64.egg/tornado/template.py", line 370, in _create_template
    f = open(path, "rb")
IOError: [Errno 2] No such file or directory: u'/home/tkemmer/src/mopidy-http-kuechenradio/mopidy_http_kuechenradio/data/template/data/clients.html'
```

Explicitly setting the  `template_path` apparently solves this. Don't know if this is a Tornado bug, but _explicit is better than implicit_ anyway.
