### PR TITLE
local: add limit and offset support to json library search helpers

### DIFF
--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -98,8 +98,8 @@ class Core(
 
         # We ignore cases when target state is set as this is buffering
         # updates (at least for now) and we need to get #234 fixed...
-        if (new_state == PlaybackState.PAUSED and not target_state
-                and self.playback.state != PlaybackState.PAUSED):
+        if (new_state == PlaybackState.PAUSED and not target_state and
+                self.playback.state != PlaybackState.PAUSED):
             self.playback.state = new_state
             self.playback._trigger_track_playback_paused()
 

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -392,8 +392,8 @@ class TracklistController(object):
         criteria = criteria or kwargs
         matches = self._tl_tracks
         for (key, values) in criteria.items():
-            if (not isinstance(values, collections.Iterable)
-                    or isinstance(values, compat.string_types)):
+            if (not isinstance(values, collections.Iterable) or
+                    isinstance(values, compat.string_types)):
                 # Fail hard if anyone is using the <0.17 calling style
                 raise ValueError('Filter values must be iterable: %r' % values)
             if key == 'tlid':

--- a/mopidy/local/json.py
+++ b/mopidy/local/json.py
@@ -157,11 +157,12 @@ class JsonLibrary(local.Library):
 
     def search(self, query=None, limit=100, offset=0, uris=None, exact=False):
         tracks = self._tracks.values()
-        # TODO: pass limit and offset into search helpers
         if exact:
-            return search.find_exact(tracks, query=query, uris=uris)
+            return search.find_exact(
+                tracks, query=query, limit=limit, offset=offset, uris=uris)
         else:
-            return search.search(tracks, query=query, uris=uris)
+            return search.search(
+                tracks, query=query, limit=limit, offset=offset, uris=uris)
 
     def begin(self):
         return compat.itervalues(self._tracks)

--- a/mopidy/local/search.py
+++ b/mopidy/local/search.py
@@ -8,7 +8,7 @@ def find_exact(tracks, query=None, limit=100, offset=0, uris=None):
     Filter a list of tracks where ``field`` is ``values``.
 
     :param list tracks: a list of :class:`~mopidy.models.Track`
-    :param dict query: one or more queries to search for
+    :param dict query: one or more field/value pairs to search for
     :param int limit: maximum number of results to return
     :param int offset: offset into result set to use.
     :param uris: zero or more URI roots to limit the search to
@@ -108,7 +108,7 @@ def find_exact(tracks, query=None, limit=100, offset=0, uris=None):
 
     # TODO: add local:search:<query>
     return SearchResult(
-        uri='local:search', tracks=tracks[offset:offset+limit])
+        uri='local:search', tracks=tracks[offset:offset + limit])
 
 
 def search(tracks, query=None, limit=100, offset=0, uris=None):
@@ -116,7 +116,7 @@ def search(tracks, query=None, limit=100, offset=0, uris=None):
     Filter a list of tracks where ``field`` is like ``values``.
 
     :param list tracks: a list of :class:`~mopidy.models.Track`
-    :param dict query: one or more queries to search for
+    :param dict query: one or more field/value pairs to search for
     :param int limit: maximum number of results to return
     :param int offset: offset into result set to use.
     :param uris: zero or more URI roots to limit the search to
@@ -218,7 +218,8 @@ def search(tracks, query=None, limit=100, offset=0, uris=None):
             else:
                 raise LookupError('Invalid lookup field: %s' % field)
     # TODO: add local:search:<query>
-    return SearchResult(uri='local:search', tracks=tracks[offset:offset+limit])
+    return SearchResult(uri='local:search',
+                        tracks=tracks[offset:offset + limit])
 
 
 def _validate_query(query):

--- a/mopidy/local/search.py
+++ b/mopidy/local/search.py
@@ -3,7 +3,18 @@ from __future__ import absolute_import, unicode_literals
 from mopidy.models import SearchResult
 
 
-def find_exact(tracks, query=None, uris=None):
+def find_exact(tracks, query=None, limit=100, offset=0, uris=None):
+    """
+    Filter a list of tracks where ``field`` is ``values``.
+
+    :param list tracks: a list of :class:`~mopidy.models.Track`
+    :param dict query: one or more queries to search for
+    :param int limit: maximum number of results to return
+    :param int offset: offset into result set to use.
+    :param uris: zero or more URI roots to limit the search to
+    :type uris: list of strings or :class:`None`
+    :rtype: :class:`~mopidy.models.SearchResult`
+    """
     # TODO Only return results within URI roots given by ``uris``
 
     if query is None:
@@ -96,10 +107,22 @@ def find_exact(tracks, query=None, uris=None):
                 raise LookupError('Invalid lookup field: %s' % field)
 
     # TODO: add local:search:<query>
