### PR TITLE
local: Lower the default scan_flush_threshold

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,10 @@ Bug fix release.
   :confval:`core/data_dir`, like the Debian and Arch packages. (Fixes:
   :issue:`1259`, PR: :issue:`1266`)
 
+- Local: Change default value of :confval:`local/scan_flush_threshold` from
+  1000 to 100 to shorten the time Mopidy-Local-SQLite blocks incoming requests
+  while scanning the local library.
+
 - M3U: Changed default for the :confval:`m3u/playlists_dir` from
   ``$XDG_DATA_DIR/mopidy/m3u`` to unset, which now means the extension's data
   dir. This does not change the defaults for desktop users, only system

--- a/mopidy/local/ext.conf
+++ b/mopidy/local/ext.conf
@@ -3,7 +3,7 @@ enabled = true
 library = json
 media_dir = $XDG_MUSIC_DIR
 scan_timeout = 1000
-scan_flush_threshold = 1000
+scan_flush_threshold = 100
 scan_follow_symlinks = false
 excluded_file_extensions =
   .directory


### PR DESCRIPTION
@tkem recommends that this is reduced from 1000 to maximum 100 to not
block incoming requests to Mopidy-Local-SQLite for too long while
scanning the local library.