### PR TITLE
audio: Make scanner report MIME for missing plugins

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,9 @@ Bug fix release.
 - Audio: Fix timeout handling in scanner. This regression caused timeouts to
   expire before it should, causing scans to fail.
 
+- Audio: Update scanner to emit MIME type instead of an error when missing a
+  plugin.
+
 
 v1.1.0 (2015-08-09)
 ===================

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -109,6 +109,17 @@ class ScannerTest(unittest.TestCase):
         wav = path_to_data_dir('scanner/empty.wav')
         self.assertEqual(self.result[wav].duration, 0)
 
+    def test_uri_list(self):
+        path = path_to_data_dir('scanner/playlist.m3u')
+        self.scan([path])
+        self.assertEqual(self.result[path].mime, 'text/uri-list')
+
+    def test_text_plain(self):
+        # GStreamer decode bin hardcodes bad handling of text plain :/
+        path = path_to_data_dir('scanner/plain.txt')
+        self.scan([path])
+        self.assertIn(path, self.errors)
+
     @unittest.SkipTest
     def test_song_without_time_is_handeled(self):
         pass

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -40,8 +40,11 @@ class ScannerTest(unittest.TestCase):
         self.assertEqual(self.result[name].tags[key], value)
 
     def check_if_missing_plugin(self):
-        if any(['missing a plug-in' in str(e) for e in self.errors.values()]):
-            raise unittest.SkipTest('Missing MP3 support?')
+        for path, result in self.result.items():
+            if not path.endswith('.mp3'):
+                continue
+            if not result.playable and result.mime == 'audio/mpeg':
+                raise unittest.SkipTest('Missing MP3 support?')
 
     def test_tags_is_set(self):
         self.scan(self.find('scanner/simple'))

--- a/tests/data/scanner/plain.txt
+++ b/tests/data/scanner/plain.txt
@@ -1,0 +1,1 @@
+Some plain text file with nothing special in it.

--- a/tests/data/scanner/playlist.m3u
+++ b/tests/data/scanner/playlist.m3u
@@ -1,0 +1,1 @@
+http://example.com/


### PR DESCRIPTION
Pre 1.1 we didn't notice this as we had built in support for MIMEs like text/uri-list, so at least we don't need to backport anything.