### PR TITLE
Fix #1031: Add get_images() to local library.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -88,6 +88,9 @@ v0.20.0 (UNRELEASED)
 
 - Sort local playlists by name. (Fixes: :issue:`1026`, PR: :issue:`1028`)
 
+- Add :meth:`mopidy.local.Library.get_images` for looking up images
+  for local URIs. (Fixes: :issue:`1031`, PR: :issue:`1032`)
+
 **File scanner**
 
 - Improve error logging for scan code (Fixes: :issue:`856`, PR: :issue:`874`)

--- a/mopidy/local/__init__.py
+++ b/mopidy/local/__init__.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import mopidy
-from mopidy import config, ext
+from mopidy import config, ext, models
 
 logger = logging.getLogger(__name__)
 
@@ -100,6 +100,27 @@ class Library(object):
         :rtype: set of values corresponding to the requested field type.
         """
         return set()
+
+    def get_images(self, uris):
+        """
+        Lookup the images for the given URIs.
+
+        The default implementation will simply call :meth:`lookup` and
+        try and use the album art for any tracks returned. Most local
+        libraries should replace this with something smarter or simply
+        return an empty dictionary.
+
+        :param list uris: list of URIs to find images for
+        :rtype: {uri: tuple of :class:`mopidy.models.Image`}
+        """
+        result = {}
+        for uri in uris:
+            image_uris = set()
+            for track in self.lookup(uri):
+                if track.album and track.album.images:
+                    image_uris.update(track.album.images)
+            result[uri] = [models.Image(uri=u) for u in image_uris]
+        return result
 
     def load(self):
         """

--- a/mopidy/local/library.py
+++ b/mopidy/local/library.py
@@ -28,6 +28,11 @@ class LocalLibraryProvider(backend.LibraryProvider):
             return set()
         return self._library.get_distinct(field, query)
 
+    def get_images(self, uris):
+        if not self._library:
+            return {}
+        return self._library.get_images(uris)
+
     def refresh(self, uri=None):
         if not self._library:
             return 0


### PR DESCRIPTION
Fixes #1031 by adding `local.Library.get_images()`, with default implementation corresponding to `LibraryProvider.get_images()`.