### PR TITLE
Make initial bootstrapping handle bad extensions

### DIFF
--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -95,7 +95,7 @@ def main():
             extension = data.extension
 
             # TODO: factor out all of this to a helper that can be tested
-            if not ext.validate_extension(data.extension, data.entry_point):
+            if not ext.validate_extension_data(data):
                 config[extension.ext_name] = {'enabled': False}
                 config_errors[extension.ext_name] = {
                     'enabled': 'extension disabled by self check.'}

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -70,7 +70,7 @@ def main():
 
         for data in extensions_data:
             if data.command:  # TODO: check isinstance?
-                data.command.set(extension=data.command)
+                data.command.set(extension=data.extension)
                 root_cmd.add_child(data.extension.ext_name, data.command)
 
         args = root_cmd.parse(mopidy_args)

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -415,8 +415,8 @@ class ConfigCommand(Command):
         super(ConfigCommand, self).__init__()
         self.set(base_verbosity_level=-1)
 
-    def run(self, config, errors, extensions):
-        print(config_lib.format(config, extensions, errors))
+    def run(self, config, errors, schemas):
+        print(config_lib.format(config, schemas, errors))
         return 0
 
 

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -65,24 +65,20 @@ def read(config_file):
         return filehandle.read()
 
 
-def load(files, extensions, overrides):
-    # Helper to get configs, as the rest of our config system should not need
-    # to know about extensions.
+def load(files, ext_schemas, ext_defaults, overrides):
     config_dir = os.path.dirname(__file__)
     defaults = [read(os.path.join(config_dir, 'default.conf'))]
-    defaults.extend(e.get_default_config() for e in extensions)
+    defaults.extend(ext_defaults)
     raw_config = _load(files, defaults, keyring.fetch() + (overrides or []))
 
     schemas = _schemas[:]
-    schemas.extend(e.get_config_schema() for e in extensions)
+    schemas.extend(ext_schemas)
     return _validate(raw_config, schemas)
 
 
-def format(config, extensions, comments=None, display=True):
-    # Helper to format configs, as the rest of our config system should not
-    # need to know about extensions.
+def format(config, ext_schemas, comments=None, display=True):
     schemas = _schemas[:]
-    schemas.extend(e.get_config_schema() for e in extensions)
+    schemas.extend(ext_schemas)
     return _format(config, comments or {}, schemas, display, False)
 
 

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -165,13 +165,15 @@ def load_extensions():
 
         try:
             extension = extension_class()
+            config_schema = extension.get_config_schema()
+            default_config = extension.get_default_config()
         except Exception:
             continue  # TODO: log this
 
-        # TODO: handle exceptions and validate result...
-        config_schema = extension.get_config_schema()
-        default_config = extension.get_default_config()
-        command = extension.get_command()
+        try:
+            command = extension.get_command()
+        except Exception:
+            command = None  # TODO: log this.
 
         installed_extensions.append(ExtensionData(
             extension, entry_point, config_schema, default_config, command))

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -148,8 +148,21 @@ def load_extensions():
     for entry_point in pkg_resources.iter_entry_points('mopidy.ext'):
         logger.debug('Loading entry point: %s', entry_point)
         extension_class = entry_point.load(require=False)
-        extension = extension_class()
+
+        try:
+            if not issubclass(extension_class, Extension):
+                continue  # TODO: log this
+        except TypeError:
+            continue  # TODO: log that extension_class is not a class
+
+        try:
+            extension = extension_class()
+        except Exception:
+            continue  # TODO: log this
+
         extension.entry_point = entry_point
+
+        # TODO: store: (instance, entry_point, command, schema, defaults)
         installed_extensions.append(extension)
         logger.debug(
             'Loaded extension: %s %s', extension.dist_name, extension.version)

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -184,47 +184,70 @@ def load_extensions():
     return installed_extensions
 
 
-def validate_extension(extension, entry_point):
+def validate_extension_data(data):
     """Verify extension's dependencies and environment.
 
     :param extensions: an extension to check
     :returns: if extension should be run
     """
 
