### PR TITLE
Add typefinding / MIME guess to scan code.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -144,6 +144,13 @@ v0.20.0 (UNRELEASED)
 
   - Update scanner to operate with milliseconds for duration.
 
+  - Update scanner to use a custom src, typefind and decodebin. This allows us
+    to catch playlists before we try to decode them.
+
+  - Refactored scanner to create a new pipeline per song, this is needed as
+    reseting decodebin is much slower than tearing it down and making a fresh
+    one.
+
 - Add :meth:`mopidy.audio.AudioListener.tags_changed`. Notifies core when new tags
   are found.
 
@@ -162,6 +169,12 @@ v0.20.0 (UNRELEASED)
 
 - Add workaround for volume not persisting across tracks on OS X.
   (Issue: :issue:`886`, PR: :issue:`958`)
+
+- Improved missing plugin error reporting in scanner.
+
+- Introduced a new return type for the scanner, a named tuple with ``uri``,
+  ``tags``, ``duration``, ``seekable`` and ``mime``. Also added support for
+  checking seekable, and the initial MIME type guess.
 
 **Stream backend**
 

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -92,6 +92,9 @@ class Scanner(object):
 
         if not self._src:
             self._src = gst.element_make_from_uri(gst.URI_SRC, uri)
+            if not self._src:
+                raise exceptions.ScannerError('Could not find any elements to '
+                                              'handle %s URI.' % protocol)
             utils.setup_proxy(self._src, self._proxy_config)
             self._pipe.add(self._src)
             self._src.link(self._typefinder)

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -47,7 +47,6 @@ class Scanner(object):
         self._pipe.add(sink)
 
         self._bus = self._pipe.get_bus()
-        self._bus.set_flushing(True)
 
     def scan(self, uri):
         """
@@ -82,8 +81,6 @@ class Scanner(object):
         self._pipe.add(self._src)
         self._src.sync_state_with_parent()
         self._src.link(self._decodebin)
-
-        self._bus.set_flushing(False)
 
         result = self._pipe.set_state(gst.STATE_PAUSED)
         if result == gst.STATE_CHANGE_NO_PREROLL:
@@ -121,8 +118,7 @@ class Scanner(object):
         raise exceptions.ScannerError('Timeout after %dms' % self._timeout_ms)
 
     def _reset(self):
-        """Ensures we cleanup child elements and flush the bus."""
-        self._bus.set_flushing(True)
+        """Ensures we cleanup child elements."""
         self._pipe.set_state(gst.STATE_NULL)
         self._src.unlink(self._decodebin)
         self._pipe.remove(self._src)

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -14,10 +14,13 @@ from mopidy.utils import encoding
 
 _missing_plugin_desc = gst.pbutils.missing_plugin_message_get_description
 
-Result = collections.namedtuple(
+_Result = collections.namedtuple(
     'Result', ('uri', 'tags', 'duration', 'seekable', 'mime'))
 
+_RAW_AUDIO = gst.Caps(b'audio/x-raw-int; audio/x-raw-float')
 
+
+# TODO: replace with a scan(uri, timeout=1000, proxy_config=None)?
 class Scanner(object):
     """
     Helper to get tags and other relevant info from URIs.
@@ -30,33 +33,6 @@ class Scanner(object):
     def __init__(self, timeout=1000, proxy_config=None):
         self._timeout_ms = timeout
         self._proxy_config = proxy_config or {}
