### PR TITLE
Local playlist refactoring

### DIFF
--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -67,8 +67,6 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
             playlists.append(playlist)
 
         self.playlists = playlists
-        # TODO: send what scheme we loaded them for?
-        backend.BackendListener.send('playlists_loaded')
 
         logger.info(
             'Loaded %d local playlists from %s',

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -38,10 +38,10 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
             logger.warn('Trying to delete unknown playlist %s', uri)
             return
         path = local_playlist_uri_to_path(uri, self._playlists_dir)
-        try:
+        if os.path.exists(path):
             os.remove(path)
-        except OSError as e:
-            logger.error('Error deleting playlist %s: %s', uri, e)
+        else:
+            logger.warn('Trying to delete missing playlist file %s', path)
         self._playlists.remove(playlist)
 
     def lookup(self, uri):
@@ -89,10 +89,10 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
         playlist = self._save_m3u(playlist)
         if index >= 0 and uri != playlist.uri:
             path = local_playlist_uri_to_path(uri, self._playlists_dir)
-            try:
+            if os.path.exists(path):
                 os.remove(path)
-            except OSError as e:
-                logger.error('Error deleting playlist %s: %s', uri, e)
+            else:
+                logger.warn('Trying to delete missing playlist file %s', path)
         if index >= 0:
             self._playlists[index] = playlist
         else:

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -67,6 +67,8 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
             playlists.append(playlist)
 
         self.playlists = playlists
+        # TODO: send what scheme we loaded them for?
+        backend.BackendListener.send('playlists_loaded')
 
         logger.info(
             'Loaded %d local playlists from %s',

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -53,9 +53,10 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
     def refresh(self):
         playlists = []
 
-        for path in glob.glob(os.path.join(self._playlists_dir, '*.m3u')):
+        encoding = sys.getfilesystemencoding()
+        for path in glob.glob(os.path.join(self._playlists_dir, b'*.m3u')):
             relpath = os.path.basename(path)
-            name, _ = os.path.splitext(relpath)
+            name = os.path.splitext(relpath)[0].decode(encoding)
             uri = path_to_local_playlist_uri(relpath)
 
             tracks = []

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -9,7 +9,7 @@ from mopidy import backend
 from mopidy.models import Playlist
 
 from .translator import parse_m3u
-from .translator import path_to_local_playlist_uri, local_playlist_uri_to_path
+from .translator import local_playlist_uri_to_path, path_to_local_playlist_uri
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -43,8 +43,6 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
         except OSError as e:
             logger.error('Error deleting playlist %s: %s', uri, e)
         self._playlists.remove(playlist)
-        # TODO: handle in PlaylistsController, playlist_changed?
-        backend.BackendListener.send('playlists_loaded')
 
     def lookup(self, uri):
         # TODO: store as {uri: playlist}?

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -8,8 +8,8 @@ import sys
 from mopidy import backend
 from mopidy.models import Playlist
 
-from .translator import parse_m3u
 from .translator import local_playlist_uri_to_path, path_to_local_playlist_uri
+from .translator import parse_m3u
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -43,6 +43,8 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
         except OSError as e:
             logger.error('Error deleting playlist %s: %s', uri, e)
         self._playlists.remove(playlist)
+        # TODO: handle in PlaylistsController, playlist_changed?
+        backend.BackendListener.send('playlists_loaded')
 
     def lookup(self, uri):
         # TODO: store as {uri: playlist}?

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -3,14 +3,13 @@ from __future__ import absolute_import, division, unicode_literals
 import glob
 import logging
 import os
-import shutil
+import sys
 
 from mopidy import backend
 from mopidy.models import Playlist
-from mopidy.utils import formatting, path
 
 from .translator import parse_m3u
-
+from .translator import path_to_local_playlist_uri, local_playlist_uri_to_path
 
 logger = logging.getLogger(__name__)
 
@@ -23,18 +22,27 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
         self.refresh()
 
     def create(self, name):
-        name = formatting.slugify(name)
-        uri = 'local:playlist:%s.m3u' % name
-        playlist = Playlist(uri=uri, name=name)
-        return self.save(playlist)
+        playlist = self._save_m3u(Playlist(name=name))
+        old_playlist = self.lookup(playlist.uri)
+        if old_playlist is not None:
+            index = self._playlists.index(old_playlist)
+            self._playlists[index] = playlist
+        else:
+            self._playlists.append(playlist)
+        logger.info('Created playlist %s', playlist.uri)
+        return playlist
 
     def delete(self, uri):
         playlist = self.lookup(uri)
         if not playlist:
+            logger.warn('Trying to delete unknown playlist %s', uri)
             return
-
+        path = local_playlist_uri_to_path(uri, self._playlists_dir)
+        try:
+            os.remove(path)
+        except OSError as e:
+            logger.error('Error deleting playlist %s: %s', uri, e)
         self._playlists.remove(playlist)
-        self._delete_m3u(playlist.uri)
 
     def lookup(self, uri):
         # TODO: store as {uri: playlist}?
@@ -45,12 +53,13 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
     def refresh(self):
         playlists = []
 
-        for m3u in glob.glob(os.path.join(self._playlists_dir, '*.m3u')):
-            name = os.path.splitext(os.path.basename(m3u))[0]
-            uri = 'local:playlist:%s' % name
+        for path in glob.glob(os.path.join(self._playlists_dir, '*.m3u')):
+            relpath = os.path.basename(path)
+            name, _ = os.path.splitext(relpath)
+            uri = path_to_local_playlist_uri(relpath)
 
             tracks = []
-            for track in parse_m3u(m3u, self._media_dir):
+            for track in parse_m3u(path, self._media_dir):
                 tracks.append(track)
 
             playlist = Playlist(uri=uri, name=name, tracks=tracks)
@@ -67,38 +76,53 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
     def save(self, playlist):
         assert playlist.uri, 'Cannot save playlist without URI'
 
-        old_playlist = self.lookup(playlist.uri)
+        uri = playlist.uri
+        # TODO: require existing (created) playlist - currently, this
+        # is a *should* in https://docs.mopidy.com/en/latest/api/core/
+        try:
+            index = self._playlists.index(self.lookup(uri))
+        except ValueError:
+            logger.warn('Saving playlist with new URI %s', uri)
+            index = -1
 
-        if old_playlist and playlist.name != old_playlist.name:
-            playlist = playlist.copy(name=formatting.slugify(playlist.name))
-            playlist = self._rename_m3u(playlist)
-
-        self._save_m3u(playlist)
-
-        if old_playlist is not None:
-            index = self._playlists.index(old_playlist)
+        playlist = self._save_m3u(playlist)
+        if index >= 0 and uri != playlist.uri:
+            path = local_playlist_uri_to_path(uri, self._playlists_dir)
+            try:
+                os.remove(path)
+            except OSError as e:
+                logger.error('Error deleting playlist %s: %s', uri, e)
+        if index >= 0:
             self._playlists[index] = playlist
         else:
             self._playlists.append(playlist)
-
         return playlist
-
-    def _m3u_uri_to_path(self, uri):
-        # TODO: create uri handling helpers for local uri types.
-        file_path = path.uri_to_path(uri).split(':', 1)[1]
-        file_path = os.path.join(self._playlists_dir, file_path)
-        path.check_file_path_is_inside_base_dir(file_path, self._playlists_dir)
-        return file_path
 
     def _write_m3u_extinf(self, file_handle, track):
         title = track.name.encode('latin-1', 'replace')
         runtime = track.length // 1000 if track.length else -1
         file_handle.write('#EXTINF:' + str(runtime) + ',' + title + '\n')
 
-    def _save_m3u(self, playlist):
-        file_path = self._m3u_uri_to_path(playlist.uri)
+    def _sanitize_m3u_name(self, name, encoding=sys.getfilesystemencoding()):
+        name = name.encode(encoding, errors='replace')
+        name = os.path.basename(name)
+        name = name.decode(encoding)
+        return name
+
+    def _save_m3u(self, playlist, encoding=sys.getfilesystemencoding()):
+        if playlist.name:
+            name = self._sanitize_m3u_name(playlist.name, encoding)
+            uri = path_to_local_playlist_uri(name.encode(encoding) + b'.m3u')
+            path = local_playlist_uri_to_path(uri, self._playlists_dir)
+        elif playlist.uri:
+            uri = playlist.uri
+            path = local_playlist_uri_to_path(uri, self._playlists_dir)
+            name, _ = os.path.splitext(os.path.basename(path).decode(encoding))
+        else:
+            raise ValueError('M3U playlist needs name or URI')
         extended = any(track.name for track in playlist.tracks)
-        with open(file_path, 'w') as file_handle:
+
+        with open(path, 'w') as file_handle:
             if extended:
                 file_handle.write('#EXTM3U\n')
             for track in playlist.tracks:
@@ -106,17 +130,5 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
                     self._write_m3u_extinf(file_handle, track)
                 file_handle.write(track.uri + '\n')
 
-    def _delete_m3u(self, uri):
-        file_path = self._m3u_uri_to_path(uri)
-        if os.path.exists(file_path):
-            os.remove(file_path)
-
-    def _rename_m3u(self, playlist):
-        dst_name = formatting.slugify(playlist.name)
-        dst_uri = 'local:playlist:%s.m3u' % dst_name
-
-        src_file_path = self._m3u_uri_to_path(playlist.uri)
-        dst_file_path = self._m3u_uri_to_path(dst_uri)
-
-        shutil.move(src_file_path, dst_file_path)
-        return playlist.copy(uri=dst_uri)
+        # assert playlist name matches file name/uri
+        return playlist.copy(uri=uri, name=name)

--- a/mopidy/local/translator.py
+++ b/mopidy/local/translator.py
@@ -37,8 +37,15 @@ def local_track_uri_to_path(uri, media_dir):
     return os.path.join(media_dir, file_path)
 
 
+def local_playlist_uri_to_path(uri, playlists_dir):
+    if not uri.startswith('local:playlist:'):
+        raise ValueError('Invalid URI %s' % uri)
+    file_path = uri_to_path(uri).split(b':', 1)[1]
+    return os.path.join(playlists_dir, file_path)
+
+
 def path_to_local_track_uri(relpath):
-    """Convert path releative to media_dir to local track URI."""
+    """Convert path relative to media_dir to local track URI."""
     if isinstance(relpath, compat.text_type):
         relpath = relpath.encode('utf-8')
     return b'local:track:%s' % urllib.quote(relpath)
@@ -49,6 +56,13 @@ def path_to_local_directory_uri(relpath):
     if isinstance(relpath, compat.text_type):
         relpath = relpath.encode('utf-8')
     return b'local:directory:%s' % urllib.quote(relpath)
+
+
+def path_to_local_playlist_uri(relpath):
+    """Convert path relative to playlists_dir to local playlist URI."""
+    if isinstance(relpath, compat.text_type):
+        relpath = relpath.encode('utf-8')
+    return b'local:playlist:%s' % urllib.quote(relpath)
 
 
 def m3u_extinf_to_track(line):

--- a/tests/local/test_playlists.py
+++ b/tests/local/test_playlists.py
@@ -201,9 +201,13 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
 
         self.assertEqual(original_playlist, looked_up_playlist)
 
-    @unittest.SkipTest
     def test_refresh(self):
-        pass
+        playlist = self.core.playlists.create('test')
+        self.assertIn(playlist, self.core.playlists.playlists)
+
+        self.core.playlists.refresh()
+
+        self.assertIn(playlist, self.core.playlists.playlists)
 
     def test_save_replaces_existing_playlist_with_updated_playlist(self):
         playlist1 = self.core.playlists.create('test1')

--- a/tests/local/test_playlists.py
+++ b/tests/local/test_playlists.py
@@ -9,6 +9,7 @@ import pykka
 
 from mopidy import core
 from mopidy.local import actor
+from mopidy.local.translator import local_playlist_uri_to_path
 from mopidy.models import Playlist, Track
 
 from tests import dummy_audio, path_to_data_dir
@@ -41,49 +42,50 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
             shutil.rmtree(self.playlists_dir)
 
     def test_created_playlist_is_persisted(self):
-        path = os.path.join(self.playlists_dir, 'test.m3u')
+        uri = 'local:playlist:test.m3u'
+        path = local_playlist_uri_to_path(uri, self.playlists_dir)
         self.assertFalse(os.path.exists(path))
 
-        self.core.playlists.create('test')
+        playlist = self.core.playlists.create('test')
+        self.assertEqual('test', playlist.name)
+        self.assertEqual(uri, playlist.uri)
         self.assertTrue(os.path.exists(path))
 
-    def test_create_slugifies_playlist_name(self):
-        path = os.path.join(self.playlists_dir, 'test-foo-bar.m3u')
-        self.assertFalse(os.path.exists(path))
-
-        playlist = self.core.playlists.create('test FOO baR')
-        self.assertEqual('test-foo-bar', playlist.name)
-        self.assertTrue(os.path.exists(path))
-
-    def test_create_slugifies_names_which_tries_to_change_directory(self):
-        path = os.path.join(self.playlists_dir, 'test-foo-bar.m3u')
-        self.assertFalse(os.path.exists(path))
-
+    def test_create_sanitizes_playlist_name(self):
         playlist = self.core.playlists.create('../../test FOO baR')
-        self.assertEqual('test-foo-bar', playlist.name)
+        self.assertEqual('test FOO baR', playlist.name)
+        path = local_playlist_uri_to_path(playlist.uri, self.playlists_dir)
+        self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))
 
     def test_saved_playlist_is_persisted(self):