-    logger.debug('Validating extension: %s', extension.ext_name)
+    logger.debug('Validating extension: %s', data.extension.ext_name)
 
-    if extension.ext_name != entry_point.name:
+    if data.extension.ext_name != data.entry_point.name:
         logger.warning(
             'Disabled extension %(ep)s: entry point name (%(ep)s) '
             'does not match extension name (%(ext)s)',
-            {'ep': entry_point.name, 'ext': extension.ext_name})
+            {'ep': data.entry_point.name, 'ext': data.extension.ext_name})
         return False
 
     try:
-        entry_point.require()
+        data.entry_point.require()
     except pkg_resources.DistributionNotFound as ex:
         logger.info(
             'Disabled extension %s: Dependency %s not found',
-            extension.ext_name, ex)
+            data.extension.ext_name, ex)
         return False
     except pkg_resources.VersionConflict as ex:
         if len(ex.args) == 2:
             found, required = ex.args
             logger.info(
                 'Disabled extension %s: %s required, but found %s at %s',
-                extension.ext_name, required, found, found.location)
+                data.extension.ext_name, required, found, found.location)
         else:
             logger.info(
-                'Disabled extension %s: %s', extension.ext_name, ex)
+                'Disabled extension %s: %s', data.extension.ext_name, ex)
         return False
 
     try:
-        extension.validate_environment()
+        data.extension.validate_environment()
     except exceptions.ExtensionError as ex:
         logger.info(
-            'Disabled extension %s: %s', extension.ext_name, ex.message)
+            'Disabled extension %s: %s', data.extension.ext_name, ex.message)
         return False
     except Exception:
-        return False  # TODO: log
+        logger.exception('Validating extension %s failed with an exception.',
+                         data.extension.ext_name)
+        return False
+
+    if not data.config_schema:
+        logger.error('Extension %s does not have a config schema, disabling.',
+                     data.extension.ext_name)
+        return False
+    elif not isinstance(data.config_schema.get('enabled'), config_lib.Boolean):
+        logger.error('Extension %s does not have the required "enabled" config'
+                     ' option, disabling.', data.extension.ext_name)
+        return False
+
+    for key, value in data.config_schema.items():
+        if not isinstance(value, config_lib.ConfigValue):
+            logger.error('Extension %s config schema contains an invalid value'
+                         ' for the option "%s", disabling.',
+                         data.extension.ext_name, key)
+            return False
+
+    if not data.config_defaults:
+        logger.error('Extension %s does not have a default config, disabling.',
+                     data.extension.ext_name)
+        return False
 
     return True

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -211,5 +211,7 @@ def validate_extension(extension):
         logger.info(
             'Disabled extension %s: %s', extension.ext_name, ex.message)
         return False
+    except Exception:
+        return False  # TODO: log
 
     return True

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -23,222 +23,201 @@ class TestExtension(ext.Extension):
 any_testextension = IsA(TestExtension)
 
 
-# ext.Extension
+class ExtensionTest(object):
 
-@pytest.fixture
-def extension():
-    return ext.Extension()
+    @pytest.fixture
+    def extension(self):
+        return ext.Extension()
 
+    def test_dist_name_is_none(self, extension):
+        assert extension.dist_name is None
 
-def test_dist_name_is_none(extension):
-    assert extension.dist_name is None
+    def test_ext_name_is_none(self, extension):
+        assert extension.ext_name is None
 
+    def test_version_is_none(self, extension):
+        assert extension.version is None
 
-def test_ext_name_is_none(extension):
-    assert extension.ext_name is None
+    def test_get_default_config_raises_not_implemented(self, extension):
+        with pytest.raises(NotImplementedError):
+            extension.get_default_config()
 
+    def test_get_config_schema_returns_extension_schema(self, extension):
+        schema = extension.get_config_schema()
+        assert isinstance(schema['enabled'], config.Boolean)
 
