### PR TITLE
Handle exceptions in load_extensions

### DIFF
--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -198,7 +198,13 @@ def load_extensions():
 
     for entry_point in pkg_resources.iter_entry_points('mopidy.ext'):
         logger.debug('Loading entry point: %s', entry_point)
-        extension_class = entry_point.load(require=False)
+        try:
+            extension_class = entry_point.load(require=False)
+        except Exception as e:
+            logger.exception("Failed to load extension {}: {}".format(
+                entry_point.name, e
+            ), exc_info=e)
+            continue
 
         try:
             if not issubclass(extension_class, Extension):

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -201,9 +201,8 @@ def load_extensions():
         try:
             extension_class = entry_point.load(require=False)
         except Exception as e:
-            logger.exception("Failed to load extension {}: {}".format(
-                entry_point.name, e
-            ), exc_info=e)
+            logger.exception("Failed to load extension %s: %s" % (
+                entry_point.name, e))
             continue
 
         try:


### PR DESCRIPTION
This will skip those extensions, instead of crashing mopidy, e.g. when
mopidy-mopify fails because of a missing HOME environment variable
during mopidy's tests.
Ref: https://github.com/dirkgroenen/mopidy-mopify/issues/119

Please note that the error will not show up with `--help`, because the logging is not setup then yet.