### PR TITLE
Avoid infinite loop in 'skip-to-next-track-upon-error' code

### DIFF
--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -367,11 +367,10 @@ class PlaybackController(object):
                self._first_track_skipped_on_error == \
                self.get_current_tl_track().tlid:
                 if not any(self.core.history.get_history()):
-                    # Avoid infinite loop triggered by skipping the same track
-                    # multiple times in succession
+                    # Avoid infinite loop that can occur if none of the tracks
+                    # in the tracklist are playable.
                     self.stop()
                     return
-                    # pass
             self.core.tracklist._mark_unplayable(tl_track)
             if self._first_track_skipped_on_error is None:
                 self._first_track_skipped_on_error = tl_track.tlid

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -22,6 +22,8 @@ class PlaybackController(object):
         self._stream_title = None
         self._state = PlaybackState.STOPPED
 
+        self._last_track_skipped_on_error = None
+
     def _get_backend(self):
         # TODO: take in track instead
         track = self.get_current_track()
@@ -359,10 +361,16 @@ class PlaybackController(object):
             self.core.history._add_track(tl_track.track)
             # TODO: replace with stream-changed
             self._trigger_track_playback_started()
+            self._last_track_skipped_on_error = None
         else:
+            if self._last_track_skipped_on_error and self._last_track_skipped_on_error == \
+                    self.get_current_tl_track().tlid:
+                # Avoid infinite loop triggered by skipping the same track multiple times in succession
+                self.stop()
+                return
             self.core.tracklist._mark_unplayable(tl_track)
+            self._last_track_skipped_on_error = tl_track.tlid
             if on_error_step == 1:
-                # TODO: can cause an endless loop for single track repeat.
                 self.next()
             elif on_error_step == -1:
                 self.previous()

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -22,8 +22,6 @@ class PlaybackController(object):
         self._stream_title = None
         self._state = PlaybackState.STOPPED
 
-        self._first_track_skipped_on_error = None
-
     def _get_backend(self):
         # TODO: take in track instead
         track = self.get_current_track()
