### PR TITLE
Issue: #997 Add a track-list length limit.

### DIFF
--- a/mopidy/core/ext.conf
+++ b/mopidy/core/ext.conf
@@ -1,1 +1,3 @@
 [core]
+enabled = true
+max_tracklist_length = 10000

--- a/mopidy/core/ext.py
+++ b/mopidy/core/ext.py
@@ -18,7 +18,8 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super(Extension, self).get_config_schema()
-        del schema['enabled']  # core cannot be disabled
+        schema['max_tracklist_length'] = config.Integer(
+            minimum=1, maximum=10000)
         return schema
 
     def setup(self, registry):

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 import logging
 import random
 
+from mopidy import exceptions
 from mopidy.core import listener
 from mopidy.internal import deprecation, validation
 from mopidy.models import TlTrack, Track
@@ -433,6 +434,13 @@ class TracklistController(object):
         tl_tracks = []
 
         for track in tracks:
+            if(self.get_length() >=
+                    self.core._config['core']['max_tracklist_length']):
+
+                raise exceptions.TracklistFull(
+                    'TracklistFull: Tried to add ' +
+                    'too many uris to the tracklist.')
+                break
             tl_track = TlTrack(self._next_tlid, track)
             self._next_tlid += 1
             if at_position is not None:

--- a/mopidy/exceptions.py
+++ b/mopidy/exceptions.py
@@ -19,6 +19,13 @@ class MopidyException(Exception):
 
 class BackendError(MopidyException):
     pass
+    
+
+class CoreError(MopidyException):
+    
+    def __init(self, message, errno=None):
+        super(CoreError, self).__init(message, errno)
+        self.errno = errno
 
 
 class ExtensionError(MopidyException):
@@ -42,6 +49,13 @@ class MixerError(MopidyException):
 
 class ScannerError(MopidyException):
     pass
+
+    
+class TracklistFull(CoreError):
+    
+    def __init(self, message, errno=None):
+        super(TracklistFull, self).__init(message, errno)
+        self.errno = errno
 
 
 class AudioException(MopidyException):

--- a/mopidy/exceptions.py
+++ b/mopidy/exceptions.py
@@ -19,10 +19,10 @@ class MopidyException(Exception):
 
 class BackendError(MopidyException):
     pass
-    
+
 
 class CoreError(MopidyException):
-    
+
     def __init(self, message, errno=None):
         super(CoreError, self).__init(message, errno)
         self.errno = errno
@@ -50,9 +50,9 @@ class MixerError(MopidyException):
 class ScannerError(MopidyException):
     pass
 
-    
+
 class TracklistFull(CoreError):
-    
+
     def __init(self, message, errno=None):
         super(TracklistFull, self).__init(message, errno)
         self.errno = errno

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -17,12 +17,19 @@ from tests import dummy_backend
 class BackendEventsTest(unittest.TestCase):
 
     def setUp(self):  # noqa: N802
+        config = {
+            'core': {
+                'max_tracklist_length': 10000,
+            }
+        }
+
         self.backend = dummy_backend.create_proxy()
         self.backend.library.dummy_library = [
             Track(uri='dummy:a'), Track(uri='dummy:b')]
 
         with deprecation.ignore():
-            self.core = core.Core.start(backends=[self.backend]).proxy()
+            self.core = core.Core.start(
+                config, backends=[self.backend]).proxy()
 
     def tearDown(self):  # noqa: N802
         pykka.ActorRegistry.stop_all()

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -11,7 +11,13 @@ from mopidy.models import TlTrack, Track
 
 class TracklistTest(unittest.TestCase):
 
