### PR TITLE
Log error and return 1 if scan attempts to load nonexistent library

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -14,6 +14,9 @@ Bug fix release.
   example Ogg Vorbis has the MIME type ``application/ogg``. (Fixes:
   :issue:`1299`)
 
+- Local: If the scan or clear commands are used on a library that does not
+  exist, return an error. Raise level of error when getting nonexistent library
+  from warning to error. (Fixes: :issue:`1298`)
 
 v1.2.0 (UNRELEASED)
 ===================

--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -76,6 +76,9 @@ class ScanCommand(commands.Command):
             bytes(file_ext.lower()) for file_ext in excluded_file_extensions)
 
         library = _get_library(args, config)
+        if library == 1:
+            logger.error('Unable to scan local library: does not exist')
+            return 1
 
         file_mtimes, file_errors = path.find_mtimes(
             media_dir, follow=config['local']['scan_follow_symlinks'])

--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -21,8 +21,8 @@ def _get_library(args, config):
     library_name = config['local']['library']
 
     if library_name not in libraries:
-        logger.warning('Local library %s not found', library_name)
-        return 1
+        logger.error('Local library %s not found', library_name)
+        return None
 
     logger.debug('Using %s as the local library', library_name)
     return libraries[library_name](config)
@@ -41,6 +41,9 @@ class ClearCommand(commands.Command):
 
     def run(self, args, config):
         library = _get_library(args, config)
+        if library is None:
+            return 1
+
         prompt = '\nAre you sure you want to clear the library? [y/N] '
 
         if compat.input(prompt).lower() != 'y':
@@ -76,8 +79,7 @@ class ScanCommand(commands.Command):
             bytes(file_ext.lower()) for file_ext in excluded_file_extensions)
 
         library = _get_library(args, config)
-        if library == 1:
-            logger.error('Unable to scan local library: does not exist')
+        if library is None:
             return 1
 
         file_mtimes, file_errors = path.find_mtimes(


### PR DESCRIPTION
Resolves issue #1298 by returning an error if scan command is used to scan a nonexistent library.