### PR TITLE
Feature/mpd protocol extensions

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -116,6 +116,9 @@ MPD frontend
 - Exclude empty tags fields from metadata output. (Fixes: :issue:`1045`, PR:
   :issue:`1235`)
 
+- Implement protocol extensions to output Album URIs and Album Images when
+  outputting track data to clients. (PR: :issue:`1230`)
+
 Stream backend
 --------------
 

--- a/mopidy/mpd/protocol/tagtype_list.py
+++ b/mopidy/mpd/protocol/tagtype_list.py
@@ -19,4 +19,6 @@ TAGTYPE_LIST = [
     'MUSICBRAINZ_ALBUMID',
     'MUSICBRAINZ_ALBUMARTISTID',
     'MUSICBRAINZ_TRACKID',
+    'X-AlbumUri',
+    'X-AlbumImage',
 ]

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -97,6 +97,12 @@ def track_to_mpd_format(track, position=None, stream_title=None):
     if track.musicbrainz_id is not None:
         result.append(('MUSICBRAINZ_TRACKID', track.musicbrainz_id))
 
+    if track.album and track.album.uri:
+        result.append(('X-AlbumUri', track.album.uri))
+    if track.album and track.album.images:
+        images = ';'.join(i for i in track.album.images if i is not '')
+        result.append(('X-AlbumImage', images))
+
     result = [element for element in result if _has_value(*element)]
 
     return result

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -14,7 +14,8 @@ class TrackMpdFormatTest(unittest.TestCase):
         name='a name',
         album=Album(
             name='an album', num_tracks=13,
-            artists=[Artist(name='an other artist')]),
+            artists=[Artist(name='an other artist')],
+            uri='urischeme:album:12345', images=['image1', 'image2']),
         track_no=7,
         composers=[Artist(name='a composer')],
         performers=[Artist(name='a performer')],
@@ -76,8 +77,10 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertIn(('Disc', 1), result)
         self.assertIn(('Pos', 9), result)
         self.assertIn(('Id', 122), result)
+        self.assertIn(('X-AlbumUri', 'urischeme:album:12345'), result)
+        self.assertIn(('X-AlbumImage', 'image2;image1'), result)
         self.assertNotIn(('Comment', 'a comment'), result)
-        self.assertEqual(len(result), 14)
+        self.assertEqual(len(result), 16)
 
     def test_track_to_mpd_format_with_last_modified(self):
         track = self.track.replace(last_modified=995303899000)

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -15,7 +15,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         album=Album(
             name='an album', num_tracks=13,
             artists=[Artist(name='an other artist')],
-            uri='urischeme:album:12345', images=['image1', 'image2']),
+            uri='urischeme:album:12345', images=['image1']),
         track_no=7,
         composers=[Artist(name='a composer')],
         performers=[Artist(name='a performer')],
@@ -78,7 +78,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertIn(('Pos', 9), result)
         self.assertIn(('Id', 122), result)
         self.assertIn(('X-AlbumUri', 'urischeme:album:12345'), result)
-        self.assertIn(('X-AlbumImage', 'image1;image2'), result)
+        self.assertIn(('X-AlbumImage', 'image1'), result)
         self.assertNotIn(('Comment', 'a comment'), result)
         self.assertEqual(len(result), 16)
 

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -78,7 +78,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertIn(('Pos', 9), result)
         self.assertIn(('Id', 122), result)
         self.assertIn(('X-AlbumUri', 'urischeme:album:12345'), result)
-        self.assertIn(('X-AlbumImage', 'image2;image1'), result)
+        self.assertIn(('X-AlbumImage', 'image1;image2'), result)
         self.assertNotIn(('Comment', 'a comment'), result)
         self.assertEqual(len(result), 16)
 


### PR DESCRIPTION
Here's an Initial proof-of-concept for some MPD protocol extensions.

Adds a new mpd command:
x_protocolextensions {BOOL}
which switches on the new functionality. This setting is stored on
a session-by-session basis, which makes slightly more work for the
client but means that the behaviour is entirely sandboxed and only
visible to clients that want it, even in a multi-client setup.

There is a new config item:
mpd/proto_ext_allowed {BOOL}
which defaults to true but, if set to false, disables the above
command, thus making mopidy revert to 'standard' MPD behaviour

Enabling x_protocolextensions then provides 2 new pieces of extra
functionality to the client:
When translating mopidy tracks to MPD output, album URIs and album
Images are output along with the standard information, eg:
X-AlbumUri: spotify:album:fhwfhewfihi38
X-AlbumImage: http://some.path.to.an/image.jpg

'search' and 'find' commands permit an extra parameter to specify
which backends to search:
search artist "someartist" domains "local:,spotify:"
Trying to use 'domains' with protocol extensions disabled will return
an error just like standard mpd.

I updated most of the existing tests so they pass, but wanted to get this up here for discussion before going on with any further new tests or documentation