### PR TITLE
Use websocket via HTTPS if appropriate

### DIFF
--- a/mopidy/http/data/mopidy.js
+++ b/mopidy/http/data/mopidy.js
@@ -2385,8 +2385,10 @@ Mopidy.prototype._getConsole = function (settings) {
 Mopidy.prototype._configure = function (settings) {
     var currentHost = (typeof document !== "undefined" &&
         document.location.host) || "localhost";
+    var protocol = (typeof document !== "undefined" &&
+        document.location.protocol === "https:") ? "wss://" : "ws://";
     settings.webSocketUrl = settings.webSocketUrl ||
-        "ws://" + currentHost + "/mopidy/ws";
+        protocol + currentHost + "/mopidy/ws";
 
     if (settings.autoConnect !== false) {
         settings.autoConnect = true;


### PR DESCRIPTION
If the page was loaded via HTTPS, the websocket should also connect via HTTPS. Fixes #950.