### PR TITLE
mpd: Implemetation for commands related to modifying stored playlists.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -33,6 +33,9 @@ Core API
 
 - Update core to handle backend crashes and bad data. (Fixes: :issue:`1161`)
 
+
+- MPD: Implemented commands for modifying stored playlists (PR: :issue:`1187`)
+
 Models
 ------
 

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -182,7 +182,7 @@ class PlaylistsController(object):
 
         with _backend_error_handling(backend):
             backend.playlists.delete(uri).get()
-            # TODO: emit playlist changed?
+            listener.CoreListener.send('playlist_changed', playlist=None)
 
         # TODO: return value?
 

--- a/mopidy/mpd/__init__.py
+++ b/mopidy/mpd/__init__.py
@@ -25,6 +25,7 @@ class Extension(ext.Extension):
         schema['connection_timeout'] = config.Integer(minimum=1)
         schema['zeroconf'] = config.String(optional=True)
         schema['command_blacklist'] = config.List(optional=True)
+        schema['default_playlist_scheme'] = config.String(optional=False)
         return schema
 
     def validate_environment(self):

--- a/mopidy/mpd/actor.py
+++ b/mopidy/mpd/actor.py
@@ -65,10 +65,10 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
 
     def tracklist_changed(self):
         self.send_idle('playlist')
-    
+
     def playlist_changed(self, playlist):
         self.send_idle('stored_playlist')
-    
+
     def options_changed(self):
         self.send_idle('options')
 

--- a/mopidy/mpd/actor.py
+++ b/mopidy/mpd/actor.py
@@ -65,7 +65,10 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
 
     def tracklist_changed(self):
         self.send_idle('playlist')
-
+    
+    def playlist_changed(self, playlist):
+        self.send_idle('stored_playlist')
+    
     def options_changed(self):
         self.send_idle('options')
 

--- a/mopidy/mpd/exceptions.py
+++ b/mopidy/mpd/exceptions.py
@@ -92,6 +92,27 @@ class MpdNotImplemented(MpdAckError):
         self.message = 'Not implemented'
 
 
+class MpdInvalidTrackForPlaylist(MpdAckError):
+    error_code = 0
+
+    def __init__(self, backend_scheme, track_scheme, *args, **kwargs):
+        super(MpdInvalidTrackForPlaylist, self).__init__(*args, **kwargs)
+        self.message = 'Playlist backend "%s" can\'t store ' \
+            'track scheme "%s"' % (backend_scheme, track_scheme)
+
+
+class MpdFailedToSavePlaylist(MpdAckError):
+    error_code = 0
+
+    def __init__(self, backend_scheme, *args, **kwargs):
+        super(MpdFailedToSavePlaylist, self).__init__(*args, **kwargs)
+        if backend_scheme is None:
+            self.message = 'Failed to save playlist'
+        else:
+            self.message = 'Backend "%s" failed to save playlist' % (
+                backend_scheme, )
+
+
 class MpdDisabled(MpdAckError):
     # NOTE: This is a custom error for Mopidy that does not exist in MPD.
     error_code = 0

--- a/mopidy/mpd/ext.conf
+++ b/mopidy/mpd/ext.conf
@@ -7,3 +7,4 @@ max_connections = 20
 connection_timeout = 60
 zeroconf = Mopidy MPD server on $hostname
 command_blacklist = listall,listallinfo
+default_playlist_scheme = m3u

--- a/mopidy/mpd/protocol/stored_playlists.py
+++ b/mopidy/mpd/protocol/stored_playlists.py
@@ -186,7 +186,8 @@ def _playlistcreate(context, name, tracks):
         # Created and saved
         return
     # Can't use backend aprropriate to passed uri schemes, use default one
-    playlist = context.core.playlists.create(name).get()
+    scheme = context.dispatcher.config['mpd']['default_playlist_scheme']
+    playlist = context.core.playlists.create(name, scheme).get()
     if not playlist:
         # If even default backend can't save playlist, everything is lost
         logger.warning('Default backend can\'t create playlists')

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -92,10 +92,12 @@ class BackendEventsTest(unittest.TestCase):
 
         self.assertEqual(send.call_args[0][0], 'playlist_changed')
 
-    @unittest.SkipTest
-    def test_playlists_delete_sends_playlist_deleted_event(self, send):
-        # TODO We should probably add a playlist_deleted event
-        pass
+    def test_playlists_delete_sends_playlist_changed_event(self, send):
+        playlist = self.core.playlists.create('foo').get()
+
+        self.core.playlists.delete(playlist.uri).get()
+
+        self.assertEqual(send.call_args[0][0], 'playlist_changed')
 
     def test_playlists_save_sends_playlist_changed_event(self, send):
         playlist = self.core.playlists.create('foo').get()

--- a/tests/mpd/protocol/__init__.py
+++ b/tests/mpd/protocol/__init__.py
@@ -33,6 +33,7 @@ class BaseTestCase(unittest.TestCase):
         return {
             'mpd': {
                 'password': None,
+                'default_playlist_scheme': 'dummy',
             }
         }
 

