### PR TITLE
Support utf-8 chars in m3u playlists

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -93,6 +93,14 @@ v0.20.0 (UNRELEASED)
 - Add basic tests for the stream library provider.
 
 
+v0.19.6 (UNRELEASED)
+====================
+
+**Audio**
+
+- Support UTF-8 in M3U playlists. (Fixes: :issue:`853`)
+
+
 v0.19.5 (2014-12-23)
 ====================
 

--- a/mopidy/audio/playlists.py
+++ b/mopidy/audio/playlists.py
@@ -58,11 +58,11 @@ def parse_m3u(data):
     # TODO: convert non URIs to file URIs.
     found_header = False
     for line in data.readlines():
-        if found_header or line.startswith('#EXTM3U'):
+        if found_header or line.startswith(b'#EXTM3U'):
             found_header = True
         else:
             continue
-        if not line.startswith('#') and line.strip():
+        if not line.startswith(b'#') and line.strip():
             yield line.strip()
 
 

--- a/tests/audio/test_playlists.py
+++ b/tests/audio/test_playlists.py
@@ -13,7 +13,7 @@ BAD = b'foobarbaz'
 M3U = b"""#EXTM3U
 #EXTINF:123, Sample artist - Sample title
 file:///tmp/foo
-#EXTINF:321,Example Artist - Example title
+#EXTINF:321,Example Artist - Example \xc5\xa7\xc5\x95
 file:///tmp/bar
 #EXTINF:213,Some Artist - Other title
 file:///tmp/baz
@@ -25,7 +25,7 @@ File1=file:///tmp/foo
 Title1=Sample Title
 Length1=123
 File2=file:///tmp/bar
-Title2=Example title
+Title2=Example \xc5\xa7\xc5\x95
 Length2=321
 File3=file:///tmp/baz
 Title3=Other title
@@ -40,7 +40,7 @@ ASX = b"""<ASX version="3.0">
     <REF href="file:///tmp/foo" />
   </ENTRY>
   <ENTRY>
-    <TITLE>Example title</TITLE>
+    <TITLE>Example \xc5\xa7\xc5\x95</TITLE>
     <REF href="file:///tmp/bar" />
   </ENTRY>
   <ENTRY>
@@ -65,7 +65,7 @@ XSPF = b"""<?xml version="1.0" encoding="UTF-8"?>
       <location>file:///tmp/foo</location>
     </track>
     <track>
-      <title>Example title</title>
+      <title>Example \xc5\xa7\xc5\x95</title>
       <location>file:///tmp/bar</location>
     </track>
     <track>


### PR DESCRIPTION
Non-ascii utf-8 chars in a .m3u playlist will cause an error similar to the following:
> 2015-01-02 17:22:31,232 - ERROR    GStreamer encountered a general supporting library error. Debug message: /usr/local/lib/python2.7/dist-packages/mopidy/audio/playlists.py(212): _event (): /GstPlayBin2:playbin20/GstURIDecodeBin:uridecodebin4/GstDecodeBin2:decodebin21/mopidy+audio+playlists+M3uDecoder:mopidy+audio+playlists+m3udecoder1:
<type 'exceptions.UnicodeDecodeError'>: 'ascii' codec can't decode byte 0xc3 in position 31: ordinal not in range(128)

This error only occurs if you **don't** enable the mopidy-mpris extension (#853 for more details). 
I added utf-8 characters to all the test playlists even though the other parsers use libraries rather than directly manipulating the bytestrings and are therefore unaffected. 

I'm not sure if `parse_urilist` needs this fix too, presumably it could contain non-ascii character comments.