### PR TITLE
Add Dbus event listener to CoreListener interface

### DIFF
--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -15,6 +15,7 @@ from mopidy.core.mixer import MixerController
 from mopidy.core.playback import PlaybackController
 from mopidy.core.playlists import PlaylistsController
 from mopidy.core.tracklist import TracklistController
+from mopidy.dbus_listener import DbusListener
 from mopidy.models import TlTrack, Track
 from mopidy.utils import versioning
 from mopidy.utils.deprecation import deprecated_property
@@ -48,6 +49,10 @@ class Core(
     """The tracklist controller. An instance of
     :class:`mopidy.core.TracklistController`."""
 
+    dbus_listener = None
+    """The DBus listener. An instance of
+    :class:`mopidy.DbusListener`."""
+
     def __init__(self, mixer=None, backends=None, audio=None):
         super(Core, self).__init__()
 
@@ -59,6 +64,7 @@ class Core(
         self.playback = PlaybackController(backends=self.backends, core=self)
         self.playlists = PlaylistsController(backends=self.backends, core=self)
         self.tracklist = TracklistController(core=self)
+        self.dbus_listener = DbusListener()
 
         self.audio = audio
 

--- a/mopidy/core/listener.py
+++ b/mopidy/core/listener.py
@@ -171,3 +171,26 @@ class CoreListener(listener.Listener):
         *MAY* be implemented by actor.
         """
         pass
+
+    def system_suspend(self, suspend):
+        """
+        Called whenever system is about to suspend or resume
+
+        *MAY* be implemented by actor.
+
+        :param suspend: true if system is about to suspend, false if resuming
+        :type time_position: boolean
+        """
+        pass
+
+    def system_shutdown(self, shutdown):
+        """
+        Called whenever system is about to shutdown or has powered on
+
+        *MAY* be implemented by actor.
+
+        :param shutdown: true if system is about to shutdown, false if powered
+        on
+        :type time_position: boolean
+        """
+        pass

--- a/mopidy/dbus_listener.py
+++ b/mopidy/dbus_listener.py
@@ -1,0 +1,51 @@
+from __future__ import absolute_import, unicode_literals
+
+import logging
+
+from dbus.mainloop.glib import DBusGMainLoop  # integration into the main loop
+
+from mopidy.core.listener import CoreListener
+
+logger = logging.getLogger(__name__)
+
+try:
+    import dbus
+except ImportError:
+    dbus = None
+
+
+class DbusListener(object):
+    """Listen to events emitted via DBus."""
+
+    def __init__(self):
+        try:
+            DBusGMainLoop(set_as_default=True)  # integrate into main loop
+            bus = dbus.SystemBus()  # connect to system wide dbus
+            # define the signal to listen to
+            bus.add_signal_receiver(
+                self.handle_suspend,               # callback function
+                'PrepareForSleep',                 # signal name
+                'org.freedesktop.login1.Manager',  # interface
+                'org.freedesktop.login1'           # bus name
+            )
+            # define the signal to listen to
+            bus.add_signal_receiver(
+                self.handle_shutdown,              # callback function
+                'PrepareForShutdown',              # signal name
+                'org.freedesktop.login1.Manager',  # interface
+                'org.freedesktop.login1'           # bus name
+            )
+            logger.info('Dbus signal receivers added successfully')
+        except dbus.exceptions.DBusException as e:
+            logger.debug('%s: Adding DBus listener failed: %s', self, e)
+            return False
+
+    def handle_suspend(self, suspend):
+        logger.debug('DBus suspend signal received: %s', suspend)
+        # Forward event from backend to frontends
+        CoreListener.send('system_suspend', suspend=suspend)
+
+    def handle_shutdown(self, shutdown):
+        logger.debug('DBus shutdown signal received: %s', shutdown)
+        # Forward event from backend to frontends
+        CoreListener.send('system_shutdown', shutdown=shutdown)


### PR DESCRIPTION
Add new class for listening to Dbus events and forward the
events via the CoreListener interface to clients.

Fixes #970