-
-        sink = gst.element_factory_make('fakesink')
-        self._src = None
-
-        def pad_added(src, pad):
-            return pad.link(sink.get_pad('sink'))
-
-        def have_type(finder, probability, caps):
-            msg = gst.message_new_application(finder, caps.get_structure(0))
-            finder.get_bus().post(msg)
-
-        self._typefinder = gst.element_factory_make('typefind')
-        self._typefinder.connect('have-type', have_type)
-
-        audio_caps = gst.Caps(b'audio/x-raw-int; audio/x-raw-float')
-        self._decodebin = gst.element_factory_make('decodebin2')
-        self._decodebin.set_property('caps', audio_caps)
-        self._decodebin.connect('pad-added', pad_added)
-
-        self._pipe = gst.element_factory_make('pipeline')
-        self._pipe.add(self._typefinder)
-        self._pipe.add(self._decodebin)
-        self._pipe.add(sink)
-
-        self._typefinder.link(self._decodebin)
-
-        self._bus = self._pipe.get_bus()
 
     def scan(self, uri):
         """
@@ -72,92 +48,109 @@ class Scanner(object):
             indicating if a seek would succeed.
         """
         tags, duration, seekable, mime = None, None, None, None
+        pipeline = _setup_pipeline(uri, self._proxy_config)
+
         try:
-            self._setup(uri)
-            tags, mime = self._collect()
-            duration = self._query_duration()
-            seekable = self._query_seekable()
+            _start_pipeline(pipeline)
+            tags, mime = _process(pipeline, self._timeout_ms / 1000.0)
+            duration = _query_duration(pipeline)
+            seekable = _query_seekable(pipeline)
         finally:
-            self._reset()
+            pipeline.set_state(gst.STATE_NULL)
+            del pipeline
 
-        return Result(uri, tags, duration, seekable, mime)
+        return _Result(uri, tags, duration, seekable, mime)
 
-    def _setup(self, uri):
-        """Primes the pipeline for collection."""
-        protocol = gst.uri_get_protocol(uri)
-        if self._src and protocol not in self._src.get_protocols():
-            self._src.unlink(self._typefinder)
-            self._pipe.remove(self._src)
-            self._src = None
 
-        if not self._src:
-            self._src = gst.element_make_from_uri(gst.URI_SRC, uri)
-            if not self._src:
-                raise exceptions.ScannerError('Could not find any elements to '
-                                              'handle %s URI.' % protocol)
-            utils.setup_proxy(self._src, self._proxy_config)
-            self._pipe.add(self._src)
-            self._src.link(self._typefinder)
+# Turns out it's _much_ faster to just create a new pipeline for every as
+# decodebins and other elements don't seem to take well to being reused.
+def _setup_pipeline(uri, proxy_config=None):
+    src = gst.element_make_from_uri(gst.URI_SRC, uri)
+    if not src:
+        raise exceptions.ScannerError('GStreamer can not open: %s' % uri)
 
-        self._pipe.set_state(gst.STATE_READY)
-        self._src.set_uri(uri)
+    typefind = gst.element_factory_make('typefind')
+    decodebin = gst.element_factory_make('decodebin2')
+    sink = gst.element_factory_make('fakesink')
 
-        result = self._pipe.set_state(gst.STATE_PAUSED)
-        if result == gst.STATE_CHANGE_NO_PREROLL:
-            # Live sources don't pre-roll, so set to playing to get data.
-            self._pipe.set_state(gst.STATE_PLAYING)
+    pipeline = gst.element_factory_make('pipeline')
+    pipeline.add_many(src, typefind, decodebin, sink)
+    gst.element_link_many(src, typefind, decodebin)
 
-    def _collect(self):
-        """Polls for messages to collect data."""
-        start = time.time()
-        timeout_s = self._timeout_ms / 1000.0
-        tags, mime, missing_description = {}, None, None
+    if proxy_config:
+        utils.setup_proxy(src, proxy_config)
 
-        while time.time() - start < timeout_s:
-            if not self._bus.have_pending():
-                continue
-            message = self._bus.pop()
+    decodebin.set_property('caps', _RAW_AUDIO)
+    decodebin.connect('pad-added', _pad_added, sink)
+    typefind.connect('have-type', _have_type, decodebin)
 