-def test_version_is_none(extension):
-    assert extension.version is None
+    def test_validate_environment_does_nothing_by_default(self, extension):
+        assert extension.validate_environment() is None
 
+    def test_setup_raises_not_implemented(self, extension):
+        with pytest.raises(NotImplementedError):
+            extension.setup(None)
 
-def test_get_default_config_raises_not_implemented(extension):
-    with pytest.raises(NotImplementedError):
-        extension.get_default_config()
 
+class LoadExtensionsTest(object):
 
-def test_get_config_schema_returns_extension_schema(extension):
-    schema = extension.get_config_schema()
-    assert isinstance(schema['enabled'], config.Boolean)
+    @pytest.yield_fixture
+    def iter_entry_points_mock(self, request):
+        patcher = mock.patch('pkg_resources.iter_entry_points')
+        iter_entry_points = patcher.start()
+        iter_entry_points.return_value = []
+        yield iter_entry_points
+        patcher.stop()
 
+    def test_no_extensions(self, iter_entry_points_mock):
+        iter_entry_points_mock.return_value = []
+        assert ext.load_extensions() == []
 
-def test_validate_environment_does_nothing_by_default(extension):
-    assert extension.validate_environment() is None
+    def test_load_extensions(self, iter_entry_points_mock):
+        mock_entry_point = mock.Mock()
+        mock_entry_point.load.return_value = TestExtension
 
+        iter_entry_points_mock.return_value = [mock_entry_point]
 
-def test_setup_raises_not_implemented(extension):
-    with pytest.raises(NotImplementedError):
-        extension.setup(None)
+        expected = ext.ExtensionData(
+            any_testextension, mock_entry_point, IsA(config.ConfigSchema),
+            any_unicode, None)
 
+        assert ext.load_extensions() == [expected]
 
-# ext.load_extensions
+    def test_gets_wrong_class(self, iter_entry_points_mock):
 
-@pytest.fixture
-def iter_entry_points_mock(request):
-    patcher = mock.patch('pkg_resources.iter_entry_points')
-    iter_entry_points = patcher.start()
-    iter_entry_points.return_value = []
-    request.addfinalizer(patcher.stop)
-    return iter_entry_points
+        class WrongClass(object):
+            pass
 
+        mock_entry_point = mock.Mock()
+        mock_entry_point.load.return_value = WrongClass
 
-def test_load_extensions_no_extenions(iter_entry_points_mock):
-    iter_entry_points_mock.return_value = []
-    assert [] == ext.load_extensions()
+        iter_entry_points_mock.return_value = [mock_entry_point]
 
+        assert ext.load_extensions() == []
 
-def test_load_extensions(iter_entry_points_mock):
-    mock_entry_point = mock.Mock()
-    mock_entry_point.load.return_value = TestExtension
+    def test_gets_instance(self, iter_entry_points_mock):
+        mock_entry_point = mock.Mock()
+        mock_entry_point.load.return_value = TestExtension()
 
-    iter_entry_points_mock.return_value = [mock_entry_point]
+        iter_entry_points_mock.return_value = [mock_entry_point]
 
-    expected = ext.ExtensionData(
-        any_testextension, mock_entry_point, IsA(config.ConfigSchema),
-        any_unicode, None)
+        assert ext.load_extensions() == []
 
-    assert ext.load_extensions() == [expected]
+    def test_creating_instance_fails(self, iter_entry_points_mock):
+        mock_extension = mock.Mock(spec=ext.Extension)
+        mock_extension.side_effect = Exception
 
+        mock_entry_point = mock.Mock()
+        mock_entry_point.load.return_value = mock_extension
 
-def test_load_extensions_gets_wrong_class(iter_entry_points_mock):
+        iter_entry_points_mock.return_value = [mock_entry_point]
 
-    class WrongClass(object):
-        pass
+        assert ext.load_extensions() == []
 
-    mock_entry_point = mock.Mock()
-    mock_entry_point.load.return_value = WrongClass
+    def test_get_config_schema_fails(self, iter_entry_points_mock):
+        mock_entry_point = mock.Mock()
+        mock_entry_point.load.return_value = TestExtension
 
