### PR TITLE
Added source field to Track model

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -47,6 +47,10 @@ Models
   reuse instances. For the test data set this was developed against, a library
   of ~14000 tracks, went from needing ~75MB to ~17MB. (Fixes: :issue:`348`)
 
+- Added ``source`` field to :class:`mopidy.models.Track` models. It can contain
+  fields like ``local``, ``stream`` or ``spotify``. Extensions can set that
+  field by specifying ``source_name`` as a attribute on the backend.
+
 MPD frontend
 ------------
 

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -42,6 +42,13 @@ class Backend(object):
     #: List of URI schemes this backend can handle.
     uri_schemes = []
 
+    #: String describing the source of tracks returned by this backend.
+    #:
+    #: If you override this value, it will be added to all track objects and
+    #: can be used by clients. An example for this might be a client showing a
+    #: Spotify logo for Spotify tracks.
+    source_name = None
+
     # Because the providers is marked as pykka_traversible, we can't get() them
     # from another actor, and need helper methods to check if the providers are
     # set or None.

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -142,6 +142,7 @@ class Backends(list):
         self.with_library_browse = collections.OrderedDict()
         self.with_playback = collections.OrderedDict()
         self.with_playlists = collections.OrderedDict()
+        self.source_names = dict()
 
         backends_by_scheme = {}
 
@@ -154,6 +155,7 @@ class Backends(list):
                 has_library_browse = b.has_library_browse().get()
                 has_playback = b.has_playback().get()
                 has_playlists = b.has_playlists().get()
