### PR TITLE
core: Normalize search queries

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -73,6 +73,10 @@ v1.0.0 (UNRELEASED)
   :meth:`mopidy.backend.PlaybackProvider.change_track` into account when
   determining success. (PR: :issue:`1071`)
 
+- Updated :meth:`mopidy.core.LibraryController.search` and
+  :meth:`mopidy.core.LibraryController.find_exact` to normalize and warn about
+  bad queries from clients. (Fixes: :issue:`1067`)
+
 **Backend API**
 
 - Remove default implementation of

--- a/mopidy/local/search.py
+++ b/mopidy/local/search.py
@@ -23,8 +23,6 @@ def find_exact(tracks, query=None, limit=100, offset=0, uris=None):
     _validate_query(query)
 
     for (field, values) in query.items():
-        if not hasattr(values, '__iter__'):
-            values = [values]
         # FIXME this is bound to be slow for large libraries
         for value in values:
             if field == 'track_no':
@@ -134,8 +132,6 @@ def search(tracks, query=None, limit=100, offset=0, uris=None):
     _validate_query(query)
 
     for (field, values) in query.items():
-        if not hasattr(values, '__iter__'):
-            values = [values]
         # FIXME this is bound to be slow for large libraries
         for value in values:
             if field == 'track_no':

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -355,3 +355,13 @@ class CoreLibraryTest(unittest.TestCase):
             query=dict(any=['a']), uris=None)
         self.library2.search.assert_called_once_with(
             query=dict(any=['a']), uris=None)
+
+    def test_search_normalises_bad_queries(self):
+        self.core.library.search({'any': 'foobar'})
+        self.library1.search.assert_called_once_with(
+            query={'any': ['foobar']}, uris=None)
+
+    def test_find_exact_normalises_bad_queries(self):
+        self.core.library.find_exact({'any': 'foobar'})
+        self.library1.find_exact.assert_called_once_with(
+            query={'any': ['foobar']}, uris=None)


### PR DESCRIPTION
This is needed as otherwise each and every backend needs to handle the fact
that some "bad" clients might send {'field': 'value'} instead of
{'field': ['value']} Though the real problem isn't the clients but our
organically grown query API.