### PR TITLE
Adding documentation for contributing on OS X

### DIFF
--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -68,6 +68,21 @@ please follow the directions :ref:`here <contributing>`.
    ``gst-plugins-meta:0.10`` is the one that actually pulls in the plugins you
    want, so pay attention to the use flags, e.g. ``alsa``, ``mp3``, etc.
 
+   If you are running OS X, you need to install a few things
+
+    #. Install Xcode command line developer tools. Do this even if you already have Xcode installed::
+      
+        xcode-select --install
+
+    #. Install `XQuartz <http://xquartz.macosforge.org/>`_ as GStreamer depends on it.
+
+    #. Make sure you have `Homebrew <http://brew.sh/>`_ installed. This is used to install Gstreamer.
+
+    #. You need to run ``brew tap homebrew/versions`` and then run the following commands::
+
+        brew install gst-python010 gst-plugins-good010
+        brew install gst-plugins-ugly --with-mad
+
 #. Install the latest release of Mopidy::
 
        sudo pip install -U mopidy


### PR DESCRIPTION
Used Parallels to install a fresh copy of OS X 10.10.2 and compiled the steps to install the necessary dependencies to contribute on OS X by installing from source. This helps clarify how to install the dependencies without having to run ```brew mopidy/mopidy/mopidy``` and have multiple copies of Mopidy on your system. This is in response to #994. 