### PR TITLE
avahi: Service hostname must contain, resolvable fqdn 

### DIFF
--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -58,10 +58,10 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
         if self.zeroconf_name:
             self.zeroconf_http = zeroconf.Zeroconf(
                 stype='_http._tcp', name=self.zeroconf_name,
-                host=self.hostname, port=self.port)
+                port=self.port)
             self.zeroconf_mopidy_http = zeroconf.Zeroconf(
                 stype='_mopidy-http._tcp', name=self.zeroconf_name,
-                host=self.hostname, port=self.port)
+                port=self.port)
             self.zeroconf_http.publish()
             self.zeroconf_mopidy_http.publish()
 

--- a/mopidy/mpd/actor.py
+++ b/mopidy/mpd/actor.py
@@ -43,7 +43,7 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
         if self.zeroconf_name:
             self.zeroconf_service = zeroconf.Zeroconf(
                 stype='_mpd._tcp', name=self.zeroconf_name,
-                host=self.hostname, port=self.port)
+                port=self.port)
             self.zeroconf_service.publish()
 
     def on_stop(self):

--- a/mopidy/zeroconf.py
+++ b/mopidy/zeroconf.py
@@ -43,21 +43,17 @@ class Zeroconf(object):
     :type text: list of str
     """
 
-    def __init__(self, name, port, stype=None, domain=None,
-                 host=None, text=None):
+    def __init__(self, name, port, stype=None, domain=None, text=None):
         self.group = None
         self.stype = stype or '_http._tcp'
         self.domain = domain or ''
         self.port = port
         self.text = text or []
-        if host in ('::', '0.0.0.0'):
-            self.host = ''
-        else:
-            self.host = host
 
         template = string.Template(name)
         self.name = template.safe_substitute(
-            hostname=self.host or socket.getfqdn(), port=self.port)
+            hostname=socket.getfqdn(), port=self.port)
+        self.host = '%s.local' % socket.getfqdn()
 
     def __str__(self):
         return 'Zeroconf service %s at [%s]:%d' % (


### PR DESCRIPTION
Service registred via avahi dbus api must contain fully resolvable FQDN with .local append to its value. Service which doesn't not abide to this rule won't be resolvable.

Test case:

```
# avahi-browse -t -v -r _mopidy-http._tcp.
Server version: avahi 0.6.31; Host name: shramba.local
E Ifce Prot Name                                          Type                 Domain
: Cache exhausted
+   eth0 IPv4 Mopidy HTTP server on namizni                 _mopidy-http._tcp    local
=   eth0 IPv4 Mopidy HTTP server on namizni                 _mopidy-http._tcp    local
   hostname = [namizni.local]
   address = [192.168.1.29]
   port = [6680]
   txt = []
: All for now
```
