### PR TITLE
core: Add exact to search() and deprecate find_exact()

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -103,6 +103,11 @@ v1.0.0 (UNRELEASED)
 - **Deprecated:** :meth:`mopidy.core.PlaylistsController.filter`. Use
   :meth:`~mopidy.core.PlaylistsController.as_list` and filter yourself.
 
+- Add ``exact`` to :meth:`mopidy.core.LibraryController.search`.
+
+- **Deprecated:** :meth:`mopidy.core.LibraryController.find_exact`. Use
+  :meth:`mopidy.core.LibraryController.search` with ``exact`` set.
+
 **Backend API**
 
 - Remove default implementation of


### PR DESCRIPTION
Backends that still implement find_exact will be called without exact as an
argument to search, and we will continue to use find_exact. Please remove
find_exact from such backends and switch to the new search API.