### PR TITLE
mpd: Ignore tracks without length in the "count" command

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,12 @@ Models
   reuse instances. For the test data set this was developed against, a library
   of ~14000 tracks, went from needing ~75MB to ~17MB. (Fixes: :issue:`348`)
 
+MPD frontend
+------------
+
+- The MPD command ``count`` now ignores tracks with no length, which would
+  previously cause a :exc:`TypeError`. (PR: :issue:`1192`)
+
 Utils
 -----
 

--- a/mopidy/mpd/protocol/music_db.py
+++ b/mopidy/mpd/protocol/music_db.py
@@ -105,7 +105,7 @@ def count(context, *args):
     result_tracks = _get_tracks(results)
     return [
         ('songs', len(result_tracks)),
-        ('playtime', sum(track.length for track in result_tracks) / 1000),
+        ('playtime', sum(t.length for t in result_tracks if t.length) / 1000),
     ]
 
 

--- a/tests/mpd/protocol/test_music_db.py
+++ b/tests/mpd/protocol/test_music_db.py
@@ -79,6 +79,16 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         self.assertInResponse('playtime: 650')
         self.assertInResponse('OK')
 
+    def test_count_with_track_length_none(self):
+        self.backend.library.dummy_find_exact_result = SearchResult(
+            tracks=[
+                Track(uri='dummy:b', date="2001", length=None),
+            ])
+        self.send_request('count "date" "2001"')
+        self.assertInResponse('songs: 1')
+        self.assertInResponse('playtime: 0')
+        self.assertInResponse('OK')
+
     def test_findadd(self):
         self.backend.library.dummy_find_exact_result = SearchResult(
             tracks=[Track(uri='dummy:a', name='A')])


### PR DESCRIPTION
Hello,
currently the MPD `count` command will raise a `TypeError: unsupported operand type(s) for +: 'int' and 'NoneType'` if one or more of the tracks has no length, in other words, the length is the default value `None`. This happens if a library provider does not provide track length information.

This is an attempt to fix this issue.