### PR TITLE
Fix #1023: Remove support for local album images from coverartarchive.org

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -66,9 +66,6 @@ v0.20.0 (UNRELEASED)
 
 **Local backend**
 
-- Add cover URL to all scanned files with MusicBrainz album IDs. (Fixes:
-  :issue:`697`, PR: :issue:`802`)
-
 - Local library API: Implementors of :meth:`mopidy.local.Library.lookup` should
   now return a list of :class:`~mopidy.models.Track` instead of a single track,
   just like the other ``lookup()`` methods in Mopidy. For now, returning a

--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -141,7 +141,6 @@ class ScanCommand(commands.Command):
                     mtime = file_mtimes.get(os.path.join(media_dir, relpath))
                     track = utils.convert_tags_to_track(tags).copy(
                         uri=uri, length=duration, last_modified=mtime)
-                    track = translator.add_musicbrainz_coverart_to_track(track)
                     if library.add_supports_tags_and_duration:
                         library.add(track, tags=tags, duration=duration)
                     else:

--- a/mopidy/local/translator.py
+++ b/mopidy/local/translator.py
@@ -13,17 +13,8 @@ from mopidy.utils.path import path_to_uri, uri_to_path
 
 
 M3U_EXTINF_RE = re.compile(r'#EXTINF:(-1|\d+),(.*)')
-COVERART_BASE = 'http://coverartarchive.org/release/%s/front'
 
 logger = logging.getLogger(__name__)
-
-
-def add_musicbrainz_coverart_to_track(track):
-    if track.album and track.album.musicbrainz_id:
-        images = [COVERART_BASE % track.album.musicbrainz_id]
-        album = track.album.copy(images=images)
-        track = track.copy(album=album)
-    return track
 
 
 def local_track_uri_to_file_uri(uri, media_dir):

--- a/tests/local/test_translator.py
+++ b/tests/local/test_translator.py
@@ -7,7 +7,7 @@ import tempfile
 import unittest
 
 from mopidy.local import translator
-from mopidy.models import Album, Track
+from mopidy.models import Track
 from mopidy.utils import path
 
 from tests import path_to_data_dir
@@ -118,16 +118,3 @@ class M3UToUriTest(unittest.TestCase):
 
 class URItoM3UTest(unittest.TestCase):
     pass
-
-
-class AddMusicbrainzCoverartTest(unittest.TestCase):
-    def test_add_cover_for_album(self):
-        album = Album(musicbrainz_id='someid')
-        track = Track(album=album)
-
-        expected = album.copy(
-            images=['http://coverartarchive.org/release/someid/front'])
-
-        self.assertEqual(
-            track.copy(album=expected),
-            translator.add_musicbrainz_coverart_to_track(track))


### PR DESCRIPTION
As discussed in #1023, the current implementation adds a link to `track.album.images` without checking if the corresponding image exists in the Cover Art Archive.

Since `album.images` is going to be deprecated anyway and replaced with `Library.get_images()`, the easiest solution is to simply remove this for now.
