### PR TITLE
Improve default get_images() implementation with album/artist URIs.

### DIFF
--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -108,7 +108,7 @@ class LibraryProvider(object):
             for track in self.lookup(uri):
                 if track.album and track.album.images:
                     image_uris.update(track.album.images)
-            result[uri] = list(map(lambda u: models.Image(uri=u), image_uris))
+            result[uri] = [models.Image(uri=u) for u in image_uris]
         return result
 
     # TODO: replace with search(query, exact=True, ...)

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -104,11 +104,11 @@ class LibraryProvider(object):
         """
         result = {}
         for uri in uris:
+            image_uris = set()
             for track in self.lookup(uri):
                 if track.album and track.album.images:
-                    for image_uri in track.album.images:
-                        image = models.Image(uri=image_uri)
-                        result.setdefault(uri, []).append(image)
+                    image_uris.update(track.album.images)
+            result[uri] = list(map(lambda u: models.Image(uri=u), image_uris))
         return result
 
     # TODO: replace with search(query, exact=True, ...)

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -17,3 +17,14 @@ class LibraryTest(unittest.TestCase):
 
         expected = {'trackuri': [models.Image(uri='imageuri')]}
         self.assertEqual(library.get_images(['trackuri']), expected)
+
+    def test_default_get_images_impl_no_album_image(self):
+        # default implementation now returns an empty list if no
+        # images are found, though it's not required to
+        track = models.Track(uri='trackuri')
+
+        library = dummy_backend.DummyLibraryProvider(backend=None)
+        library.dummy_library.append(track)
+
+        expected = {'trackuri': []}
+        self.assertEqual(library.get_images(['trackuri']), expected)


### PR DESCRIPTION
This slightly improves the new default `get_images()` implementation when called with album or artist URIs. An album or artist URI `lookup` may result in multiple tracks which will probably share the same album(s), resulting in duplicate image URIs being reported. With this patch, image URIs belonging to all tracks reported for a given input URI are put into a set first, thus eliminating duplicates.

As a side effect, the default implementation now returns an empty list if no images can be found.
