### PR TITLE
mpd:Fix swapped Name and Title fields for streams

### DIFF
--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -38,12 +38,15 @@ def track_to_mpd_format(track, position=None, stream_title=None):
         # https://github.com/mopidy/mopidy/issues/923#issuecomment-79584110
         ('Time', track.length and (track.length // 1000) or 0),
         ('Artist', concat_multi_values(track.artists, 'name')),
-        ('Title', track.name or ''),
         ('Album', track.album and track.album.name or ''),
     ]
 
-    if stream_title:
-        result.append(('Name', stream_title))
+    if stream_title is not None:
+        result.append(('Title', stream_title))
+        if track.name:
+            result.append(('Name', track.name))
+    else:
+        result.append(('Title', track.name or ''))
 
     if track.date:
         result.append(('Date', track.date))


### PR DESCRIPTION
Fixes #1212

When stream_title is set:
use stream_title for mpd's Title field, and use track.name (if set) for mpd's Name field

When stream_title is not set:
use track.name for mpd's Title field. Do not output Name field.