### PR TITLE
Fix #1162: Ignore None result and exception from PlaylistsProvider.create()

### DIFF
--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -123,13 +123,21 @@ class PlaylistsController(object):
         :rtype: :class:`mopidy.models.Playlist`
         """
         if uri_scheme in self.backends.with_playlists:
-            backend = self.backends.with_playlists[uri_scheme]
+            backends = [self.backends.with_playlists[uri_scheme]]
         else:
-            # TODO: this fallback looks suspicious
-            backend = list(self.backends.with_playlists.values())[0]
-        playlist = backend.playlists.create(name).get()
-        listener.CoreListener.send('playlist_changed', playlist=playlist)
-        return playlist
+            backends = self.backends.with_playlists.values()
+        for backend in backends:
+            playlist = None
+            try:
+                playlist = backend.playlists.create(name).get()
+            except Exception:
+                logger.exception('%s backend caused an exception.',
+                                 backend.actor_ref.actor_class.__name__)
+            # Workaround for playlist providers that return None from create()
+            if not playlist:
+                continue
+            listener.CoreListener.send('playlist_changed', playlist=playlist)
+            return playlist
 
     def delete(self, uri):
         """

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -99,6 +99,32 @@ class PlaylistTest(BasePlaylistsTest):
         self.sp1.create.assert_called_once_with('foo')
         self.assertFalse(self.sp2.create.called)
 
+    def test_create_without_uri_scheme_ignores_none(self):
+        playlist = Playlist()
+        self.sp1.create().get.return_value = None
+        self.sp1.reset_mock()
+        self.sp2.create().get.return_value = playlist
+        self.sp2.reset_mock()
+
+        result = self.core.playlists.create('foo')
+
+        self.assertEqual(playlist, result)
+        self.sp1.create.assert_called_once_with('foo')
+        self.sp2.create.assert_called_once_with('foo')
+
+    def test_create_without_uri_scheme_ignores_exception(self):
+        playlist = Playlist()
+        self.sp1.create().get.side_effect = Exception
+        self.sp1.reset_mock()
+        self.sp2.create().get.return_value = playlist
+        self.sp2.reset_mock()
+
+        result = self.core.playlists.create('foo')
+
+        self.assertEqual(playlist, result)
+        self.sp1.create.assert_called_once_with('foo')
+        self.sp2.create.assert_called_once_with('foo')
+
     def test_create_with_uri_scheme_selects_the_matching_backend(self):
         playlist = Playlist()
         self.sp2.create().get.return_value = playlist


### PR DESCRIPTION
Workaround for #1162: if `PlaylistsProvider.create()` returns `None` or raises an exception, try the next provider.