### PR TITLE
local: Fix exact search to handle tracks where album is None

### DIFF
--- a/mopidy/local/search.py
+++ b/mopidy/local/search.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
-from mopidy.models import Album, SearchResult
+from mopidy.models import SearchResult
 
 
 def find_exact(tracks, query=None, uris=None):
@@ -23,7 +23,8 @@ def find_exact(tracks, query=None, uris=None):
 
             uri_filter = lambda t: q == t.uri
             track_name_filter = lambda t: q == t.name
-            album_filter = lambda t: q == getattr(t, 'album', Album()).name
+            album_filter = lambda t: q == getattr(
+                getattr(t, 'album', None), 'name', None)
             artist_filter = lambda t: filter(
                 lambda a: q == a.name, t.artists)
             albumartist_filter = lambda t: any([

--- a/tests/local/test_search.py
+++ b/tests/local/test_search.py
@@ -1,0 +1,16 @@
+from __future__ import unicode_literals
+
+import unittest
+
+from mopidy.local import search
+from mopidy.models import Album, Track
+
+
+class LocalLibrarySearchTest(unittest.TestCase):
+    def test_find_exact_with_album_query(self):
+        expected_tracks = [Track(album=Album(name='foo'))]
+        tracks = [Track(), Track(album=Album(name='bar'))] + expected_tracks
+
+        search_result = search.find_exact(tracks, {'album': ['foo']})
+
+        self.assertEqual(search_result.tracks, tuple(expected_tracks))


### PR DESCRIPTION
Fixes an issue in exact search so it handles filtering over Tracks where a Track's album is None (see #930).