-        path1 = os.path.join(self.playlists_dir, 'test1.m3u')
-        path2 = os.path.join(self.playlists_dir, 'test2-foo-bar.m3u')
+        uri1 = 'local:playlist:test1.m3u'
+        uri2 = 'local:playlist:test2.m3u'
+
+        path1 = local_playlist_uri_to_path(uri1, self.playlists_dir)
+        path2 = local_playlist_uri_to_path(uri2, self.playlists_dir)
 
         playlist = self.core.playlists.create('test1')
-
+        self.assertEqual('test1', playlist.name)
+        self.assertEqual(uri1, playlist.uri)
         self.assertTrue(os.path.exists(path1))
         self.assertFalse(os.path.exists(path2))
 
-        playlist = playlist.copy(name='test2 FOO baR')
-        playlist = self.core.playlists.save(playlist)
-
-        self.assertEqual('test2-foo-bar', playlist.name)
+        playlist = self.core.playlists.save(playlist.copy(name='test2'))
+        self.assertEqual('test2', playlist.name)
+        self.assertEqual(uri2, playlist.uri)
         self.assertFalse(os.path.exists(path1))
         self.assertTrue(os.path.exists(path2))
 
     def test_deleted_playlist_is_removed(self):
-        path = os.path.join(self.playlists_dir, 'test.m3u')
+        uri = 'local:playlist:test.m3u'
+        path = local_playlist_uri_to_path(uri, self.playlists_dir)
+
         self.assertFalse(os.path.exists(path))
 
         playlist = self.core.playlists.create('test')
