### PR TITLE
stream: Ignore file protocol if Mopidy-File is enabled

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 
 This changelog is used to track all major changes to Mopidy.
 
+
+v1.1.1 (UNRELEASED)
+===================
+
+Bug fix release.
+
+- Stream: If "file" is present in the :confval:`stream/protocols` config value
+  and the :ref:`ext-file` extension is enabled, we exited with an error because
+  two extensions claimed the same URI scheme. We now log a warning recommending
+  to remove "file" from the :confval:`stream/protocols` config, and then
+  proceed startup. (Fixes: :issue:`1248`, PR: :issue:`1254`)
+
+
 v1.1.0 (2015-08-09)
 ===================
 

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -36,6 +36,13 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
         self.uri_schemes = audio_lib.supported_uri_schemes(
             config['stream']['protocols'])
 
+        if 'file' in self.uri_schemes and config['file']['enabled']:
+            logger.warning(
+                'The stream/protocols config value includes the "file" '
+                'protocol. "file" playback is now handled by Mopidy-File. '
+                'Please remove it from the stream/protocols config.')
+            self.uri_schemes -= {'file'}
+
 
 class StreamLibraryProvider(backend.LibraryProvider):
 


### PR DESCRIPTION
If Mopidy-File is enabled it handles playback of file:// URIs.

Mopidy-Stream used to do this, but in Mopidy 1.1 we removed "file" from
the default value of the stream/protocols config. However, many users
upgrading to Mopidy 1.1 have set stream/protocols to include "file" in
their existing config, and thus Mopidy fails to start because both
backends tries to claim the "file" protocol.

Fixes #1248