### PR TITLE
local: Fix get_images() for local libraries returning single track from lookup().

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -108,7 +108,7 @@ v0.20.0 (UNRELEASED)
   (Fixes: :issue:`967`)
 
 - Add :meth:`mopidy.local.Library.get_images` for looking up images
-  for local URIs. (Fixes: :issue:`1031`, PR: :issue:`1032`)
+  for local URIs. (Fixes: :issue:`1031`, PR: :issue:`1032` and :issue:`1037`)
 
 **MPD frontend**
 

--- a/mopidy/local/__init__.py
+++ b/mopidy/local/__init__.py
@@ -116,7 +116,11 @@ class Library(object):
         result = {}
         for uri in uris:
             image_uris = set()
-            for track in self.lookup(uri):
+            tracks = self.lookup(uri)
+            # local libraries may return single track
+            if isinstance(tracks, models.Track):
+                tracks = [tracks]
+            for track in tracks:
                 if track.album and track.album.images:
                     image_uris.update(track.album.images)
             result[uri] = [models.Image(uri=u) for u in image_uris]

--- a/tests/local/test_library.py
+++ b/tests/local/test_library.py
@@ -597,6 +597,18 @@ class LocalLibraryProviderTest(unittest.TestCase):
         result = library.get_images([track.uri])
         self.assertEqual(result, {track.uri: [image]})
 
+    @mock.patch.object(json.JsonLibrary, 'lookup')
+    def test_default_get_images_impl_single_track(self, mock_lookup):
+        library = actor.LocalBackend(config=self.config, audio=None).library
+
+        image = Image(uri='imageuri')
+        album = Album(images=[image.uri])
+        track = Track(uri='trackuri', album=album)
+        mock_lookup.return_value = track
+
+        result = library.get_images([track.uri])
+        self.assertEqual(result, {track.uri: [image]})
+
     @mock.patch.object(json.JsonLibrary, 'get_images')
     def test_local_library_get_images(self, mock_get_images):
         library = actor.LocalBackend(config=self.config, audio=None).library


### PR DESCRIPTION
Fix for PR #1032: Ignored the fact that local libraries could still return a single track from `lookup()` for backward-compatibility; results in 
```
  File "/home/tkemmer/src/mopidy/mopidy/local/library.py", line 34, in get_images
    return self._library.get_images(uris)
  File "/home/tkemmer/src/mopidy/mopidy/local/__init__.py", line 119, in get_images
    for track in self.lookup(uri):
TypeError: 'Track' object is not iterable
```