### PR TITLE
core: Make history.add() private

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,7 +26,8 @@ v1.0.0 (UNRELEASED)
   the Python API with the WebSocket/JavaScript API. (Fixes: :issue:`952`)
 
 - Add :class:`mopidy.core.HistoryController` which keeps track of what tracks
-  have been played. (Fixes: :issue:`423`, PR: :issue:`803`)
+  have been played. (Fixes: :issue:`423`, :issue:`1056`, PR: :issue:`803`,
+  :issue:`1063`)
 
 - Add :class:`mopidy.core.MixerController` which keeps track of volume and
   mute. (Fixes: :issue:`962`)

--- a/mopidy/core/history.py
+++ b/mopidy/core/history.py
@@ -15,8 +15,10 @@ class HistoryController(object):
     def __init__(self):
         self._history = []
 
-    def add(self, track):
+    def _add_track(self, track):
         """Add track to the playback history.
+
+        Internal method for :class:`mopidy.core.PlaybackController`.
 
         :param track: track to add
         :type track: :class:`mopidy.models.Track`

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -312,7 +312,7 @@ class PlaybackController(object):
 
         if success:
             self.core.tracklist._mark_playing(tl_track)
-            self.core.history.add(tl_track.track)
+            self.core.history._add_track(tl_track.track)
             # TODO: replace with stream-changed
             self._trigger_track_playback_started()
         else:

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -18,24 +18,24 @@ class PlaybackHistoryTest(unittest.TestCase):
         self.history = HistoryController()
 
     def test_add_track(self):
-        self.history.add(self.tracks[0])
+        self.history._add_track(self.tracks[0])
         self.assertEqual(self.history.get_length(), 1)
 
-        self.history.add(self.tracks[1])
+        self.history._add_track(self.tracks[1])
         self.assertEqual(self.history.get_length(), 2)
 
-        self.history.add(self.tracks[2])
+        self.history._add_track(self.tracks[2])
         self.assertEqual(self.history.get_length(), 3)
 
     def test_non_tracks_are_rejected(self):
         with self.assertRaises(TypeError):
-            self.history.add(object())
+            self.history._add_track(object())
 
         self.assertEqual(self.history.get_length(), 0)
 
     def test_history_entry_contents(self):
         track = self.tracks[0]
-        self.history.add(track)
+        self.history._add_track(track)
 
         result = self.history.get_history()
         (timestamp, ref) = result[0]


### PR DESCRIPTION
Instead of changing the signature to add(uri, name) I opted for
renaming it to _add_track(track).

Since it's internal we may change it whenever we like to. Since you need
different logic for extracting an interesting name from a track and from
a ref or a stream title, it makes sense to add another method for adding
refs/stream titles to the history when that time comes.

Fixes #1056