-    iter_entry_points_mock.return_value = [mock_entry_point]
+        iter_entry_points_mock.return_value = [mock_entry_point]
 
-    assert [] == ext.load_extensions()
+        with mock.patch.object(TestExtension, 'get_config_schema') as get:
+            get.side_effect = Exception
 
+            assert ext.load_extensions() == []
+            get.assert_called_once_with()
 
-def test_load_extensions_gets_instance(iter_entry_points_mock):
-    mock_entry_point = mock.Mock()
-    mock_entry_point.load.return_value = TestExtension()
+    def test_get_default_config_fails(self, iter_entry_points_mock):
+        mock_entry_point = mock.Mock()
+        mock_entry_point.load.return_value = TestExtension
 
-    iter_entry_points_mock.return_value = [mock_entry_point]
+        iter_entry_points_mock.return_value = [mock_entry_point]
 
-    assert [] == ext.load_extensions()
+        with mock.patch.object(TestExtension, 'get_default_config') as get:
+            get.side_effect = Exception
 
+            assert ext.load_extensions() == []
+            get.assert_called_once_with()
 
-def test_load_extensions_creating_instance_fails(iter_entry_points_mock):
-    mock_extension = mock.Mock(spec=ext.Extension)
-    mock_extension.side_effect = Exception
+    def test_get_command_fails(self, iter_entry_points_mock):
+        mock_entry_point = mock.Mock()
+        mock_entry_point.load.return_value = TestExtension
 
-    mock_entry_point = mock.Mock()
-    mock_entry_point.load.return_value = mock_extension
+        iter_entry_points_mock.return_value = [mock_entry_point]
 
-    iter_entry_points_mock.return_value = [mock_entry_point]
+        with mock.patch.object(TestExtension, 'get_command') as get:
+            get.side_effect = Exception
 
-    assert [] == ext.load_extensions()
+            assert ext.load_extensions() == []
+            get.assert_called_once_with()
 
 
-def test_load_extensions_get_config_schema_fails(iter_entry_points_mock):
-    mock_entry_point = mock.Mock()
-    mock_entry_point.load.return_value = TestExtension
+class ValidateExtensionDataTest(object):
 
-    iter_entry_points_mock.return_value = [mock_entry_point]
+    @pytest.fixture
+    def ext_data(self):
+        extension = TestExtension()
 
-    with mock.patch.object(TestExtension, 'get_config_schema') as get_schema:
-        get_schema.side_effect = Exception
-        assert [] == ext.load_extensions()
-        get_schema.assert_called_once_with()
+        entry_point = mock.Mock()
+        entry_point.name = extension.ext_name
 
+        schema = extension.get_config_schema()
+        defaults = extension.get_default_config()
+        command = extension.get_command()
 
-def test_load_extensions_get_default_config_fails(iter_entry_points_mock):
-    mock_entry_point = mock.Mock()
-    mock_entry_point.load.return_value = TestExtension
+        return ext.ExtensionData(
+            extension, entry_point, schema, defaults, command)
 
