### PR TITLE
m3u: Replace slashes in playlist names with pipes.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -323,6 +323,9 @@ M3U backend
   migrate your local playlists to work with the M3U backend. (Fixes:
   :issue:`1054`, PR: :issue:`1066`)
 
+- In playlist names, replace "/", which are illegal in M3U file names,
+  with "|". (PR: :issue:`1084`)
+
 MPD frontend
 ------------
 

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -4,6 +4,7 @@ import glob
 import logging
 import operator
 import os
+import re
 import sys
 
 from mopidy import backend
@@ -15,6 +16,10 @@ logger = logging.getLogger(__name__)
 
 
 class M3UPlaylistsProvider(backend.PlaylistsProvider):
+
+    # TODO: currently this only handles UNIX file systems
+    _invalid_filename_chars = re.compile(r'[/]')
+
     def __init__(self, *args, **kwargs):
         super(M3UPlaylistsProvider, self).__init__(*args, **kwargs)
 
@@ -89,8 +94,10 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         file_handle.write('#EXTINF:' + str(runtime) + ',' + title + '\n')
 
     def _sanitize_m3u_name(self, name, encoding=sys.getfilesystemencoding()):
+        name = self._invalid_filename_chars.sub('|', name.strip())
+        # make sure we end up with a valid path segment
         name = name.encode(encoding, errors='replace')
-        name = os.path.basename(name)
+        name = os.path.basename(name)  # paranoia?
         name = name.decode(encoding)
         return name
 

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -50,8 +50,8 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.assertTrue(os.path.exists(path))
 
     def test_create_sanitizes_playlist_name(self):
-        playlist = self.core.playlists.create('../../test FOO baR')
-        self.assertEqual('test FOO baR', playlist.name)
+        playlist = self.core.playlists.create('  ../../test FOO baR ')
+        self.assertEqual('..|..|test FOO baR', playlist.name)
         path = playlist_uri_to_path(playlist.uri, self.playlists_dir)
         self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))


### PR DESCRIPTION
Reflecting what MPD does to playlist names; also stripping the name provided by the user, since leading/trailing spaces may easily creep in via the UI.