-            if message.type == gst.MESSAGE_ELEMENT:
-                if gst.pbutils.is_missing_plugin_message(message):
-                    missing_description = encoding.locale_decode(
-                        _missing_plugin_desc(message))
-            elif message.type == gst.MESSAGE_APPLICATION:
-                mime = message.structure.get_name()
-                if mime.startswith('text/') or mime == 'application/xml':
-                    return tags, mime
-            elif message.type == gst.MESSAGE_ERROR:
-                error = encoding.locale_decode(message.parse_error()[0])
-                if missing_description:
-                    error = '%s (%s)' % (missing_description, error)
-                raise exceptions.ScannerError(error)
-            elif message.type == gst.MESSAGE_EOS:
+    return pipeline
+
+
+def _have_type(element, probability, caps, decodebin):
+    decodebin.set_property('sink-caps', caps)
+    msg = gst.message_new_application(element, caps.get_structure(0))
+    element.get_bus().post(msg)
+
+
+def _pad_added(element, pad, sink):
+    return pad.link(sink.get_pad('sink'))
+
+
+def _start_pipeline(pipeline):
+    if pipeline.set_state(gst.STATE_PAUSED) == gst.STATE_CHANGE_NO_PREROLL:
+        pipeline.set_state(gst.STATE_PLAYING)
+
+
+def _query_duration(pipeline):
+    try:
+        duration = pipeline.query_duration(gst.FORMAT_TIME, None)[0]
+    except gst.QueryError:
+        return None
+
+    if duration < 0:
+        return None
+    else:
+        return duration // gst.MSECOND
+
+
+def _query_seekable(pipeline):
+    query = gst.query_new_seeking(gst.FORMAT_TIME)
+    pipeline.query(query)
+    return query.parse_seeking()[1]
+
+
+def _process(pipeline, timeout):
+    start = time.time()
+    tags, mime, missing_description = {}, None, None
+    bus = pipeline.get_bus()
+
+    while time.time() - start < timeout:
+        if not bus.have_pending():
+            continue
+        message = bus.pop()
+
+        if message.type == gst.MESSAGE_ELEMENT:
+            if gst.pbutils.is_missing_plugin_message(message):
+                missing_description = encoding.locale_decode(
+                    _missing_plugin_desc(message))
+        elif message.type == gst.MESSAGE_APPLICATION:
+            mime = message.structure.get_name()
+            if mime.startswith('text/') or mime == 'application/xml':
                 return tags, mime
-            elif message.type == gst.MESSAGE_ASYNC_DONE:
-                if message.src == self._pipe:
-                    return tags, mime
-            elif message.type == gst.MESSAGE_TAG:
-                taglist = message.parse_tag()
-                # Note that this will only keep the last tag.
-                tags.update(utils.convert_taglist(taglist))
+        elif message.type == gst.MESSAGE_ERROR:
+            error = encoding.locale_decode(message.parse_error()[0])
+            if missing_description:
+                error = '%s (%s)' % (missing_description, error)
+            raise exceptions.ScannerError(error)
+        elif message.type == gst.MESSAGE_EOS:
+            return tags, mime
+        elif message.type == gst.MESSAGE_ASYNC_DONE:
+            if message.src == pipeline:
+                return tags, mime
+        elif message.type == gst.MESSAGE_TAG:
+            taglist = message.parse_tag()
+            # Note that this will only keep the last tag.
+            tags.update(utils.convert_taglist(taglist))
 
-        raise exceptions.ScannerError('Timeout after %dms' % self._timeout_ms)
-
-    def _reset(self):
-        self._pipe.set_state(gst.STATE_NULL)
-
-    def _query_duration(self):
-        try:
-            duration = self._pipe.query_duration(gst.FORMAT_TIME, None)[0]
-        except gst.QueryError:
-            return None
-
-        if duration < 0:
-            return None
-        else:
-            return duration // gst.MSECOND
-
-    def _query_seekable(self):
-        query = gst.query_new_seeking(gst.FORMAT_TIME)
-        self._pipe.query(query)
-        return query.parse_seeking()[1]
+    raise exceptions.ScannerError('Timeout after %dms' % (timeout * 1000))

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -125,9 +125,12 @@ def _process(pipeline, timeout_ms):
     timeout = timeout_ms * gst.MSECOND
     tags, mime, missing_description = {}, None, None
 