-    return SearchResult(uri='local:search', tracks=tracks)
+    return SearchResult(
+        uri='local:search', tracks=tracks[offset:offset+limit])
 
 
-def search(tracks, query=None, uris=None):
+def search(tracks, query=None, limit=100, offset=0, uris=None):
+    """
+    Filter a list of tracks where ``field`` is like ``values``.
+
+    :param list tracks: a list of :class:`~mopidy.models.Track`
+    :param dict query: one or more queries to search for
+    :param int limit: maximum number of results to return
+    :param int offset: offset into result set to use.
+    :param uris: zero or more URI roots to limit the search to
+    :type uris: list of strings or :class:`None`
+    :rtype: :class:`~mopidy.models.SearchResult`
+    """
     # TODO Only return results within URI roots given by ``uris``
 
     if query is None:
@@ -195,7 +218,7 @@ def search(tracks, query=None, uris=None):
             else:
                 raise LookupError('Invalid lookup field: %s' % field)
     # TODO: add local:search:<query>
-    return SearchResult(uri='local:search', tracks=tracks)
+    return SearchResult(uri='local:search', tracks=tracks[offset:offset+limit])
 
 
 def _validate_query(query):

--- a/mopidy/local/search.py
+++ b/mopidy/local/search.py
@@ -124,8 +124,8 @@ def search(tracks, query=None, uris=None):
                 return bool(t.name and q in t.name.lower())
 
             def album_filter(t):
-                return bool(t.album and t.album.name
-                            and q in t.album.name.lower())
+                return bool(t.album and t.album.name and
+                            q in t.album.name.lower())
 
             def artist_filter(t):
                 return bool(filter(lambda a:

--- a/tests/local/test_json.py
+++ b/tests/local/test_json.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
+
 import unittest
 
 from mopidy.local import json
-from mopidy.models import Ref
+from mopidy.models import Ref, Track
+
+
+from tests import path_to_data_dir
 
 
 class BrowseCacheTest(unittest.TestCase):
@@ -38,3 +42,52 @@ class BrowseCacheTest(unittest.TestCase):
     def test_lookup_foo_baz(self):
         result = self.cache.lookup('local:directory:foo/unknown')
         self.assertEqual([], result)
+
+
+class JsonLibraryTest(unittest.TestCase):
+
+    config = {
+        'local': {
+            'media_dir': path_to_data_dir(''),
+            'data_dir': path_to_data_dir(''),
+            'playlists_dir': b'',
+            'library': 'json',
+        },
+    }
+
+    def setUp(self):  # noqa: N802
+        self.library = json.JsonLibrary(self.config)
+
+    def _create_tracks(self, count):
+        for i in xrange(count):
+            self.library.add(Track(uri='local:track:%d' % i))
+
+    def test_search_should_default_limit_results(self):
+        self._create_tracks(101)
+
+        result = self.library.search()
+        result_exact = self.library.search(exact=True)
+
+        self.assertEqual(len(result.tracks), 100)
+        self.assertEqual(len(result_exact.tracks), 100)
+
+    def test_search_should_limit_results(self):
+        self._create_tracks(100)
+
+        result = self.library.search(limit=35)
+        result_exact = self.library.search(exact=True, limit=35)
+
+        self.assertEqual(len(result.tracks), 35)
+        self.assertEqual(len(result_exact.tracks), 35)
+
+    def test_search_should_offset_results(self):
+        self._create_tracks(200)
+
+        expected = self.library.search(limit=110).tracks[10:]
+        expected_exact = self.library.search(exact=True, limit=110).tracks[10:]
+
+        result = self.library.search(offset=10).tracks
+        result_exact = self.library.search(offset=10, exact=True).tracks
+
+        self.assertEqual(expected, result)
+        self.assertEqual(expected_exact, result_exact)

--- a/tests/local/test_json.py
+++ b/tests/local/test_json.py
@@ -59,7 +59,7 @@ class JsonLibraryTest(unittest.TestCase):
         self.library = json.JsonLibrary(self.config)
 
     def _create_tracks(self, count):
-        for i in xrange(count):
+        for i in range(count):
             self.library.add(Track(uri='local:track:%d' % i))
 
     def test_search_should_default_limit_results(self):


### PR DESCRIPTION
Fixes the json local library's search behavior by adding support for limit and offset parameters to search helpers. Currently, `JsonLibrary.search` returns all matching results, and ignores the limit and offset parameters. (see #917)

----
Note: LocalLibraryProvider [does not pass any limit/offset arguments][llp] when searching its local backend (which has [a default limit of 100 and offset of 0][search]). When using mopidy as a mpd server, this affects how many results [the `list` command][list] returns:

([mpd backend]: [result of `$ mpc list artist | wc -l`])
mpd: 1033
mopidy (develop): 1031
mopidy (fix/local-json-limit-offset): 86

[llp]: https://github.com/mopidy/mopidy/blob/develop/mopidy/local/library.py#L44
[search]: https://docs.mopidy.com/en/latest/modules/local/#mopidy.local.Library.search
[list]: https://github.com/mopidy/mopidy/blob/develop/mopidy/mpd/protocol/music_db.py#L167

<!---
@huboard:{"milestone_order":936.5,"order":970.0,"custom_state":""}
-->
