### PR TITLE
Decode all strerror-based exception messages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -144,6 +144,10 @@ v0.20.0 (UNRELEASED)
 - Start setting the ``Name`` field with the stream title when listening to
   radio streams. (Fixes: :issue:`944`, PR: :issue:`1030`)
 
+- Fix crash on socket error when using a locale causing the exception's error
+  message to contain characters not in ASCII. (Fixes: issue:`971`, PR:
+  :issue:`1044`)
+
 **HTTP frontend**
 
 - **Deprecated:** Deprecated the :confval:`http/static_dir` config. Please make

--- a/mopidy/utils/network.py
+++ b/mopidy/utils/network.py
@@ -199,7 +199,8 @@ class Connection(object):
         except socket.error as e:
             if e.errno in (errno.EWOULDBLOCK, errno.EINTR):
                 return data
-            self.stop('Unexpected client error: %s' % e)
+            self.stop(
+                'Unexpected client error: %s' % encoding.locale_decode(e))
             return b''
 
     def enable_timeout(self):

--- a/mopidy/utils/path.py
+++ b/mopidy/utils/path.py
@@ -12,6 +12,7 @@ import glib
 
 from mopidy import compat, exceptions
 from mopidy.compat import queue
+from mopidy.utils import encoding
 
 
 logger = logging.getLogger(__name__)
@@ -157,7 +158,8 @@ def _find_worker(relative, follow, done, work, results, errors):
                 errors[path] = exceptions.FindError('Not a file or directory.')
 
         except OSError as e:
-            errors[path] = exceptions.FindError(e.strerror, e.errno)
+            errors[path] = exceptions.FindError(
+                encoding.locale_decode(e.strerror), e.errno)
         finally:
             work.task_done()
 


### PR DESCRIPTION
I reviewed all instances of:

- EnvironmentError
- OSError
- IOError
- socket.error

In most cases, we already used encoding.locale_decode().

The case fixed in mopidy/utils/network.py fixes #971.

The case fixed in mopidy/utils/path.py might be triggered during a
local library scan.

<!---
@huboard:{"order":566.1875,"milestone_order":1044,"custom_state":""}
-->
