### PR TITLE
http: Fix threading issue causing duplicate WS messages

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,6 +23,8 @@ Bug fix release.
   where the scanner hangs on non-audio files like video. The scanner will now
   also let us know if we found any decodeable audio. (Fixes: :issue:`726`)
 
+- HTTP: Fix threading bug that would cause duplicate delivery of WS messages.
+
 
 v1.0.0 (2015-03-25)
 ===================


### PR DESCRIPTION
The problem presents itself when a JSON-RPC call triggers some event in core.
When this happens we have a thread outside of Tornado call `write_message`
interleaved with a potentially ongoing write if the JSON-RPC response.

To avoid this we now follow Tornado best practices and add callbacks to the
IOLoop to ensure that there isn't any interleaved access of Tornado state.