-    iter_entry_points_mock.return_value = [mock_entry_point]
-
-    with mock.patch.object(TestExtension, 'get_default_config') as get_default:
-        get_default.side_effect = Exception
-        assert [] == ext.load_extensions()
-        get_default.assert_called_once_with()
-
-
-def test_load_extensions_get_command_fails(iter_entry_points_mock):
-    mock_entry_point = mock.Mock()
-    mock_entry_point.load.return_value = TestExtension
-
-    iter_entry_points_mock.return_value = [mock_entry_point]
-
-    with mock.patch.object(TestExtension, 'get_command') as get_command:
-        get_command.side_effect = Exception
-        assert [] == ext.load_extensions()
-        get_command.assert_called_once_with()
-
-
-# ext.validate_extension_data
-
-@pytest.fixture
-def ext_data():
-    extension = TestExtension()
-
-    entry_point = mock.Mock()
-    entry_point.name = extension.ext_name
-
-    schema = extension.get_config_schema()
-    defaults = extension.get_default_config()
-    command = extension.get_command()
-
-    return ext.ExtensionData(extension, entry_point, schema, defaults, command)
-
-
-def test_validate_extension_name_mismatch(ext_data):
-    ext_data.entry_point.name = 'barfoo'
-    assert not ext.validate_extension_data(ext_data)
-
-
-def test_validate_extension_distribution_not_found(ext_data):
-    error = pkg_resources.DistributionNotFound
-    ext_data.entry_point.require.side_effect = error
-    assert not ext.validate_extension_data(ext_data)
-
-
-def test_validate_extension_version_conflict(ext_data):
-    ext_data.entry_point.require.side_effect = pkg_resources.VersionConflict
-    assert not ext.validate_extension_data(ext_data)
-
-
-def test_validate_extension_exception(ext_data):
-    ext_data.entry_point.require.side_effect = Exception
-
-    # We trust that entry points are well behaved, so exception will bubble.
-    with pytest.raises(Exception):
+    def test_name_mismatch(self, ext_data):
+        ext_data.entry_point.name = 'barfoo'
         assert not ext.validate_extension_data(ext_data)
 
-
-def test_validate_extension_instance_validate_env_ext_error(ext_data):
-    extension = ext_data.extension
-    with mock.patch.object(extension, 'validate_environment') as validate:
-        validate.side_effect = exceptions.ExtensionError('error')
-
+    def test_distribution_not_found(self, ext_data):
+        error = pkg_resources.DistributionNotFound
+        ext_data.entry_point.require.side_effect = error
         assert not ext.validate_extension_data(ext_data)
-        validate.assert_called_once_with()
 
-
-def test_validate_extension_instance_validate_env_exception(ext_data):
-    extension = ext_data.extension
-    with mock.patch.object(extension, 'validate_environment') as validate:
-        validate.side_effect = Exception
-
+    def test_version_conflict(self, ext_data):
+        error = pkg_resources.VersionConflict
+        ext_data.entry_point.require.side_effect = error
         assert not ext.validate_extension_data(ext_data)
-        validate.assert_called_once_with()
 
+    def test_entry_point_require_exception(self, ext_data):
+        ext_data.entry_point.require.side_effect = Exception
 
-def test_validate_extension_with_missing_schema(ext_data):
-    ext_data = ext_data._replace(config_schema=None)
-    assert not ext.validate_extension_data(ext_data)
+        # Hope that entry points are well behaved, so exception will bubble.
+        with pytest.raises(Exception):
+            assert not ext.validate_extension_data(ext_data)
 
+    def test_extenions_validate_environment_error(self, ext_data):
+        extension = ext_data.extension
+        with mock.patch.object(extension, 'validate_environment') as validate:
+            validate.side_effect = exceptions.ExtensionError('error')
 
-def test_validate_extension_with_schema_that_is_missing_enabled(ext_data):
-    del ext_data.config_schema['enabled']
-    ext_data.config_schema['baz'] = config.String()
-    assert not ext.validate_extension_data(ext_data)
+            assert not ext.validate_extension_data(ext_data)
+            validate.assert_called_once_with()
 
+    def test_extenions_validate_environment_exception(self, ext_data):
+        extension = ext_data.extension
+        with mock.patch.object(extension, 'validate_environment') as validate:
+            validate.side_effect = Exception
 
-def test_validate_extension_with_schema_with_wrong_types(ext_data):
-    ext_data.config_schema['enabled'] = 123
-    assert not ext.validate_extension_data(ext_data)
+            assert not ext.validate_extension_data(ext_data)
+            validate.assert_called_once_with()
 
+    def test_missing_schema(self, ext_data):
+        ext_data = ext_data._replace(config_schema=None)
+        assert not ext.validate_extension_data(ext_data)
 
