### PR TITLE
core: Cleanup track ended event handling

### DIFF
--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -347,11 +347,11 @@ class EventEmissionTest(BaseTest):
             listener_mock.send.mock_calls,
             [
                 mock.call(
-                    'track_playback_ended',
-                    tl_track=tl_tracks[0], time_position=mock.ANY),
-                mock.call(
                     'playback_state_changed',
                     old_state='paused', new_state='playing'),
+                mock.call(
+                    'track_playback_ended',
+                    tl_track=tl_tracks[0], time_position=mock.ANY),
                 mock.call(
                     'track_playback_started', tl_track=tl_tracks[1]),
             ])
@@ -371,11 +371,11 @@ class EventEmissionTest(BaseTest):
             listener_mock.send.mock_calls,
             [
                 mock.call(
-                    'track_playback_ended',
-                    tl_track=tl_tracks[0], time_position=mock.ANY),
-                mock.call(
                     'playback_state_changed', old_state='playing',
                     new_state='playing'),
+                mock.call(
+                    'track_playback_ended',
+                    tl_track=tl_tracks[0], time_position=mock.ANY),
                 mock.call(
                     'track_playback_started', tl_track=tl_tracks[2]),
             ])


### PR DESCRIPTION
Trigger playback ended on:
- stream changed
- EOS
- stop via stream changed events

Old behavior was to manually trigger on:
- next
- prev
- play with other track and old state != STOPPED
- stop