-    def setUp(self):  # noqa: N802
+    def setUp(self):  # noqa:
+        config = {
+            'core': {
+                'max_tracklist_length': 10000,
+            }
+        }
+
         self.tracks = [
             Track(uri='dummy1:a', name='foo'),
             Track(uri='dummy1:b', name='foo'),
@@ -29,7 +35,7 @@ class TracklistTest(unittest.TestCase):
         self.library.lookup.side_effect = lookup
         self.backend.library = self.library
 
-        self.core = core.Core(mixer=None, backends=[self.backend])
+        self.core = core.Core(config, mixer=None, backends=[self.backend])
         self.tl_tracks = self.core.tracklist.add(uris=[
             t.uri for t in self.tracks])
 
@@ -107,6 +113,12 @@ class TracklistTest(unittest.TestCase):
 class TracklistIndexTest(unittest.TestCase):
 
     def setUp(self):  # noqa: N802
+        config = {
+            'core': {
+                'max_tracklist_length': 10000,
+            }
+        }
+
         self.tracks = [
             Track(uri='dummy1:a', name='foo'),
             Track(uri='dummy1:b', name='foo'),
@@ -116,7 +128,7 @@ class TracklistIndexTest(unittest.TestCase):
         def lookup(uris):
             return {u: [t for t in self.tracks if t.uri == u] for u in uris}
 
-        self.core = core.Core(mixer=None, backends=[])
+        self.core = core.Core(config, mixer=None, backends=[])
         self.core.library = mock.Mock(spec=core.LibraryController)
         self.core.library.lookup.side_effect = lookup
 

--- a/tests/local/test_playback.py
+++ b/tests/local/test_playback.py
@@ -22,6 +22,9 @@ from tests.local import generate_song, populate_tracklist
 
 class LocalPlaybackProviderTest(unittest.TestCase):
     config = {
+        'core': {
+            'max_tracklist_length': 10000,
+        },
         'local': {
             'media_dir': path_to_data_dir(''),
             'data_dir': path_to_data_dir(''),
@@ -51,7 +54,7 @@ class LocalPlaybackProviderTest(unittest.TestCase):
         self.audio = dummy_audio.create_proxy()
         self.backend = actor.LocalBackend.start(
             config=self.config, audio=self.audio).proxy()
-        self.core = core.Core(backends=[self.backend])
+        self.core = core.Core(self.config, backends=[self.backend])
         self.playback = self.core.playback
         self.tracklist = self.core.tracklist
 

--- a/tests/local/test_tracklist.py
+++ b/tests/local/test_tracklist.py
@@ -17,6 +17,9 @@ from tests.local import generate_song, populate_tracklist
 
 class LocalTracklistProviderTest(unittest.TestCase):
     config = {
+        'core': {
+            'max_tracklist_length': 10000
+        },
         'local': {
             'media_dir': path_to_data_dir(''),
             'data_dir': path_to_data_dir(''),
@@ -35,7 +38,7 @@ class LocalTracklistProviderTest(unittest.TestCase):
         self.audio = dummy_audio.create_proxy()
         self.backend = actor.LocalBackend.start(
             config=self.config, audio=self.audio).proxy()
-        self.core = core.Core(mixer=None, backends=[self.backend])
+        self.core = core.Core(self.config, mixer=None, backends=[self.backend])
         self.controller = self.core.tracklist
         self.playback = self.core.playback
 

--- a/tests/mpd/protocol/__init__.py
+++ b/tests/mpd/protocol/__init__.py
@@ -31,6 +31,9 @@ class BaseTestCase(unittest.TestCase):
 
     def get_config(self):
         return {
+            'core': {
+                'max_tracklist_length': 10000
+            },
             'mpd': {
                 'password': None,
             }
@@ -45,7 +48,9 @@ class BaseTestCase(unittest.TestCase):
 
         with deprecation.ignore():
             self.core = core.Core.start(
-                mixer=self.mixer, backends=[self.backend]).proxy()
+                self.get_config(),
+                mixer=self.mixer,
+                backends=[self.backend]).proxy()
 
         self.uri_map = uri_mapper.MpdUriMapper(self.core)
         self.connection = MockConnection()

--- a/tests/mpd/test_status.py
+++ b/tests/mpd/test_status.py
@@ -25,12 +25,20 @@ STOPPED = PlaybackState.STOPPED
 class StatusHandlerTest(unittest.TestCase):
 
     def setUp(self):  # noqa: N802
+        config = {
+            'core': {
+                'max_tracklist_length': 10000,
+            }
+        }
+
         self.mixer = dummy_mixer.create_proxy()
         self.backend = dummy_backend.create_proxy()
 
         with deprecation.ignore():
             self.core = core.Core.start(
-                mixer=self.mixer, backends=[self.backend]).proxy()
+                config,
+                mixer=self.mixer,
+                backends=[self.backend]).proxy()
 
         self.dispatcher = dispatcher.MpdDispatcher(core=self.core)
         self.context = self.dispatcher.context


### PR DESCRIPTION
Added in the check to the add method in core/tracklist.py, added the schema to core/actor.py, and added the max_tracklist_length to the config file. Even if the config tracklist length has a ceiling of 10,000 and the default is 10,000. Also added in the core config values to relevant test cases. I think that's everything mentioned in 997.

Any suggestions/concerns?