### PR TITLE
Add tags and duration to local library add()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -51,6 +51,9 @@ v0.20.0 (UNRELEASED)
   just like the other ``lookup()`` methods in Mopidy. For now, returning a
   single track will continue to work. (PR: :issue:`840`)
 
+- Add support for giving local libraries direct access to tags and duration.
+  (Fixes: :issue:`967`)
+
 **File scanner**
 
 - Improve error logging for scan code (Fixes: :issue:`856`, PR: :issue:`874`)

--- a/mopidy/local/__init__.py
+++ b/mopidy/local/__init__.py
@@ -70,8 +70,8 @@ class Library(object):
     #: Name of the local library implementation, must be overriden.
     name = None
 
-    #: Feature marker to indicate that you want add calls to be called with
-    #: optional arguments tags and duration.
+    #: Feature marker to indicate that you want :meth:`add()` calls to be
+    #: called with optional arguments tags and duration.
     add_supports_tags_and_duration = False
 
     def __init__(self, config):
@@ -142,7 +142,7 @@ class Library(object):
     def add(self, track, tags=None, duration=None):
         """
         Add the given track to library. Optional args will only be added if
-        `add_supports_tags_and_duration` has been set.
+        :attr:`add_supports_tags_and_duration` has been set.
 
         :param track: Track to add to the library
         :type track: :class:`~mopidy.models.Track`

--- a/mopidy/local/__init__.py
+++ b/mopidy/local/__init__.py
@@ -70,6 +70,10 @@ class Library(object):
     #: Name of the local library implementation, must be overriden.
     name = None
 
+    #: Feature marker to indicate that you want add calls to be called with
+    #: optional arguments tags and duration.
+    add_supports_tags_and_duration = False
+
     def __init__(self, config):
         self._config = config
 
@@ -135,12 +139,19 @@ class Library(object):
         """
         raise NotImplementedError
 
-    def add(self, track):
+    def add(self, track, tags=None, duration=None):
         """
-        Add the given track to library.
+        Add the given track to library. Optional args will only be added if
+        `add_supports_tags_and_duration` has been set.
 
         :param track: Track to add to the library
         :type track: :class:`~mopidy.models.Track`
+        :param tags: All the tags the scanner found for the media. See
+            :module:`mopidy.audio.utils` for details about the tags.
+        :type tags: dictionary of tag keys with a list of values.
+        :param duration: Duration of media in milliseconds or :class:`None` if
+            unknown
+        :type duration: :class:`int` or :class:`None`
         """
         raise NotImplementedError
 

--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -139,8 +139,10 @@ class ScanCommand(commands.Command):
                     track = utils.convert_tags_to_track(tags).copy(
                         uri=uri, length=duration, last_modified=mtime)
                     track = translator.add_musicbrainz_coverart_to_track(track)
-                    # TODO: add tags to call if library supports it.
-                    library.add(track)
+                    if library.add_supports_tags_and_duration:
+                        library.add(track, tags=tags, duration=duration)
+                    else:
+                        library.add(track)
                     logger.debug('Added %s', track.uri)
             except exceptions.ScannerError as error:
                 logger.warning('Failed %s: %s', uri, error)


### PR DESCRIPTION
@tkem couldn't quite make my mind up to if the API should passing in `add(track)` for "legacy" clients and then `add(uri, tags, duration)` for new ones, so ended up with this mix. To be honest I don't care exactly which variant we go with as long as it solves the use case you had :-)