### PR TITLE
core: Update playback code to take change track into account.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -69,6 +69,10 @@ v1.0.0 (UNRELEASED)
   - :meth:`mopidy.core.TracklistController.mark_playing`
   - :meth:`mopidy.core.TracklistController.mark_unplayable`
 
+- Updated :meth:`mopidy.core.PlaybackController.play` to take
+  :meth:`mopidy.backend.PlaybackProvider.change_track` into account when
+  determining success. (PR: :issue:`1071`)
+
 **Backend API**
 
 - Remove default implementation of

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -312,8 +312,8 @@ class PlaybackController(object):
 
         if backend:
             backend.playback.prepare_change()
-            backend.playback.change_track(tl_track.track)
-            success = backend.playback.play().get()
+            success = (backend.playback.change_track(tl_track.track).get() and
+                       backend.playback.play().get())
 
         if success:
             self.core.tracklist._mark_playing(tl_track)

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -126,8 +126,8 @@ class CorePlaybackTest(unittest.TestCase):
             self.core.playback.current_tl_track, self.tl_tracks[3])
 
     def test_play_skips_to_next_on_unplayable_track(self):
-        """Checks that we handle change track failing."""
-        self.playback2.change_track().get.return_value = False
+        """Checks that we handle backend.change_track failing."""
+        self.playback2.change_track.return_value.get.return_value = False
 
         self.core.tracklist.clear()
         self.core.tracklist.add(self.tracks[:2])


### PR DESCRIPTION
This change has us checking the return value of change_track when deciding if
the play call was a success or if the track is unplayable. Which ensures that
the following can no longer happen: 1) play stream 2) play stream that fails
change_track 3) stream 1) continues playing. Correct behavior being the next
stream playing instead.

<!---
@huboard:{"order":669.375,"milestone_order":1071,"custom_state":""}
-->
