### PR TITLE
core: Protect against old clients that implement backend.play

### DIFF
--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -312,8 +312,13 @@ class PlaybackController(object):
 
         if backend:
             backend.playback.prepare_change()
-            success = (backend.playback.change_track(tl_track.track).get() and
-                       backend.playback.play().get())
+            try:
+                success = (
+                    backend.playback.change_track(tl_track.track).get() and
+                    backend.playback.play().get())
+            except TypeError:
+                logger.error('%s needs to be updated to work with this '
+                             'version of Mopidy.', backend)
 
         if success:
             self.core.tracklist._mark_playing(tl_track)

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -650,3 +650,15 @@ class TestStream(unittest.TestCase):
 
         self.replay_audio_events()
         self.assertEqual(self.playback.get_stream_title(), None)
+
+
+class CorePlaybackWithOldBackendTest(unittest.TestCase):
+    def test_type_error_from_old_backend_does_not_crash_core(self):
+        b = mock.Mock()
+        b.uri_schemes.get.return_value = ['dummy1']
+        b.playback = mock.Mock(spec=backend.PlaybackProvider)
+        b.playback.play.side_effect = TypeError
+
+        c = core.Core(mixer=None, backends=[b])
+        c.tracklist.add([Track(uri='dummy1:a', length=40000)])
+        c.playback.play()  # No TypeError == test passed.


### PR DESCRIPTION
We could possibly also try and do this setup time instead? Using inspect to see we can bind the old signature?