+    types = (gst.MESSAGE_ELEMENT | gst.MESSAGE_APPLICATION | gst.MESSAGE_ERROR
+             | gst.MESSAGE_EOS | gst.MESSAGE_ASYNC_DONE | gst.MESSAGE_TAG)
+
     start = clock.get_time()
     while timeout > 0:
-        message = bus.timed_pop(timeout)
+        message = bus.timed_pop_filtered(timeout, types)
 
         if message is None:
             break

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -73,11 +73,8 @@ class Scanner(object):
 
     def _setup(self, uri):
         """Primes the pipeline for collection."""
-        self._pipe.set_state(gst.STATE_READY)
-
         self._src = gst.element_make_from_uri(gst.URI_SRC, uri)
         utils.setup_proxy(self._src, self._proxy_config)
-
         self._pipe.add(self._src)
         self._src.sync_state_with_parent()
         self._src.link(self._decodebin)

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -15,7 +15,7 @@ from mopidy.utils import encoding
 _missing_plugin_desc = gst.pbutils.missing_plugin_message_get_description
 
 Result = collections.namedtuple(
-    'Result', ('uri', 'tags', 'duration', 'seekable'))
+    'Result', ('uri', 'tags', 'duration', 'seekable', 'mime'))
 
 
 class Scanner(object):
@@ -37,14 +37,24 @@ class Scanner(object):
         def pad_added(src, pad):
             return pad.link(sink.get_pad('sink'))
 
+        def have_type(finder, probability, caps):
+            msg = gst.message_new_application(finder, caps.get_structure(0))
+            finder.get_bus().post(msg)
+
+        self._typefinder = gst.element_factory_make('typefind')
+        self._typefinder.connect('have-type', have_type)
+
         audio_caps = gst.Caps(b'audio/x-raw-int; audio/x-raw-float')
         self._decodebin = gst.element_factory_make('decodebin2')
         self._decodebin.set_property('caps', audio_caps)
         self._decodebin.connect('pad-added', pad_added)
 
         self._pipe = gst.element_factory_make('pipeline')
+        self._pipe.add(self._typefinder)
         self._pipe.add(self._decodebin)
         self._pipe.add(sink)
+
+        self._typefinder.link(self._decodebin)
 
         self._bus = self._pipe.get_bus()
 
@@ -54,28 +64,29 @@ class Scanner(object):
 
         :param uri: URI of the resource to scan.
         :type event: string
-        :return: A named tuple containing ``(uri, tags, duration, seekable)``.
+        :return: A named tuple containing
+            ``(uri, tags, duration, seekable, mime)``.
             ``tags`` is a dictionary of lists for all the tags we found.
             ``duration`` is the length of the URI in milliseconds, or
