### PR TITLE
Add backend.playlists.get_playlists()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -58,6 +58,12 @@ v0.20.0 (UNRELEASED)
   :attr:`mopidy.backend.PlaylistsProvider.playlists`. This is potentially
   backwards incompatible. (PR: :issue:`1046`)
 
+- Add :meth:`mopidy.backend.PlaylistProvider.get_playlists()`. (PR:
+  :issue:`1048`)
+
+- **Deprecated:** :attr:`mopidy.backend.PlaylistsProvider.playlists`. (PR:
+  :issue:`1048`)
+
 **Commands**
 
 - Make the ``mopidy`` command print a friendly error message if the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -52,6 +52,14 @@ v0.20.0 (UNRELEASED)
   :meth:`mopidy.core.PlaybackController.get_stream_title` for letting clients
   know about the current song in streams. (PR: :issue:`938`, :issue:`1030`)
 
+- Add ``ref`` keyword argument to
+  :meth:`mopidy.core.PlaylistsController.get_playlists`. (PR: :issue:`1048`)
+
+- **Deprecated:** The ``include_tracks`` keyword argument to
+  :meth:`mopidy.core.PlaylistsController.get_playlists`. Use the ``ref``
+  keyword argument instead as soon as backends start support it. (PR:
+  :issue:`1048`)
+
 **Backend API**
 
 - Remove default implementation of

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -267,15 +267,29 @@ class PlaylistsProvider(object):
     # currently make available. lookup() should be used for getting full
     # playlists with all details.
 
-    def get_playlists(self):
+    def get_playlists(self, ref=True):
         """
         Get available playlists.
 
-        :rtype: list of :class:`mopidy.models.Playlist`
+        If ``ref`` is :class:`False`, a list of :class:`mopidy.models.Playlist`
+        is returned.
+
+        If ``ref`` is :class:`True`, a list of :class:`mopidy.models.Ref`
+        referencing the playlists is returned.
+
+        Implementors should use :class:`True` as the default value for the
+        ``ref`` keyword argument.
 
         .. versionadded:: 0.20
+
+        .. deprecated:: 0.20
+            The ``ref`` keyword argument will be removed in the future together
+            with the behavior associated with ``ref`` being :class:`False`.
         """
-        return self.playlists
+        if ref:
+            return []
+        else:
+            return self.playlists
 
     @property
     def playlists(self):

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -267,12 +267,28 @@ class PlaylistsProvider(object):
     # currently make available. lookup() should be used for getting full
     # playlists with all details.
 
+    def get_playlists(self):
+        """
+        Get available playlists.
+
+        :rtype: list of :class:`mopidy.models.Playlist`
+
+        .. versionadded:: 0.20
+        """
+        return self.playlists
+
     @property
     def playlists(self):
         """
         Currently available playlists.
 
         Read/write. List of :class:`mopidy.models.Playlist`.
+
+        .. deprecated:: 0.20
+            If your backend requires Mopidy >= 0.20, implement
+            :meth:`get_playlists` instead of this property. If you must stay
+            compatible with Mopidy < 0.20, you're free to implement
+            :meth:`get_playlists` in addition to this property.
         """
         return []
 

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -22,7 +22,7 @@ class PlaylistsController(object):
     Returns a list of :class:`mopidy.models.Playlist`.
     """
     def get_playlists(self, include_tracks=True):
-        futures = [b.playlists.get_playlists()
+        futures = [b.playlists.get_playlists(ref=False)
                    for b in self.backends.with_playlists.values()]
         results = pykka.get_all(futures)
         playlists = list(itertools.chain(*results))

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -22,7 +22,7 @@ class PlaylistsController(object):
     Returns a list of :class:`mopidy.models.Playlist`.
     """
     def get_playlists(self, include_tracks=True):