+        self.assertEqual('test', playlist.name)
+        self.assertEqual(uri, playlist.uri)
         self.assertTrue(os.path.exists(path))
 
         self.core.playlists.delete(playlist.uri)
@@ -92,24 +94,22 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
     def test_playlist_contents_is_written_to_disk(self):
         track = Track(uri=generate_song(1))
         playlist = self.core.playlists.create('test')
-        playlist_path = os.path.join(self.playlists_dir, 'test.m3u')
-        playlist = playlist.copy(tracks=[track])
-        playlist = self.core.playlists.save(playlist)
+        playlist = self.core.playlists.save(playlist.copy(tracks=[track]))
+        path = local_playlist_uri_to_path(playlist.uri, self.playlists_dir)
 
-        with open(playlist_path) as playlist_file:
-            contents = playlist_file.read()
+        with open(path) as f:
+            contents = f.read()
 
         self.assertEqual(track.uri, contents.strip())
 
     def test_extended_playlist_contents_is_written_to_disk(self):
         track = Track(uri=generate_song(1), name='Test', length=60000)
         playlist = self.core.playlists.create('test')
-        playlist_path = os.path.join(self.playlists_dir, 'test.m3u')
-        playlist = playlist.copy(tracks=[track])
-        playlist = self.core.playlists.save(playlist)
+        playlist = self.core.playlists.save(playlist.copy(tracks=[track]))
+        path = local_playlist_uri_to_path(playlist.uri, self.playlists_dir)
 
