### PR TITLE
tests: fix test breakage due to promotion from int to long

### DIFF
--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -192,7 +192,7 @@ def _find(root, thread_count=10, relative=False, follow=False):
 
 def find_mtimes(root, follow=False):
     results, errors = _find(root, relative=False, follow=follow)
-    mtimes = dict((f, int(st.st_mtime * 1000)) for f, st in results.items())
+    mtimes = dict((f, int(st.st_mtime) * 1000) for f, st in results.items())
     return mtimes, errors
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -32,6 +32,6 @@ class IsA(object):
         return str(self.klass)
 
 
-any_int = IsA(int)
+any_int = IsA((int, long))
 any_str = IsA(str)
 any_unicode = IsA(compat.text_type)

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -40,7 +40,7 @@ class PlaybackHistoryTest(unittest.TestCase):
         result = self.history.get_history()
         (timestamp, ref) = result[0]
 
-        self.assertIsInstance(timestamp, int)
+        self.assertIsInstance(timestamp, (int, long))
         self.assertEqual(track.uri, ref.uri)
         self.assertIn(track.name, ref.name)
         for artist in track.artists:


### PR DESCRIPTION
In internals/path.py. there is a snippet of code that multiples mtime
for a file with 1000, and then casting it to `int`. This pseudo-casting
is pointless, as it only truncates to an integer (whole number), instead
of actuallly ensuring the type is an <int>.

>>> type(int(2**32))
<type 'long'>

Instead, fix the tests to look for (int, long).

This bug found on a 32-bit VM :)