### PR TITLE
Update source.rst

### DIFF
--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -52,8 +52,8 @@ from source by hand.
 
    If you use Fedora you can install GStreamer like this::
 
-       sudo yum install -y python-gst0.10 gstreamer0.10-plugins-good \
-           gstreamer0.10-plugins-ugly gstreamer0.10-tools
+       sudo yum install -y python-gstreamer1 gstreamer-plugins-good \
+           gstreamer-plugins-ugly gstreamer-tools
 
    If you use Gentoo you need to be careful because GStreamer 0.10 is in a
    different lower slot than 1.0, the default. Your emerge commands will need


### PR DESCRIPTION
I have corrected the yum install command for Fedora, this has been tested with Fedora 20 and 21, would send screenshot of below if possible

```
[root@localhost jmcl]# sudo yum install -y python-gstreamer1 gstreamer-plugins-good \
            gstreamer-plugins-ugly gstreamer-tools
Loaded plugins: langpacks
Repository intellinuxgraphics is listed more than once in the configuration
Package python-gstreamer1-1.4.0-1.fc21.x86_64 already installed and latest version
Package gstreamer-plugins-good-0.10.31-13.fc21.x86_64 already installed and latest version
Package gstreamer-plugins-ugly-0.10.19-18.fc21.x86_64 already installed and latest version
Package gstreamer-tools-0.10.36-10.fc21.x86_64 already installed and latest version
Nothing to do
[root@localhost jmcl]# cat /etc/redhat-release 
Fedora release 21 (Twenty One)
[root@localhost jmcl]# uname -a
Linux localhost.localdomain 3.17.6-300.fc21.x86_64 #1 SMP Mon Dec 8 22:29:32 UTC 2014 x86_64 x86_64 x86_64 GNU/Linux
[root@localhost jmcl]#
```