### PR TITLE
audio: Fix scan timeout handling

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,6 +21,9 @@ Bug fix release.
   with a limited set of environment variables. (Fixes: :issue:`1249`, PR:
   :issue:`1255`)
 
+- Audio: Fix timeout handling in scanner. This regression caused timeouts to
+  expire before it should, causing scans to fail.
+
 
 v1.1.0 (2015-08-09)
 ===================

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -139,7 +139,7 @@ def _process(pipeline, timeout_ms):
     types = (gst.MESSAGE_ELEMENT | gst.MESSAGE_APPLICATION | gst.MESSAGE_ERROR
              | gst.MESSAGE_EOS | gst.MESSAGE_ASYNC_DONE | gst.MESSAGE_TAG)
 
-    start = clock.get_time()
+    previous = clock.get_time()
     while timeout > 0:
         message = bus.timed_pop_filtered(timeout, types)
 
@@ -171,7 +171,9 @@ def _process(pipeline, timeout_ms):
             # Note that this will only keep the last tag.
             tags.update(utils.convert_taglist(taglist))
 
-        timeout -= clock.get_time() - start
+        now = clock.get_time()
+        timeout -= now - previous
+        previous = now
 
     raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)
 


### PR DESCRIPTION
Seems I broke this back in match with 9e8b3263abf5fa8529dedeb46392f8f19eb723f4, could also be back-ported easily to 1.0.x as this was introduced for 1.0.0