### PR TITLE
core/backend: Stop supporting old search signatures

### DIFF
--- a/mopidy/local/library.py
+++ b/mopidy/local/library.py
@@ -51,12 +51,7 @@ class LocalLibraryProvider(backend.LibraryProvider):
             tracks = [tracks]
         return tracks
 
-    def find_exact(self, query=None, uris=None):
+    def search(self, query=None, uris=None, exact=False):
         if not self._library:
             return None
-        return self._library.search(query=query, uris=uris, exact=True)
-
-    def search(self, query=None, uris=None):
-        if not self._library:
-            return None
-        return self._library.search(query=query, uris=uris, exact=False)
+        return self._library.search(query=query, uris=uris, exact=exact)

--- a/tests/dummy_backend.py
+++ b/tests/dummy_backend.py
@@ -46,16 +46,15 @@ class DummyLibraryProvider(backend.LibraryProvider):
     def get_distinct(self, field, query=None):
         return self.dummy_get_distinct_result.get(field, set())
 
-    def find_exact(self, **query):
-        return self.dummy_find_exact_result
-
     def lookup(self, uri):
         return [t for t in self.dummy_library if uri == t.uri]
 
     def refresh(self, uri=None):
         pass
 
-    def search(self, **query):
+    def search(self, query=None, uris=None, exact=False):
+        if exact:  # TODO: remove uses of dummy_find_exact_result
+            return self.dummy_find_exact_result
         return self.dummy_search_result
 
 


### PR DESCRIPTION
All backends are expected to support the exact argument. A friendly log message
will be printed to prompt users to upgrade backends that fail due to this.