### PR TITLE
core: Only emit stream title changed for streams

### DIFF
--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -121,12 +121,16 @@ class Core(
             return
 
         tags = self.audio.get_current_tags().get()
-        if not tags or 'title' not in tags or not tags['title']:
+        if not tags:
             return
 
-        title = tags['title'][0]
-        self.playback._stream_title = title
-        CoreListener.send('stream_title_changed', title=title)
+        # TODO: this limits us to only streams that set organization, this is
+        # a hack to make sure we don't emit stream title changes for plain
+        # tracks. We need a better way to decide if something is a stream.
+        if 'title' in tags and tags['title'] and 'organization' in tags:
+            title = tags['title'][0]
+            self.playback._stream_title = title
+            CoreListener.send('stream_title_changed', title=title)
 
 
 class Backends(list):

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -582,6 +582,7 @@ class TestStream(unittest.TestCase):
 
     def test_get_stream_title_during_playback_with_tags_change(self):
         self.core.playback.play()
+        self.audio.trigger_fake_tags_changed({'organization': ['baz']})
         self.audio.trigger_fake_tags_changed({'title': ['foobar']}).get()
 
         self.replay_audio_events()
@@ -589,6 +590,7 @@ class TestStream(unittest.TestCase):
 
     def test_get_stream_title_after_next(self):
         self.core.playback.play()
+        self.audio.trigger_fake_tags_changed({'organization': ['baz']})
         self.audio.trigger_fake_tags_changed({'title': ['foobar']}).get()
         self.core.playback.next()
 
@@ -597,8 +599,10 @@ class TestStream(unittest.TestCase):
 
     def test_get_stream_title_after_next_with_tags_change(self):
         self.core.playback.play()
+        self.audio.trigger_fake_tags_changed({'organization': ['baz']})
         self.audio.trigger_fake_tags_changed({'title': ['foo']}).get()
         self.core.playback.next()
+        self.audio.trigger_fake_tags_changed({'organization': ['baz']})
         self.audio.trigger_fake_tags_changed({'title': ['bar']}).get()
 
         self.replay_audio_events()
@@ -606,6 +610,7 @@ class TestStream(unittest.TestCase):
 
     def test_get_stream_title_after_stop(self):
         self.core.playback.play()
+        self.audio.trigger_fake_tags_changed({'organization': ['baz']})
         self.audio.trigger_fake_tags_changed({'title': ['foobar']}).get()
         self.core.playback.stop()
 

--- a/tests/dummy_audio.py
+++ b/tests/dummy_audio.py
@@ -110,7 +110,7 @@ class DummyAudio(pykka.ThreadingActor):
         self._state_change_result = False
 
     def trigger_fake_tags_changed(self, tags):
-        self._tags = tags
+        self._tags.update(tags)
         audio.AudioListener.send('tags_changed', tags=self._tags.keys())
 
     def get_about_to_finish_callback(self):


### PR DESCRIPTION
This is done by checking for the presence of the organization tag typically set
by web streams. This might be a bit to strict and a bad heuristic, but it's
currently better than wrongly emitting stream titles for non streams IMO.