### PR TITLE
Print friendly error message if gobject isn't found

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,11 @@ This changelog is used to track all major changes to Mopidy.
 v0.20.0 (UNRELEASED)
 ====================
 
+**Commands**
+
+- Make the ``mopidy`` command print a friendly error message if the
+  :mod:`gobject` Python module cannot be imported. (Fixes: :issue:`836`)
+
 **Local backend**
 
 - Add cover URL to all scanned files with MusicBrainz album IDs. (Fixes:

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -4,9 +4,23 @@ import logging
 import os
 import signal
 import sys
+import textwrap
 
-import gobject
-gobject.threads_init()
+try:
+    import gobject
+    gobject.threads_init()
+except ImportError:
+    print(textwrap.dedent("""
+        ERROR: The gobject Python package was not found.
+
+        Mopidy requires GStreamer (and GObject) to work. These are C libraries
+        with a number of dependencies themselves, and cannot be installed with
+        the regular Python tools like pip.
+
+        Please see http://docs.mopidy.com/en/latest/installation/ for
+        instructions on how to install the required dependencies.
+    """))
+    raise
 
 try:
     # Make GObject's mainloop the event loop for python-dbus


### PR DESCRIPTION
Fixes #836
