### PR TITLE
Fix #1218

### DIFF
--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -87,10 +87,10 @@ def track_to_mpd_format(track, position=None, stream_title=None):
     if track.disc_no:
         result.append(('Disc', track.disc_no))
 
-    if track.last_modified is not None:
-        datestring = datetime.datetime.fromtimestamp(
+    if track.last_modified:
+        datestring = datetime.datetime.utcfromtimestamp(
             track.last_modified // 1000).isoformat()
-        result.append(('Last-Modified', datestring))
+        result.append(('Last-Modified', datestring + 'Z'))
 
     if track.musicbrainz_id is not None:
         result.append(('MUSICBRAINZ_TRACKID', track.musicbrainz_id))

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -89,7 +89,7 @@ def track_to_mpd_format(track, position=None, stream_title=None):
 
     if track.last_modified is not None:
         datestring = datetime.datetime.fromtimestamp(
-            track.last_modified // 1000).strftime('%Y-%m-%dT%H:%M:%S%Z')
+            track.last_modified // 1000).isoformat()
         result.append(('Last-Modified', datestring))
 
     if track.musicbrainz_id is not None:

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import datetime
 import re
 
 from mopidy.models import TlTrack
@@ -85,6 +86,11 @@ def track_to_mpd_format(track, position=None, stream_title=None):
 
     if track.disc_no:
         result.append(('Disc', track.disc_no))
+
+    if track.last_modified is not None:
+        datestring = datetime.datetime.fromtimestamp(
+            track.last_modified // 1000).strftime('%Y-%m-%dT%H:%M:%S%Z')
+        result.append(('Last-Modified', datestring))
 
     if track.musicbrainz_id is not None:
         result.append(('MUSICBRAINZ_TRACKID', track.musicbrainz_id))

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -23,7 +23,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         date='1977-01-01',
         disc_no=1,
         comment='a comment',
-        length=137000
+        length=137000,
     )
 
     def setUp(self):  # noqa: N802

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -98,6 +98,24 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertNotIn(('Comment', 'a comment'), result)
         self.assertEqual(len(result), 13)
 
+    def test_track_to_mpd_format_with_last_modified_of_zero(self):
+        track = self.track.replace(last_modified=0)
+        result = translator.track_to_mpd_format(track)
+        self.assertIn(('file', 'a uri'), result)
+        self.assertIn(('Time', 137), result)
+        self.assertIn(('Artist', 'an artist'), result)
+        self.assertIn(('Title', 'a name'), result)
+        self.assertIn(('Album', 'an album'), result)
+        self.assertIn(('AlbumArtist', 'an other artist'), result)
+        self.assertIn(('Composer', 'a composer'), result)
+        self.assertIn(('Performer', 'a performer'), result)
+        self.assertIn(('Genre', 'a genre'), result)
+        self.assertIn(('Track', '7/13'), result)
+        self.assertIn(('Date', '1977-01-01'), result)
+        self.assertIn(('Disc', 1), result)
+        self.assertNotIn(('Comment', 'a comment'), result)
+        self.assertEqual(len(result), 12)
+
     def test_track_to_mpd_format_musicbrainz_trackid(self):
         track = self.track.replace(musicbrainz_id='foo')
         result = translator.track_to_mpd_format(track)

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import datetime
 import unittest
 
 from mopidy.internal import path
@@ -82,12 +81,6 @@ class TrackMpdFormatTest(unittest.TestCase):
 
     def test_track_to_mpd_format_with_last_modified(self):
         track = self.track.replace(last_modified=995303899000)
-        # Due to this being local time-zone dependant, we have
-        # to calculate what the Last-Modified output will look like
-        # on the machine where the tests are being run. So this only tests
-        # that the output is actually there.
-        datestring = datetime.datetime.fromtimestamp(
-            track.last_modified // 1000).isoformat()
         result = translator.track_to_mpd_format(track)
         self.assertIn(('file', 'a uri'), result)
         self.assertIn(('Time', 137), result)
@@ -101,7 +94,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertIn(('Track', '7/13'), result)
         self.assertIn(('Date', '1977-01-01'), result)
         self.assertIn(('Disc', 1), result)
-        self.assertIn(('Last-Modified', datestring), result)
+        self.assertIn(('Last-Modified', '2001-07-16T17:18:19Z'), result)
         self.assertNotIn(('Comment', 'a comment'), result)
         self.assertEqual(len(result), 13)
 

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import datetime
 import unittest
 
 from mopidy.internal import path
@@ -81,6 +82,12 @@ class TrackMpdFormatTest(unittest.TestCase):
 
     def test_track_to_mpd_format_with_last_modified(self):
         track = self.track.replace(last_modified=995303899000)
+        # Due to this being local time-zone dependant, we have
+        # to calculate what the Last-Modified output will look like
+        # on the machine where the tests are being run. So this only tests
+        # that the output is actually there.
+        datestring = datetime.datetime.fromtimestamp(
+            track.last_modified // 1000).isoformat()
         result = translator.track_to_mpd_format(track)
         self.assertIn(('file', 'a uri'), result)
         self.assertIn(('Time', 137), result)
@@ -94,7 +101,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertIn(('Track', '7/13'), result)
         self.assertIn(('Date', '1977-01-01'), result)
         self.assertIn(('Disc', 1), result)
-        self.assertIn(('Last-Modified', '2001-07-16T18:18:19'), result)
+        self.assertIn(('Last-Modified', datestring), result)
         self.assertNotIn(('Comment', 'a comment'), result)
         self.assertEqual(len(result), 13)
 

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -22,7 +22,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         date='1977-01-01',
         disc_no=1,
         comment='a comment',
-        length=137000,
+        length=137000
     )
 
     def setUp(self):  # noqa: N802
@@ -78,6 +78,25 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertIn(('Id', 122), result)
         self.assertNotIn(('Comment', 'a comment'), result)
         self.assertEqual(len(result), 14)
+
+    def test_track_to_mpd_format_with_last_modified(self):
+        track = self.track.replace(last_modified=995303899000)
+        result = translator.track_to_mpd_format(track)
+        self.assertIn(('file', 'a uri'), result)
+        self.assertIn(('Time', 137), result)
+        self.assertIn(('Artist', 'an artist'), result)
+        self.assertIn(('Title', 'a name'), result)
+        self.assertIn(('Album', 'an album'), result)
+        self.assertIn(('AlbumArtist', 'an other artist'), result)
+        self.assertIn(('Composer', 'a composer'), result)
+        self.assertIn(('Performer', 'a performer'), result)
+        self.assertIn(('Genre', 'a genre'), result)
+        self.assertIn(('Track', '7/13'), result)
+        self.assertIn(('Date', '1977-01-01'), result)
+        self.assertIn(('Disc', 1), result)
+        self.assertIn(('Last-Modified', '2001-07-16T18:18:19'), result)
+        self.assertNotIn(('Comment', 'a comment'), result)
+        self.assertEqual(len(result), 13)
 
     def test_track_to_mpd_format_musicbrainz_trackid(self):
         track = self.track.replace(musicbrainz_id='foo')


### PR DESCRIPTION
Output the last_modified timestamp from mopidy's track model to mpd clients
in the same format as mpd uses - yyyy-mm-ddTHH:MM:SS

Outputs nothing for Last-Modified if last_modified is None