--- a/tests/mpd/protocol/test_stored_playlists.py
+++ b/tests/mpd/protocol/test_stored_playlists.py
@@ -211,29 +211,95 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.assertEqualResponse('ACK [50@0] {load} No such playlist')
 
     def test_playlistadd(self):
+        tracks = [
+            Track(uri='dummy:a'),
+            Track(uri='dummy:b'),
+        ]
+        self.backend.library.dummy_library = tracks
+        self.backend.playlists.set_dummy_playlists([
+            Playlist(
+                name='name', uri='dummy:a1', tracks=[tracks[0]])])
+        self.send_request('playlistadd "name" "dummy:b"')
+        self.assertInResponse('OK')
+        self.assertEqual(
+            2, len(self.backend.playlists.get_items("dummy:a1").get()))
+
+    def test_playlistadd_creates_playlist(self):
+        tracks = [
+            Track(uri='dummy:a'),
+        ]
+        self.backend.library.dummy_library = tracks
         self.send_request('playlistadd "name" "dummy:a"')
-        self.assertEqualResponse('ACK [0@0] {playlistadd} Not implemented')
+        self.assertInResponse('OK')
+        self.assertNotEqual(
+            None, self.backend.playlists.lookup("dummy:name").get())
 
     def test_playlistclear(self):
+        self.backend.playlists.set_dummy_playlists([
+            Playlist(
+                name='name', uri='dummy:a1', tracks=[Track(uri='b')])])
+
         self.send_request('playlistclear "name"')
-        self.assertEqualResponse('ACK [0@0] {playlistclear} Not implemented')
+        self.assertInResponse('OK')
+        self.assertEqual(
+            0, len(self.backend.playlists.get_items("dummy:a1").get()))
+
+    def test_playlistclear_creates_playlist(self):
+        self.send_request('playlistclear "name"')
+        self.assertInResponse('OK')
+        self.assertNotEqual(
+            None, self.backend.playlists.lookup("dummy:name").get())
 
     def test_playlistdelete(self):
-        self.send_request('playlistdelete "name" "5"')
-        self.assertEqualResponse('ACK [0@0] {playlistdelete} Not implemented')
+        tracks = [
+            Track(uri='dummy:a'),
+            Track(uri='dummy:b'),
+            Track(uri='dummy:c'),
+        ]   # len() == 3
+        self.backend.playlists.set_dummy_playlists([
+            Playlist(
+                name='name', uri='dummy:a1', tracks=tracks)])
+
+        self.send_request('playlistdelete "name" "2"')
+        self.assertInResponse('OK')
+        self.assertEqual(
+            2, len(self.backend.playlists.get_items("dummy:a1").get()))
 
     def test_playlistmove(self):
-        self.send_request('playlistmove "name" "5" "10"')
-        self.assertEqualResponse('ACK [0@0] {playlistmove} Not implemented')
+        tracks = [
+            Track(uri='dummy:a'),
+            Track(uri='dummy:b'),
+            Track(uri='dummy:c')    # this one is getting moved to top
+        ]
+        self.backend.playlists.set_dummy_playlists([
+            Playlist(
+                name='name', uri='dummy:a1', tracks=tracks)])
+        self.send_request('playlistmove "name" "2" "0"')
+        self.assertInResponse('OK')
+        self.assertEqual(
+            "dummy:c",
+            self.backend.playlists.get_items("dummy:a1").get()[0].uri)
 
     def test_rename(self):
+        self.backend.playlists.set_dummy_playlists([
+            Playlist(
+                name='old_name', uri='dummy:a1', tracks=[Track(uri='b')])])
         self.send_request('rename "old_name" "new_name"')
-        self.assertEqualResponse('ACK [0@0] {rename} Not implemented')
+        self.assertInResponse('OK')
+        self.assertNotEqual(
+            None, self.backend.playlists.lookup("dummy:new_name").get())
 
     def test_rm(self):
+        self.backend.playlists.set_dummy_playlists([
+            Playlist(
+                name='name', uri='dummy:a1', tracks=[Track(uri='b')])])
         self.send_request('rm "name"')
-        self.assertEqualResponse('ACK [0@0] {rm} Not implemented')
+        self.assertInResponse('OK')
+        self.assertEqual(
+            None, self.backend.playlists.lookup("dummy:a1").get())
 
     def test_save(self):
         self.send_request('save "name"')
-        self.assertEqualResponse('ACK [0@0] {save} Not implemented')
+        self.assertInResponse('OK')
+        self.assertNotEqual(
+            None, self.backend.playlists.lookup("dummy:name").get())


### PR DESCRIPTION
This PR implements all missing commands from `mpd/protocol/stored_playlists.py`. It turned out to be rather simple, so I just hope I didn't overlooked anything big.

Main problem can be in fe8bb5114e9969f328e66f9d3be722f523ae51f3. Event on delete is important for MPD clients, but if anything else relies on playlist to be valid object instead of None, this change may break it.

I've tested implementation with GMPC, Cantana and MPDroid.