### PR TITLE
Re-set volume explicitly to the current level whenever changing tracks.

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -320,7 +320,9 @@ class Audio(pykka.ThreadingActor):
         :param uri: the URI to play
         :type uri: string
         """
+        current_volume = self.get_volume()
         self._playbin.set_property('uri', uri)
+        self.set_volume(current_volume)
 
     def set_appsrc(
             self, caps, need_data=None, enough_data=None, seek_data=None):

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -320,6 +320,9 @@ class Audio(pykka.ThreadingActor):
         :param uri: the URI to play
         :type uri: string
         """
+        # Note: Hack to workaround issue on Mac OS X where volume level
+        # does not persist between track changes.
+        # https://github.com/mopidy/mopidy/issues/886
         current_volume = self.get_volume()
         self._playbin.set_property('uri', uri)
         self.set_volume(current_volume)


### PR DESCRIPTION
 Workaround for issue #886.

<!---
@huboard:{"order":971.0,"milestone_order":958,"custom_state":""}
-->
