### PR TITLE
Issue #910 and spelling fix

### DIFF
--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -61,8 +61,7 @@ class ScanCommand(commands.Command):
         super(ScanCommand, self).__init__()
         self.add_argument('--limit',
                           action='store', type=int, dest='limit', default=None,
-                          help='Maxmimum number of tracks to scan')
-
+                          help='Maximum number of tracks to scan')
     def run(self, args, config):
         media_dir = config['local']['media_dir']
         scan_timeout = config['local']['scan_timeout']
@@ -121,7 +120,9 @@ class ScanCommand(commands.Command):
         logger.info('Scanning...')
 
         uris_to_update = sorted(uris_to_update, key=lambda v: v.lower())
+        print("Before: ", uris_to_update)
         uris_to_update = uris_to_update[:args.limit]
+        print("After: ", uris_to_update)
 
         scanner = scan.Scanner(scan_timeout)
         progress = _Progress(flush_threshold, len(uris_to_update))

--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -62,6 +62,9 @@ class ScanCommand(commands.Command):
         self.add_argument('--limit',
                           action='store', type=int, dest='limit', default=None,
                           help='Maximum number of tracks to scan')
+        self.add_argument('--force',
+                          action='store_true',dest='force',default=False,
+                          help='Forces the scanner to re-scan all media files')
     def run(self, args, config):
         media_dir = config['local']['media_dir']
         scan_timeout = config['local']['scan_timeout']
@@ -96,7 +99,7 @@ class ScanCommand(commands.Command):
             if mtime is None:
                 logger.debug('Missing file %s', track.uri)
                 uris_to_remove.add(track.uri)
-            elif mtime > track.last_modified:
+            elif mtime > track.last_modified or args.force:
                 uris_to_update.add(track.uri)
             uris_in_library.add(track.uri)
 
@@ -120,9 +123,7 @@ class ScanCommand(commands.Command):
         logger.info('Scanning...')
 
         uris_to_update = sorted(uris_to_update, key=lambda v: v.lower())
-        print("Before: ", uris_to_update)
         uris_to_update = uris_to_update[:args.limit]
-        print("After: ", uris_to_update)
 
         scanner = scan.Scanner(scan_timeout)
         progress = _Progress(flush_threshold, len(uris_to_update))


### PR DESCRIPTION
In issue #910 an enhancement was requested to add a --force argument to the scan command.

Also, while working on #910 I noticed the help text for --limit had a miss-spelled word so went ahead and fixed that.