-        futures = [b.playlists.playlists
+        futures = [b.playlists.get_playlists()
                    for b in self.backends.with_playlists.values()]
         results = pykka.get_all(futures)
         playlists = list(itertools.chain(*results))

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -19,14 +19,28 @@ class PlaylistsController(object):
     """
     Get the available playlists.
 
+    If ``include_tracks`` is :class:`False` the tracks will be removed from the
+    playlists to save bandwidth.
+
+    If ``ref`` is :class:`True`, a list of :class:`mopidy.models.Ref` is
+    returned instead of playlists. This will be the default behavior in the
+    future. Note that not all backends supports returning
+    :class:`~mopidy.models.Ref` objects yet.
+
     Returns a list of :class:`mopidy.models.Playlist`.
+
+    .. versionadded:: 0.20
+        Added the ``ref`` keyword argument.
+
+    .. deprecated:: 0.20
+        The ``include_tracks`` keyword argument. Use ``ref`` instead.
     """
-    def get_playlists(self, include_tracks=True):
-        futures = [b.playlists.get_playlists(ref=False)
+    def get_playlists(self, include_tracks=True, ref=False):
+        futures = [b.playlists.get_playlists(ref=ref)
                    for b in self.backends.with_playlists.values()]
         results = pykka.get_all(futures)
         playlists = list(itertools.chain(*results))
-        if not include_tracks:
+        if not ref and not include_tracks:
             playlists = [p.copy(tracks=[]) for p in playlists]
         return playlists
 

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -41,7 +41,7 @@ class PlaylistsTest(unittest.TestCase):
         with self.assertRaises(NotImplementedError):
             provider.playlists = []
 
-    def test_get_playlists_impl_falls_back_to_playlists_property(self):
+    def test_get_playlists_nonref_impl_falls_back_to_playlists_property(self):
         provider = backend.PlaylistsProvider(backend=None)
 
         with mock.patch(
@@ -49,6 +49,11 @@ class PlaylistsTest(unittest.TestCase):
                 new_callable=mock.PropertyMock) as mock_playlists_prop:
             mock_playlists_prop.return_value = mock.sentinel.playlists_prop
 
-            result = provider.get_playlists()
+            result = provider.get_playlists(ref=False)
 
         self.assertEqual(result, mock.sentinel.playlists_prop)
+
+    def test_get_playlists_ref_default_impl(self):
+        provider = backend.PlaylistsProvider(backend=None)
+
+        self.assertEqual(provider.get_playlists(ref=True), [])

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -2,6 +2,8 @@ from __future__ import absolute_import, unicode_literals
 
 import unittest
 
+import mock
+
 from mopidy import backend, models
 
 from tests import dummy_backend
@@ -32,9 +34,21 @@ class LibraryTest(unittest.TestCase):
 
 class PlaylistsTest(unittest.TestCase):
     def test_playlists_default_impl(self):
-        playlists = backend.PlaylistsProvider(backend=None)
+        provider = backend.PlaylistsProvider(backend=None)
 
-        self.assertEqual(playlists.playlists, [])
+        self.assertEqual(provider.playlists, [])
 
         with self.assertRaises(NotImplementedError):
-            playlists.playlists = []
+            provider.playlists = []
+
+    def test_get_playlists_impl_falls_back_to_playlists_property(self):
+        provider = backend.PlaylistsProvider(backend=None)
+
+        with mock.patch(
+                'mopidy.backend.PlaylistsProvider.playlists',
+                new_callable=mock.PropertyMock) as mock_playlists_prop:
+            mock_playlists_prop.return_value = mock.sentinel.playlists_prop
+
+            result = provider.get_playlists()
+
+        self.assertEqual(result, mock.sentinel.playlists_prop)

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -50,6 +50,17 @@ class PlaylistsTest(unittest.TestCase):
         self.sp1.get_playlists.assert_called_once_with(ref=False)
         self.sp2.get_playlists.assert_called_once_with(ref=False)
 
+    def test_get_playlists_refs(self):
+        result = self.core.playlists.get_playlists(ref=True)
+
+        self.assertIn(self.pl1a, result)
+        self.assertIn(self.pl1b, result)
+        self.assertIn(self.pl2a, result)
+        self.assertIn(self.pl2b, result)
+
+        self.sp1.get_playlists.assert_called_once_with(ref=True)
+        self.sp2.get_playlists.assert_called_once_with(ref=True)
+
     def test_get_playlists_includes_tracks_by_default(self):
         result = self.core.playlists.get_playlists()
 

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -28,22 +28,27 @@ class PlaylistsTest(unittest.TestCase):
 
         self.pl1a = Playlist(name='A', tracks=[Track(uri='dummy1:a')])
         self.pl1b = Playlist(name='B', tracks=[Track(uri='dummy1:b')])
-        self.sp1.playlists.get.return_value = [self.pl1a, self.pl1b]
+        self.sp1.get_playlists.return_value.get.return_value = [
+            self.pl1a, self.pl1b]
 
         self.pl2a = Playlist(name='A', tracks=[Track(uri='dummy2:a')])
         self.pl2b = Playlist(name='B', tracks=[Track(uri='dummy2:b')])
-        self.sp2.playlists.get.return_value = [self.pl2a, self.pl2b]
+        self.sp2.get_playlists.return_value.get.return_value = [
+            self.pl2a, self.pl2b]
 
         self.core = core.Core(mixer=None, backends=[
             self.backend3, self.backend1, self.backend2])
 
     def test_get_playlists_combines_result_from_backends(self):
-        result = self.core.playlists.playlists
+        result = self.core.playlists.get_playlists()
 
         self.assertIn(self.pl1a, result)
         self.assertIn(self.pl1b, result)
         self.assertIn(self.pl2a, result)
         self.assertIn(self.pl2b, result)
+
+        self.sp1.get_playlists.assert_called_once_with()
+        self.sp2.get_playlists.assert_called_once_with()
 
     def test_get_playlists_includes_tracks_by_default(self):
         result = self.core.playlists.get_playlists()
@@ -53,7 +58,7 @@ class PlaylistsTest(unittest.TestCase):
         self.assertEqual(result[1].name, 'B')
         self.assertEqual(len(result[1].tracks), 1)
 
-    def test_get_playlist_can_strip_tracks_from_returned_playlists(self):
+    def test_get_playlists_can_strip_tracks_from_returned_playlists(self):
         result = self.core.playlists.get_playlists(include_tracks=False)
 
         self.assertEqual(result[0].name, 'A')

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -47,8 +47,8 @@ class PlaylistsTest(unittest.TestCase):
         self.assertIn(self.pl2a, result)
         self.assertIn(self.pl2b, result)
 
-        self.sp1.get_playlists.assert_called_once_with()
-        self.sp2.get_playlists.assert_called_once_with()
+        self.sp1.get_playlists.assert_called_once_with(ref=False)
+        self.sp2.get_playlists.assert_called_once_with(ref=False)
 
     def test_get_playlists_includes_tracks_by_default(self):
         result = self.core.playlists.get_playlists()

--- a/tests/utils/test_jsonrpc.py
+++ b/tests/utils/test_jsonrpc.py
@@ -640,7 +640,7 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
 
         self.assertIn('core.playlists.get_playlists', methods)
         self.assertEqual(
-            len(methods['core.playlists.get_playlists']['params']), 1)
+            len(methods['core.playlists.get_playlists']['params']), 2)
 
         self.assertIn('core.tracklist.filter', methods.keys())
         self.assertEqual(


### PR DESCRIPTION
This makes it possible for e.g. Mopidy-Spotify 2 to not implement the `playlists` property which is expensive to generate, and will often be accessed by Pykka looking over the attributes of the backend actor.

Before this PR:

- 2x `playlists` property accesses during Mopidy startup, spending 3491+258 ms.
- 3x `playlists` property accesses during ncmpcpp startup, spending 255+241+231 ms.

After this PR:

- 1x `get_playlists()` calls during Mopidy startup, spending 3504 ms.
- 3x `get_playlists()` calls during ncmpcpp startup, spending 260+239+230 ms.

When enough backends implement the `ref=True` support, frontends like MPD can switch to using refs, and the numbers above should fall to <100 ms.

We haven't decided entirely on the API for getting playlists in the core-cleanup effort, so it might be we just want to merge the `get_playlists()` addition and not the `ref=True` addtion.

<!---
@huboard:{"order":1049.0,"milestone_order":1048,"custom_state":""}
-->