-def test_validate_extension_with_schema_with_invalid_type(ext_data):
-    ext_data.config_schema['baz'] = 123
-    assert not ext.validate_extension_data(ext_data)
+    def test_schema_that_is_missing_enabled(self, ext_data):
+        del ext_data.config_schema['enabled']
+        ext_data.config_schema['baz'] = config.String()
+        assert not ext.validate_extension_data(ext_data)
 
+    def test_schema_with_wrong_types(self, ext_data):
+        ext_data.config_schema['enabled'] = 123
+        assert not ext.validate_extension_data(ext_data)
 
-def test_validate_extension_with_no_defaults(ext_data):
-    ext_data = ext_data._replace(config_defaults=None)
-    assert not ext.validate_extension_data(ext_data)
+    def test_schema_with_invalid_type(self, ext_data):
+        ext_data.config_schema['baz'] = 123
+        assert not ext.validate_extension_data(ext_data)
+
+    def test_no_default_config(self, ext_data):
+        ext_data = ext_data._replace(config_defaults=None)
+        assert not ext.validate_extension_data(ext_data)

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,9 +1,13 @@
 from __future__ import absolute_import, unicode_literals
 
+import mock
+
 import pytest
 
 from mopidy import config, ext
 
+
+# ext.Extension
 
 @pytest.fixture
 def extension():
@@ -39,3 +43,76 @@ def test_validate_environment_does_nothing_by_default(extension):
 def test_setup_raises_not_implemented(extension):
     with pytest.raises(NotImplementedError):
         extension.setup(None)
+
+
+# ext.load_extensions
+
+class TestExtension(ext.Extension):
+    dist_name = 'Mopidy-Foobar'
+    ext_name = 'foobar'
+    version = '1.2.3'
+
+
+@mock.patch('pkg_resources.iter_entry_points')
+def test_load_extensions_no_extenions(mock_entry_points):
+    mock_entry_points.return_value = []
+    assert [] == ext.load_extensions()
+
+
+@mock.patch('pkg_resources.iter_entry_points')
+def test_load_extensions(mock_entry_points):
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = TestExtension
+
+    mock_entry_points.return_value = [mock_entry_point]
+
+    extensions = ext.load_extensions()
+    assert len(extensions) == 1
+    assert isinstance(extensions[0], TestExtension)
+
+
+@mock.patch('pkg_resources.iter_entry_points')
+def test_load_extensions_gets_wrong_class(mock_entry_points):
+
+    class WrongClass(object):
+        pass
+
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = WrongClass
+
+    mock_entry_points.return_value = [mock_entry_point]
+
+    assert [] == ext.load_extensions()
+
+
+@mock.patch('pkg_resources.iter_entry_points')
+def test_load_extensions_gets_instance(mock_entry_points):
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = TestExtension()
+
+    mock_entry_points.return_value = [mock_entry_point]
+
+    assert [] == ext.load_extensions()
+
+
+@mock.patch('pkg_resources.iter_entry_points')
+def test_load_extensions_creating_instance_fails(mock_entry_points):
+    mock_extension = mock.Mock(spec=ext.Extension)
+    mock_extension.side_effect = Exception
+
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = mock_extension
+
+    mock_entry_points.return_value = [mock_entry_point]
+    assert [] == ext.load_extensions()
+
+
+@mock.patch('pkg_resources.iter_entry_points')
+def test_load_extensions_store_entry_point(mock_entry_points):
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = TestExtension
+    mock_entry_points.return_value = [mock_entry_point]
+
+    extensions = ext.load_extensions()
+    assert len(extensions) == 1
+    assert extensions[0].entry_point == mock_entry_point

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -124,6 +124,46 @@ def test_load_extensions_creating_instance_fails(iter_entry_points_mock):
     assert [] == ext.load_extensions()
 
 