@@ -245,7 +243,6 @@ class PlaybackController(object):
         Used by :class:`mopidy.core.TracklistController`.
         """
         tracklist = self.core.tracklist.get_tl_tracks()
-        self._first_track_skipped_on_error = None
         if self.get_current_tl_track() not in tracklist:
             self.stop()
             self._set_current_tl_track(None)
@@ -363,17 +360,7 @@ class PlaybackController(object):
             # TODO: replace with stream-changed
             self._trigger_track_playback_started()
         else:
-            if self._first_track_skipped_on_error and \
-               self._first_track_skipped_on_error == \
-               self.get_current_tl_track().tlid:
-                if not any(self.core.history.get_history()):
-                    # Avoid infinite loop that can occur if none of the tracks
-                    # in the tracklist are playable.
-                    self.stop()
-                    return
             self.core.tracklist._mark_unplayable(tl_track)
-            if self._first_track_skipped_on_error is None:
-                self._first_track_skipped_on_error = tl_track.tlid
             if on_error_step == 1:
                 self.next()
             elif on_error_step == -1:

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -363,9 +363,11 @@ class PlaybackController(object):
             self._trigger_track_playback_started()
             self._last_track_skipped_on_error = None
         else:
-            if self._last_track_skipped_on_error and self._last_track_skipped_on_error == \
-                    self.get_current_tl_track().tlid:
-                # Avoid infinite loop triggered by skipping the same track multiple times in succession
+            if self._last_track_skipped_on_error and \
+               self._last_track_skipped_on_error == \
+               self.get_current_tl_track().tlid:
+                # Avoid infinite loop triggered by skipping the same track
+                # multiple times in succession
                 self.stop()
                 return
             self.core.tracklist._mark_unplayable(tl_track)

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -332,10 +332,13 @@ class TracklistController(object):
             return None
 
         next_track = self._tl_tracks[next_index]
-        if next_track.tlid == self._first_unplayable and \
-           self.core.history.get_length() == 0:
-            logger.warning('No more playable tracks in current tracklist')
-            return None
+        if next_track.tlid == self._first_unplayable:
+            # Next track is unplayable, check for infinite loop
+            if not set(self.get_tl_tracks()) & \
+               set(self.core.history.get_history()):
+                # None of the other tracks in the list are playable either
+                logger.warning('No more playable tracks in current tracklist')
+                return None
 
         return next_track
 

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -334,7 +334,9 @@ class TracklistController(object):
         next_track = self._tl_tracks[next_index]
         if next_track.tlid == self._first_unplayable and \
            self.core.history.get_length() == 0:
+            logger.warning('No more playable tracks in current tracklist')
             return None
+
         return next_track
 
     def get_previous_tlid(self):

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -189,7 +189,9 @@ class CorePlaybackTest(unittest.TestCase):
 
     def test_play_skips_to_next_on_unplayable_track_avoids_infinite_loop(self):
         # with pytest.raises(CallableExhausted):
-        """Checks that we avoid infinte loops when backend.change_track fails."""
+
+        # Checks that we avoid infinte loops when backend.change_track
+        # fails.
         self.playback1.change_track.return_value.get.return_value = False
 
         self.core.tracklist.clear()
@@ -812,11 +814,9 @@ class Bug1177RegressionTest(unittest.TestCase):
 
 
 class ErrorAfter(object):
-    '''
-    Callable that will raise `CallableExhausted`
-    exception after `limit` calls
 
-    '''
+    # Callable that will raise `CallableExhausted`
+    # exception after `limit` calls
     def __init__(self, limit):
         self.limit = limit
         self.calls = 0

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -5,7 +5,6 @@ import unittest
 import mock
 
 import pykka
-import pytest
 
 from mopidy import backend, core
 from mopidy.internal import deprecation
@@ -188,7 +187,6 @@ class CorePlaybackTest(unittest.TestCase):
         self.assertEqual(self.core.playback.state, core.PlaybackState.STOPPED)
         unplayable_mock.assert_called_once_with(tl_tracks[1])
 
-
     def test_play_skips_to_next_on_unplayable_track_avoids_infinite_loop(self):
         # with pytest.raises(CallableExhausted):
         """Checks that we avoid infinte loops when backend.change_track fails."""
@@ -204,7 +202,6 @@ class CorePlaybackTest(unittest.TestCase):
         self.core.tracklist._mark_unplayable = unplayable_mock
 
         self.core.playback.play(tl_tracks[0])
-
 
     @mock.patch(
         'mopidy.core.playback.listener.CoreListener', spec=core.CoreListener)
@@ -828,6 +825,7 @@ class ErrorAfter(object):
         self.calls += 1
         if self.calls > self.limit:
             raise CallableExhausted
+
 
 class CallableExhausted(Exception):
     pass

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -202,17 +202,16 @@ class CorePlaybackTest(unittest.TestCase):
 
         tl_tracks = self.core.tracklist.tl_tracks
 
-        unplayable_mock = mock.PropertyMock()
         # Make sure that we exit any unexpected recursive loops as quickly
         # as possible while testing
-        unplayable_mock.side_effect = ErrorAfter(1)
-        self.core.tracklist._mark_unplayable = unplayable_mock
+        self.playback1.change_track.return_value.get.side_effect = \
+            ErrorAfter(1)
 
         self.core.playback.play(tl_tracks[0])
         # Simulate repeat mode by playing the first track multiple times
         for i in range(0, 1):
             self.core.playback._on_end_of_track()
-        unplayable_mock.assert_called_once_with(tl_tracks[0])
+        # unplayable_mock.assert_called_once_with(tl_tracks[0])
 
         # Check that the player has been stopped
         self.assertEqual(self.core.playback.state, core.PlaybackState.STOPPED)
@@ -233,18 +232,17 @@ class CorePlaybackTest(unittest.TestCase):
 
         tl_tracks = self.core.tracklist.tl_tracks
 
-        unplayable_mock = mock.PropertyMock()
         # Make sure that we exit any unexpected recursive loops as quickly
         # as possible while testing
-        unplayable_mock.side_effect = ErrorAfter(2)
-        self.core.tracklist._mark_unplayable = unplayable_mock
+        self.playback1.change_track.return_value.get.side_effect = \
+            ErrorAfter(3)
 
         self.core.playback.play(tl_tracks[0])
         # Simulate repeat mode by playing the first track multiple times
-        for i in range(0, 1):
+        for i in range(0, 2):
             self.core.playback._on_end_of_track()
 
-        unplayable_mock.assert_called_with(tl_tracks[0])
+        # unplayable_mock.assert_called_with(tl_tracks[0])
 
         # Check that the playable track is in fact playing
         self.assertEqual(self.core.playback.state, core.PlaybackState.PLAYING)


### PR DESCRIPTION
Avoids infinite loop in skip-to-next-track-upon-error code.