### PR TITLE
Fix #1026: Sort local playlists by name.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -89,6 +89,7 @@ v0.20.0 (UNRELEASED)
   better and fixes bug in deletion of playlists. (Fixes: :issue:`937`, 
   PR: :issue:`995` and rebased into :issue:`1000`)
 
+- Sort local playlists by name. (Fixes: :issue:`1026`, PR: :issue:`1028`)
 
 **File scanner**
 

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, division, unicode_literals
 
 import glob
 import logging
+import operator
 import os
 import sys
 
@@ -29,6 +30,7 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
             self._playlists[index] = playlist
         else:
             self._playlists.append(playlist)
+        self._playlists.sort(key=operator.attrgetter('name'))
         logger.info('Created playlist %s', playlist.uri)
         return playlist
 
@@ -45,7 +47,8 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
         self._playlists.remove(playlist)
 
     def lookup(self, uri):
-        # TODO: store as {uri: playlist}?
+        # TODO: store as {uri: playlist} when get_playlists() gets
+        # implemented
         for playlist in self._playlists:
             if playlist.uri == uri:
                 return playlist
@@ -66,7 +69,7 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
             playlist = Playlist(uri=uri, name=name, tracks=tracks)
             playlists.append(playlist)
 
-        self.playlists = playlists
+        self.playlists = sorted(playlists, key=operator.attrgetter('name'))
 
         logger.info(
             'Loaded %d local playlists from %s',
@@ -95,6 +98,7 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
             self._playlists[index] = playlist
         else:
             self._playlists.append(playlist)
+        self._playlists.sort(key=operator.attrgetter('name'))
         return playlist
 
     def _write_m3u_extinf(self, file_handle, track):

--- a/tests/local/test_playlists.py
+++ b/tests/local/test_playlists.py
@@ -267,3 +267,27 @@ class LocalPlaylistsProviderTest(unittest.TestCase):
             playlist.name, backend.playlists.playlists[0].name)
         self.assertEqual(
             track.uri, backend.playlists.playlists[0].tracks[0].uri)
+
+    def test_playlist_sort_order(self):
+        def check_order(playlists, names):
+            self.assertEqual(names, [playlist.name for playlist in playlists])
+
+        self.core.playlists.create('c')
+        self.core.playlists.create('a')
+        self.core.playlists.create('b')
+
+        check_order(self.core.playlists.playlists, ['a', 'b', 'c'])
+
+        self.core.playlists.refresh()
+
+        check_order(self.core.playlists.playlists, ['a', 'b', 'c'])
+
+        playlist = self.core.playlists.lookup('local:playlist:a.m3u')
+        playlist = playlist.copy(name='d')
+        playlist = self.core.playlists.save(playlist)
+
+        check_order(self.core.playlists.playlists, ['b', 'c', 'd'])
+
+        self.core.playlists.delete('local:playlist:c.m3u')
+
+        check_order(self.core.playlists.playlists, ['b', 'd'])


### PR DESCRIPTION
Fixes #1026 by sorting the local playlists according to their `name` property after every `create`, `save` and `refresh` operation. Slightly inefficient, but this should be converted to use a `{uri: playlist}` mapping after `get_playlists()` gets implemented, anyway.
