### PR TITLE
backend: Remove default impl of PlaylistProvider.playlists

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,12 @@ v0.20.0 (UNRELEASED)
   :meth:`mopidy.core.PlaybackController.get_stream_title` for letting clients
   know about the current song in streams. (PR: :issue:`938`, :issue:`1030`)
 
+**Backend API**
+
+- Remove default implementation of
+  :attr:`mopidy.backend.PlaylistsProvider.playlists`. This is potentially
+  backwards incompatible. (PR: :issue:`1046`)
+
 **Commands**
 
 - Make the ``mopidy`` command print a friendly error message if the

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import copy
-
 from mopidy import listener, models
 
 
@@ -263,7 +261,6 @@ class PlaylistsProvider(object):
 
     def __init__(self, backend):
         self.backend = backend
-        self._playlists = []
 
     # TODO Replace playlists property with a get_playlists() method which
     # returns playlist Ref's instead of the gigantic data structures we
@@ -277,11 +274,11 @@ class PlaylistsProvider(object):
 
         Read/write. List of :class:`mopidy.models.Playlist`.
         """
-        return copy.copy(self._playlists)
+        return []
 
     @playlists.setter  # noqa
     def playlists(self, playlists):
-        self._playlists = playlists
+        raise NotImplementedError
 
     def create(self, name):
         """

--- a/mopidy/local/playlists.py
+++ b/mopidy/local/playlists.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, division, unicode_literals
 
+import copy
 import glob
 import logging
 import operator
@@ -20,7 +21,16 @@ class LocalPlaylistsProvider(backend.PlaylistsProvider):
         super(LocalPlaylistsProvider, self).__init__(*args, **kwargs)
         self._media_dir = self.backend.config['local']['media_dir']
         self._playlists_dir = self.backend.config['local']['playlists_dir']
+        self._playlists = []
         self.refresh()
+
+    @property
+    def playlists(self):
+        return copy.copy(self._playlists)
+
+    @playlists.setter
+    def playlists(self, playlists):
+        self._playlists = playlists
 
     def create(self, name):
         playlist = self._save_m3u(Playlist(name=name))

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
-from mopidy import models
+from mopidy import backend, models
 
 from tests import dummy_backend
 
@@ -28,3 +28,13 @@ class LibraryTest(unittest.TestCase):
 
         expected = {'trackuri': []}
         self.assertEqual(library.get_images(['trackuri']), expected)
+
+
+class PlaylistsTest(unittest.TestCase):
+    def test_playlists_default_impl(self):
+        playlists = backend.PlaylistsProvider(backend=None)
+
+        self.assertEqual(playlists.playlists, [])
+
+        with self.assertRaises(NotImplementedError):
+            playlists.playlists = []

--- a/tests/dummy_backend.py
+++ b/tests/dummy_backend.py
@@ -6,6 +6,8 @@ used in tests of the frontends.
 
 from __future__ import absolute_import, unicode_literals
 
+import copy
+
 import pykka
 
 from mopidy import backend
@@ -85,6 +87,18 @@ class DummyPlaybackProvider(backend.PlaybackProvider):
 
 
 class DummyPlaylistsProvider(backend.PlaylistsProvider):
+    def __init__(self, backend):
+        super(DummyPlaylistsProvider, self).__init__(backend)
+        self._playlists = []
+
+    @property
+    def playlists(self):
+        return copy.copy(self._playlists)
+
+    @playlists.setter
+    def playlists(self, playlists):
+        self._playlists = playlists
+
     def create(self, name):
         playlist = Playlist(name=name, uri='dummy:%s' % name)
         self._playlists.append(playlist)


### PR DESCRIPTION
The default was insane. For one, because overriding e.g. just the
getter would make the property have a pair of working getter and
setter that are entirely disconnected.