-            :class:`None` if the URI has no duration. ``seekable`` is boolean
+            :class:`None` if the URI has no duration. ``seekable`` is boolean.
             indicating if a seek would succeed.
         """
-        tags, duration, seekable = None, None, None
+        tags, duration, seekable, mime = None, None, None, None
         try:
             self._setup(uri)
-            tags = self._collect()
+            tags, mime = self._collect()
             duration = self._query_duration()
             seekable = self._query_seekable()
         finally:
             self._reset()
 
-        return Result(uri, tags, duration, seekable)
+        return Result(uri, tags, duration, seekable, mime)
 
     def _setup(self, uri):
         """Primes the pipeline for collection."""
         protocol = gst.uri_get_protocol(uri)
         if self._src and protocol not in self._src.get_protocols():
-            self._src.unlink(self._decodebin)
+            self._src.unlink(self._typefinder)
             self._pipe.remove(self._src)
             self._src = None
 
@@ -83,8 +94,7 @@ class Scanner(object):
             self._src = gst.element_make_from_uri(gst.URI_SRC, uri)
             utils.setup_proxy(self._src, self._proxy_config)
             self._pipe.add(self._src)
-            self._src.sync_state_with_parent()
-            self._src.link(self._decodebin)
+            self._src.link(self._typefinder)
 
         self._pipe.set_state(gst.STATE_READY)
         self._src.set_uri(uri)
@@ -98,7 +108,7 @@ class Scanner(object):
         """Polls for messages to collect data."""
         start = time.time()
         timeout_s = self._timeout_ms / 1000.0
-        tags = {}
+        tags, mime = {}, None
 
         while time.time() - start < timeout_s:
             if not self._bus.have_pending():
@@ -109,14 +119,18 @@ class Scanner(object):
                 if gst.pbutils.is_missing_plugin_message(message):
                     description = _missing_plugin_desc(message)
                     raise exceptions.ScannerError(description)
+            elif message.type == gst.MESSAGE_APPLICATION:
+                mime = message.structure.get_name()
+                if mime.startswith('text/') or mime == 'application/xml':
+                    return tags, mime
             elif message.type == gst.MESSAGE_ERROR:
                 raise exceptions.ScannerError(
                     encoding.locale_decode(message.parse_error()[0]))
             elif message.type == gst.MESSAGE_EOS:
-                return tags
+                return tags, mime
             elif message.type == gst.MESSAGE_ASYNC_DONE:
                 if message.src == self._pipe:
-                    return tags
+                    return tags, mime
             elif message.type == gst.MESSAGE_TAG:
                 taglist = message.parse_tag()
                 # Note that this will only keep the last tag.

--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -133,7 +133,8 @@ class ScanCommand(commands.Command):
             try:
                 relpath = translator.local_track_uri_to_path(uri, media_dir)
                 file_uri = path.path_to_uri(os.path.join(media_dir, relpath))
-                tags, duration = scanner.scan(file_uri)
+                result = scanner.scan(file_uri)
+                tags, duration = result.tags, result.duration
                 if duration < MIN_DURATION_MS:
                     logger.warning('Failed %s: Track shorter than %dms',
                                    uri, MIN_DURATION_MS)

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -45,9 +45,9 @@ class StreamLibraryProvider(backend.LibraryProvider):
             return [Track(uri=uri)]
 
         try:
-            tags, duration = self._scanner.scan(uri)
-            track = utils.convert_tags_to_track(tags).copy(
-                uri=uri, length=duration)
+            result = self._scanner.scan(uri)
+            track = utils.convert_tags_to_track(result.tags).copy(
+                uri=uri, length=result.duration)
         except exceptions.ScannerError as e:
             logger.warning('Problem looking up %s: %s', uri, e)
             track = Track(uri=uri)

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -31,9 +31,9 @@ class ScannerTest(unittest.TestCase):
             uri = path_lib.path_to_uri(path)
             key = uri[len('file://'):]
             try:
-                tags, duration = scanner.scan(uri)
-                self.tags[key] = tags
-                self.durations[key] = duration
+                result = scanner.scan(uri)
+                self.tags[key] = result.tags
+                self.durations[key] = result.duration
             except exceptions.ScannerError as error:
                 self.errors[key] = error
 


### PR DESCRIPTION
With this in place we can scan a playlist without our playlist elements installed, check if it's `text/*` or `application/xml` try and `urlopen` it and parse it as a playlist (that is until we switch to totemplparser) without any gstreamer element magic.

This also improves:

- Missing plugin messages on errors.
- Seekable lookup which I want to try and use.
- Got rid of some code that wasn't really doing much for us.

Changelog entry will be forthcoming tomorrow :-)