+def test_load_extensions_get_config_schema_fails(iter_entry_points_mock):
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = TestExtension
+
+    iter_entry_points_mock.return_value = [mock_entry_point]
+
+    with mock.patch.object(TestExtension, 'get_config_schema') as get_schema:
+        get_schema.side_effect = Exception
+        assert [] == ext.load_extensions()
+        get_schema.assert_called_once_with()
+
+
+def test_load_extensions_get_default_config_fails(iter_entry_points_mock):
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = TestExtension
+
+    iter_entry_points_mock.return_value = [mock_entry_point]
+
+    with mock.patch.object(TestExtension, 'get_default_config') as get_default:
+        get_default.side_effect = Exception
+        assert [] == ext.load_extensions()
+        get_default.assert_called_once_with()
+
+
+def test_load_extensions_get_command_fails(iter_entry_points_mock):
+    mock_entry_point = mock.Mock()
+    mock_entry_point.load.return_value = TestExtension
+
+    iter_entry_points_mock.return_value = [mock_entry_point]
+
+    expected = ext.ExtensionData(
+        any_testextension, mock_entry_point, IsA(config.ConfigSchema),
+        any_unicode, None)
+
+    with mock.patch.object(TestExtension, 'get_command') as get_command:
+        get_command.side_effect = Exception
+        assert [expected] == ext.load_extensions()
+        get_command.assert_called_once_with()
+
+
 # ext.validate_extension
 
 @pytest.fixture

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -154,13 +154,9 @@ def test_load_extensions_get_command_fails(iter_entry_points_mock):
 
     iter_entry_points_mock.return_value = [mock_entry_point]
 
-    expected = ext.ExtensionData(
-        any_testextension, mock_entry_point, IsA(config.ConfigSchema),
-        any_unicode, None)
-
     with mock.patch.object(TestExtension, 'get_command') as get_command:
         get_command.side_effect = Exception
-        assert [expected] == ext.load_extensions()
+        assert [] == ext.load_extensions()
         get_command.assert_called_once_with()
 
 

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,35 +1,41 @@
 from __future__ import absolute_import, unicode_literals
 
-import unittest
+import pytest
 
 from mopidy import config, ext
 
 
-class ExtensionTest(unittest.TestCase):
+@pytest.fixture
+def extension():
+    return ext.Extension()
 
-    def setUp(self):  # noqa: N802
-        self.ext = ext.Extension()
 
-    def test_dist_name_is_none(self):
-        self.assertIsNone(self.ext.dist_name)
+def test_dist_name_is_none(extension):
+    assert extension.dist_name is None
 
-    def test_ext_name_is_none(self):
-        self.assertIsNone(self.ext.ext_name)
 
-    def test_version_is_none(self):
-        self.assertIsNone(self.ext.version)
+def test_ext_name_is_none(extension):
+    assert extension.ext_name is None
 
-    def test_get_default_config_raises_not_implemented(self):
-        with self.assertRaises(NotImplementedError):
-            self.ext.get_default_config()
 
-    def test_get_config_schema_returns_extension_schema(self):
-        schema = self.ext.get_config_schema()
-        self.assertIsInstance(schema['enabled'], config.Boolean)
+def test_version_is_none(extension):
+    assert extension.version is None
 
-    def test_validate_environment_does_nothing_by_default(self):
-        self.assertIsNone(self.ext.validate_environment())
 
-    def test_setup_raises_not_implemented(self):
-        with self.assertRaises(NotImplementedError):
-            self.ext.setup(None)
+def test_get_default_config_raises_not_implemented(extension):
+    with pytest.raises(NotImplementedError):
+        extension.get_default_config()
+
+
+def test_get_config_schema_returns_extension_schema(extension):
+    schema = extension.get_config_schema()
+    assert isinstance(schema['enabled'], config.Boolean)
+
+
+def test_validate_environment_does_nothing_by_default(extension):
+    assert extension.validate_environment() is None
+
+
+def test_setup_raises_not_implemented(extension):
+    with pytest.raises(NotImplementedError):
+        extension.setup(None)


### PR DESCRIPTION
Note that I'm actually not doing any error checking on commands, as we need them a bit to early with the current code flow. Also note that the we only check that the default config is truthy, we might want to be more strict about this.

First part of fixing #1148 - following step will be checking config handling, and then finally `setup` and the actually actor startups.