-        with open(playlist_path) as playlist_file:
-            contents = playlist_file.read().splitlines()
+        with open(path) as f:
+            contents = f.read().splitlines()
 
         self.assertEqual(contents, ['#EXTM3U', '#EXTINF:60,Test', track.uri])
 
@@ -123,7 +123,7 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
 
         self.assert_(backend.playlists.playlists)
         self.assertEqual(
-            'local:playlist:test', backend.playlists.playlists[0].uri)
+            playlist.uri, backend.playlists.playlists[0].uri)
         self.assertEqual(
             playlist.name, backend.playlists.playlists[0].name)
         self.assertEqual(
@@ -154,7 +154,7 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
         self.assert_(not self.core.playlists.playlists)
 
     def test_delete_non_existant_playlist(self):
-        self.core.playlists.delete('file:///unknown/playlist')
+        self.core.playlists.delete('local:playlist:unknown')
 
     def test_delete_playlist_removes_it_from_the_collection(self):
         playlist = self.core.playlists.create('test')
@@ -162,6 +162,19 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
 
         self.core.playlists.delete(playlist.uri)
 
+        self.assertNotIn(playlist, self.core.playlists.playlists)
+
+    def test_delete_playlist_without_file(self):
+        playlist = self.core.playlists.create('test')
+        self.assertIn(playlist, self.core.playlists.playlists)
+
+        path = local_playlist_uri_to_path(playlist.uri, self.playlists_dir)
+        self.assertTrue(os.path.exists(path))
+
+        os.remove(path)
+        self.assertFalse(os.path.exists(path))
+
+        self.core.playlists.delete(playlist.uri)
         self.assertNotIn(playlist, self.core.playlists.playlists)
 
     def test_filter_without_criteria(self):
@@ -218,6 +231,27 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
         self.assertNotIn(playlist1, self.core.playlists.playlists)
         self.assertIn(playlist2, self.core.playlists.playlists)
 
+    def test_create_replaces_existing_playlist_with_updated_playlist(self):
+        track = Track(uri=generate_song(1))
+        playlist1 = self.core.playlists.create('test')
+        playlist1 = self.core.playlists.save(playlist1.copy(tracks=[track]))
+        self.assertIn(playlist1, self.core.playlists.playlists)
+
+        playlist2 = self.core.playlists.create('test')
+        self.assertEqual(playlist1.uri, playlist2.uri)
+        self.assertNotIn(playlist1, self.core.playlists.playlists)
+        self.assertIn(playlist2, self.core.playlists.playlists)
+
+    def test_save_playlist_with_new_uri(self):
+        # you *should* not do this
+        uri = 'local:playlist:test.m3u'
+        playlist = self.core.playlists.save(Playlist(uri=uri))
+        self.assertIn(playlist, self.core.playlists.playlists)
+        self.assertEqual(uri, playlist.uri)
+        self.assertEqual('test', playlist.name)
+        path = local_playlist_uri_to_path(playlist.uri, self.playlists_dir)
+        self.assertTrue(os.path.exists(path))
+
     def test_playlist_with_unknown_track(self):
         track = Track(uri='file:///dev/null')
         playlist = self.core.playlists.create('test')
@@ -228,7 +262,7 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
 
         self.assert_(backend.playlists.playlists)
         self.assertEqual(
-            'local:playlist:test', backend.playlists.playlists[0].uri)
+            'local:playlist:test.m3u', backend.playlists.playlists[0].uri)
         self.assertEqual(
             playlist.name, backend.playlists.playlists[0].name)
         self.assertEqual(


### PR DESCRIPTION
Fixes #937; I decided to do a little refactoring of the local playlist code, even at the risk of putting "too much" in a single PR:

- Local playlist URIs now look similar to local track URIs; added `local_playlist_uri_to_path()` and `path_to_local_playlist_uri()` to `mopidy.local.translator`.

- Dropped `formatting.slugify()` for playlist names. Since my early MPD days, I have this M3U playlist named `Radio Österreich.m3u` for local radio streams, and I *really* hate if that gets messed up... Instead, M3U playlist names are sanitized with respect to the file system encoding, and only the `os.path.basename` of a given name is used. This means that a `LocalPlaylistsProvider.create('A/B')` will result in a file named `B.m3u`. This is less than ideal and subject to discussion, but the best I could come up with for now. Seems to work great with modifying *existing* M3U files, though...

- ~~Emit a `playlists_loaded` event after successfully deleting a playlist. With `create` and `save`, `playlist_changed` events are all already emitted by the `PlaylistController`, but AFAICS no events are sent when a playlist is deleted, which might also be of interest to clients. I didn't want to use `playlist_changed` for playlists no longer accessible since clients may not handle this well. I think this needs more discussion and should really be handled by the `PlaylistController` for consistency.~~

- The current docs [https://docs.mopidy.com/en/latest/api/core/#mopidy.core.PlaylistsController.save] state that for `save()`, "you *should* not set the uri atribute yourself, but use playlist objects returned by create() or retrieved from playlists". IMHO, this SHOULD might as well be changed to MUST, making things a little easier on the backend side. However, for this PR only a warning is logged if `save()` is called with a "new" playlist URI.

- Creating or saving a playlist with a name/URI of another existing playlist will overwrite the other playlist without further notice. Now, I don't think it is specified in the docs what should happen in this case. I left it as I think was originally intended, but I guess this case needs to be documented, at least.

- In addition to adapting and extending the existing unit tests, I also implemented playlist deletion and adding stream URIs to existing playlist in a feature branch for Mopidy-Mobile, which was my original use case for #937. That's how I also noticed the missing event notification for `delete`. Therefore I'd really like to see this in a not-too-distant v0.19.x bugfix release ;-)
