### PR TITLE
core/backend: Remove find_exact from backends

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -138,6 +138,11 @@ v1.0.0 (UNRELEASED)
 
   - Remove :attr:`mopidy.backend.PlaylistsProvider.playlists` property.
 
+- Removed ``find_exact`` from :class:`mopidy.backend.LibraryProvider` and
+  added an ``exact`` param to  :meth:`mopidy.backend.LibraryProvider.search`
+  to replace the old code path. Core will continue supporting backends that
+  have not upgraded for now.
+
 **Commands**
 
 - Make the ``mopidy`` command print a friendly error message if the

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -119,15 +119,6 @@ class LibraryProvider(object):
             result[uri] = [models.Image(uri=u) for u in image_uris]
         return result
 
-    # TODO: replace with search(query, exact=True, ...)
-    def find_exact(self, query=None, uris=None):
-        """
-        See :meth:`mopidy.core.LibraryController.find_exact`.
-
-        *MAY be implemented by subclass.*
-        """
-        pass
-
     def lookup(self, uri):
         """
         See :meth:`mopidy.core.LibraryController.lookup`.
@@ -144,11 +135,14 @@ class LibraryProvider(object):
         """
         pass
 
-    def search(self, query=None, uris=None):
+    def search(self, query=None, uris=None, exact=False):
         """
         See :meth:`mopidy.core.LibraryController.search`.
 
         *MAY be implemented by subclass.*
+
+        .. versionadded:: 1.0
+            The ``exact`` param which replaces the old ``find_exact``.
         """
         pass
 


### PR DESCRIPTION
Functionality has been replaced with an `exact` param in the search method.
Backends that still implement find_exact will continue being called via
the old method for now.