+                source_name = b.source_name.get()
             except Exception:
                 self.remove(b)
                 logger.exception('Fetching backend info for %s failed',
@@ -174,3 +176,5 @@ class Backends(list):
                     self.with_playback[scheme] = b
                 if has_playlists:
                     self.with_playlists[scheme] = b
+
+            self.source_names[b] = source_name

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -198,6 +198,9 @@ class LibraryController(object):
         If the URI expands to multiple tracks, the returned list will contain
         them all.
 
+        Tracks will be annotated with the ``source`` field, if the backend
+        provides such a value.
+
         :param uri: track URI
         :type uri: string or :class:`None`
         :param uris: track URIs
@@ -234,8 +237,14 @@ class LibraryController(object):
         for (backend, u), future in futures.items():
             with _backend_error_handling(backend):
                 result = future.get()
+                source = backend.source_name.get()
                 if result is not None:
                     validation.check_instances(result, models.Track)
+
+                    # Add the backend source to the tracks
+                    if source:
+                        result = [r.replace(source=source) for r in result]
+
                     results[u] = result
 
         if uri:
@@ -273,6 +282,9 @@ class LibraryController(object):
         If ``uris`` is given, the search is limited to results from within the
         URI roots. For example passing ``uris=['file:']`` will limit the search
         to the local backend.
+
+        Tracks will be annotated with the ``source`` field, if the backend
+        provides such a value.
 
         Examples::
 
@@ -342,7 +354,14 @@ class LibraryController(object):
                     result = future.get()
                     if result is not None:
                         validation.check_instance(result, models.SearchResult)
-                        results.append(result)
+
+                        source = backend.source_name.get()
+                        if source:
+                            newtracks = [t.replace(source=source)
+                                         for t in result.tracks]
+                            results.append(result.replace(tracks=newtracks))
+                        else:
+                            results.append(result)
             except TypeError:
                 backend_name = backend.actor_ref.actor_class.__name__
                 logger.warning(

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -237,7 +237,7 @@ class LibraryController(object):
         for (backend, u), future in futures.items():
             with _backend_error_handling(backend):
                 result = future.get()
-                source = backend.source_name.get()
+                source = self.backends.source_names.get(backend)
                 if result is not None:
                     validation.check_instances(result, models.Track)
 
@@ -355,7 +355,7 @@ class LibraryController(object):
                     if result is not None:
                         validation.check_instance(result, models.SearchResult)
 
-                        source = backend.source_name.get()
+                        source = self.backends.source_names.get(backend)
                         if source:
                             newtracks = [t.replace(source=source)
                                          for t in result.tracks]

--- a/mopidy/file/backend.py
+++ b/mopidy/file/backend.py
@@ -13,6 +13,7 @@ logger = logging.getLogger(__name__)
 
 class FileBackend(pykka.ThreadingActor, backend.Backend):
     uri_schemes = ['file']
+    source_name = 'file'
 
     def __init__(self, config, audio):
         super(FileBackend, self).__init__()

--- a/mopidy/local/actor.py
+++ b/mopidy/local/actor.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 class LocalBackend(pykka.ThreadingActor, backend.Backend):
     uri_schemes = ['local']
     libraries = []
+    source_name = 'local'
 
     def __init__(self, config, audio):
         super(LocalBackend, self).__init__()

--- a/mopidy/m3u/actor.py
+++ b/mopidy/m3u/actor.py
@@ -15,6 +15,7 @@ logger = logging.getLogger(__name__)
 
 class M3UBackend(pykka.ThreadingActor, backend.Backend):
     uri_schemes = ['m3u']
+    source_name = 'm3u'
 
     def __init__(self, config, audio):
         super(M3UBackend, self).__init__()

--- a/mopidy/models/__init__.py
+++ b/mopidy/models/__init__.py
@@ -253,6 +253,9 @@ class Track(ValidatedImmutableObject):
     #: equivalent timestamp or simply a version counter.
     last_modified = fields.Integer(min=0)
 
+    #: The track source, e.g. "spotify" or "local". Read-only.
+    source = fields.String()
+
 
 class TlTrack(ValidatedImmutableObject):
 

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -16,6 +16,8 @@ logger = logging.getLogger(__name__)
 
 class StreamBackend(pykka.ThreadingActor, backend.Backend):
 
+    source_name = 'stream'
+
     def __init__(self, config, audio):
         super(StreamBackend, self).__init__()
 

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -15,6 +15,7 @@ class BaseCoreLibraryTest(unittest.TestCase):
         dummy1_root = Ref.directory(uri='dummy1:directory', name='dummy1')
         self.backend1 = mock.Mock()
         self.backend1.uri_schemes.get.return_value = ['dummy1']
+        self.backend1.source_name.get.return_value = None
         self.backend1.actor_ref.actor_class.__name__ = 'DummyBackend1'
         self.library1 = mock.Mock(spec=backend.LibraryProvider)
         self.library1.get_images.return_value.get.return_value = {}
@@ -25,6 +26,7 @@ class BaseCoreLibraryTest(unittest.TestCase):
         self.backend2 = mock.Mock()
         self.backend2.uri_schemes.get.return_value = ['dummy2', 'du2']
         self.backend2.actor_ref.actor_class.__name__ = 'DummyBackend2'
+        self.backend2.source_name.get.return_value = None
         self.library2 = mock.Mock(spec=backend.LibraryProvider)
         self.library2.get_images.return_value.get.return_value = {}
         self.library2.root_directory.get.return_value = dummy2_root
@@ -34,6 +36,7 @@ class BaseCoreLibraryTest(unittest.TestCase):
         self.backend3 = mock.Mock()
         self.backend3.uri_schemes.get.return_value = ['dummy3']
         self.backend3.actor_ref.actor_class.__name__ = 'DummyBackend3'
+        self.backend3.source_name.get.return_value = None
         self.backend3.has_library().get.return_value = False
         self.backend3.has_library_browse().get.return_value = False
 
@@ -167,6 +170,16 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         self.assertFalse(self.library1.lookup.called)
         self.assertFalse(self.library2.lookup.called)
 
+    def test_lookup_adds_source(self):
+        # Overwrite the source_name attribute
+        self.backend1.source_name.get.return_value = 'hamspam'
+
+        track = Track(name='abc', source='hamspam')
+        self.library1.lookup().get.return_value = [track]
+
+        result = self.core.library.lookup(uris=['dummy1:a'])
+        assert result == {'dummy1:a': [track]}
+
     def test_refresh_with_uri_selects_dummy1_backend(self):
         self.core.library.refresh('dummy1:a')
 
@@ -264,6 +277,22 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         self.core.library.search({'any': 'foobar'})
         self.library1.search.assert_called_once_with(
             query={'any': ['foobar']}, uris=None, exact=False)
+
+    def test_search_adds_source(self):
+        # Overwrite the source_name attribute
+        self.backend1.source_name.get.return_value = 'hamspam'
+
+        track = Track(name='abc')
+        track_with_source = Track(name='abc', source='hamspam')
+
+        # The library doesn't set the source
+        library_result = SearchResult(tracks=[track])
+        self.library1.search.return_value.get.return_value = library_result
+
+        # ...but it should be in the final search results.
+        result = self.core.library.search({'any': ['a']})
+        assert len(result) == 1
+        assert track_with_source in result[0].tracks
 
 
 class DeprecatedFindExactCoreLibraryTest(BaseCoreLibraryTest):

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -172,13 +172,14 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
     def test_lookup_adds_source(self):
         # Overwrite the source_name attribute
-        self.backend1.source_name.get.return_value = 'hamspam'
+        source = 'hamspam'
+        self.backend1.source_name.get.return_value = source
 
-        track = Track(name='abc', source='hamspam')
-        self.library1.lookup().get.return_value = [track]
+        track = Track(name='abc')
+        self.library1.lookup.return_value.get.return_value = [track]
 
         result = self.core.library.lookup(uris=['dummy1:a'])
-        assert result == {'dummy1:a': [track]}
+        assert result == {'dummy1:a': [track.replace(source=source)]}
 
     def test_refresh_with_uri_selects_dummy1_backend(self):
         self.core.library.refresh('dummy1:a')

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -26,12 +26,14 @@ class CorePlaybackTest(unittest.TestCase):
 
         self.backend1 = mock.Mock()
         self.backend1.uri_schemes.get.return_value = ['dummy1']
+        self.backend1.source_name.get.return_value = None
         self.playback1 = mock.Mock(spec=backend.PlaybackProvider)
         self.playback1.get_time_position.return_value.get.return_value = 1000
         self.backend1.playback = self.playback1
 
         self.backend2 = mock.Mock()
         self.backend2.uri_schemes.get.return_value = ['dummy2']
+        self.backend2.source_name.get.return_value = None
         self.playback2 = mock.Mock(spec=backend.PlaybackProvider)
         self.playback2.get_time_position.return_value.get.return_value = 2000
         self.backend2.playback = self.playback2
@@ -40,6 +42,7 @@ class CorePlaybackTest(unittest.TestCase):
         self.backend3 = mock.Mock()
         self.backend3.uri_schemes.get.return_value = ['dummy3']
         self.backend3.has_playback().get.return_value = False
+        self.backend3.source_name.get.return_value = None
 
         self.tracks = [
             Track(uri='dummy1:a', length=40000),
@@ -725,6 +728,7 @@ class CorePlaybackWithOldBackendTest(unittest.TestCase):
 
         b = mock.Mock()
         b.uri_schemes.get.return_value = ['dummy1']
+        b.source_name.get.return_value = None
         b.playback = mock.Mock(spec=backend.PlaybackProvider)
         b.playback.play.side_effect = TypeError
         b.library.lookup.return_value.get.return_value = [
@@ -747,6 +751,7 @@ class TestPlay(unittest.TestCase):
 
         self.backend = mock.Mock()
         self.backend.uri_schemes.get.return_value = ['dummy']
+        self.backend.source_name.get.return_value = None
         self.core = core.Core(config, backends=[self.backend])
 
         self.tracks = [Track(uri='dummy:a', length=1234),
@@ -771,6 +776,7 @@ class Bug1177RegressionTest(unittest.TestCase):
 
         b = mock.Mock()
         b.uri_schemes.get.return_value = ['dummy']
+        b.source_name.get.return_value = None
         b.playback = mock.Mock(spec=backend.PlaybackProvider)
         b.playback.change_track.return_value.get.return_value = True
         b.playback.play.return_value.get.return_value = True

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -31,6 +31,7 @@ class TracklistTest(unittest.TestCase):
 
         self.backend = mock.Mock()
         self.backend.uri_schemes.get.return_value = ['dummy1']
+        self.backend.source_name.get.return_value = None
         self.library = mock.Mock(spec=backend.LibraryProvider)
         self.library.lookup.side_effect = lookup
         self.backend.library = self.library

--- a/tests/local/test_library.py
+++ b/tests/local/test_library.py
@@ -41,27 +41,35 @@ class LocalLibraryProviderTest(unittest.TestCase):
         Track(
             uri='local:track:path1', name='track1',
             artists=[artists[0]], album=albums[0],
-            date='2001-02-03', length=4000, track_no=1),
+            date='2001-02-03', length=4000, track_no=1,
+            source='local'),
         Track(
             uri='local:track:path2', name='track2',
             artists=[artists[1]], album=albums[1],
-            date='2002', length=4000, track_no=2),
+            date='2002', length=4000, track_no=2,
+            source='local'),
         Track(
             uri='local:track:path3', name='track3',
             artists=[artists[3]], album=albums[2],
-            date='2003', length=4000, track_no=3),
+            date='2003', length=4000, track_no=3,
+            source='local'),
         Track(
             uri='local:track:path4', name='track4',
             artists=[artists[2]], album=albums[3],
             date='2004', length=60000, track_no=4,
-            comment='This is a fantastic track'),
+            comment='This is a fantastic track',
+            source='local'),
         Track(
             uri='local:track:path5', name='track5', genre='genre1',
-            album=albums[3], length=4000, composers=[artists[4]]),
+            album=albums[3], length=4000, composers=[artists[4]],
+            source='local'),
         Track(
             uri='local:track:path6', name='track6', genre='genre2',
-            album=albums[3], length=4000, performers=[artists[5]]),
-        Track(uri='local:track:nameless', album=albums[-1]),
+            album=albums[3], length=4000, performers=[artists[5]],
+            source='local'),
+        Track(
+            uri='local:track:nameless', album=albums[-1],
+            source='local'),
     ]
 
     config = {
@@ -114,7 +122,7 @@ class LocalLibraryProviderTest(unittest.TestCase):
 
             # Sanity check that value is in the library
             result = backend.library.lookup(self.tracks[0].uri)
-            self.assertEqual(result, self.tracks[0:1])
+            self.assertEqual(result, [self.tracks[0].replace(source=None)])
 
             # Clear and refresh.
             open(tmplib, 'w').close()
@@ -134,7 +142,8 @@ class LocalLibraryProviderTest(unittest.TestCase):
     def test_lookup(self):
         uri = self.tracks[0].uri
         result = self.library.lookup(uris=[uri])
-        self.assertEqual(result[uri], self.tracks[0:1])
+        tracks = [self.tracks[0].replace(source='local')]
+        self.assertEqual(result[uri], tracks)
 
     def test_lookup_unknown_track(self):
         tracks = self.library.lookup(uris=['fake:/uri'])


### PR DESCRIPTION
This fixes issue #1108.

- New field `source` in `Track` model
- Can be influenced by setting the `source_name` attribute on the backend (should we use `source` there too?)
- The attribute is set automatically by core/library during lookup and search
- Existing tests have been fixed
- Two tests are provided
- Changelog has been updated

Please review this well, especially the tests. I hope I didn't break the logic of any tests :)

Are all cases covered in which songs are added to the playback queue?

Also, right now there's no fallback to using `ext_name` if a backend doesn't set the name. Would that be possible somehow?