### PR TITLE
mpd: Enable browsing of empty dirs

### DIFF
--- a/mopidy/mpd/protocol/music_db.py
+++ b/mopidy/mpd/protocol/music_db.py
@@ -421,8 +421,6 @@ def lsinfo(context, uri=None):
     if uri in (None, '', '/'):
         result.extend(protocol.stored_playlists.listplaylists(context))
 
-    if not result:
-        raise exceptions.MpdNoExistError('Not found')
     return result
 
 

--- a/tests/mpd/protocol/test_music_db.py
+++ b/tests/mpd/protocol/test_music_db.py
@@ -351,6 +351,13 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         self.assertInResponse('directory: dummy/foo')
         self.assertInResponse('OK')
 
+    def test_lsinfo_for_empty_dir_returns_nothing(self):
+        self.backend.library.dummy_browse_result = {
+            'dummy:/': []}
+
+        self.sendRequest('lsinfo "/dummy"')
+        self.assertInResponse('OK')
+
     def test_lsinfo_for_dir_does_not_recurse(self):
         self.backend.library.dummy_library = [
             Track(uri='dummy:/a', name='a'),


### PR DESCRIPTION
This was disabled together with a bunch of other changes without any explanation in commit f24ca36e5a5b72c886d6d8e8df88be79fb094dda. I'm guessing that this wasn't intentional, and no test covered the case.
