### PR TITLE
Pass unicode string to `path.is_path_inside_base_dir`

### DIFF
--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -132,5 +132,6 @@ class FileLibraryProvider(backend.LibraryProvider):
 
     def _is_in_basedir(self, local_path):
         return any(
-            path.is_path_inside_base_dir(local_path, media_dir['path'])
+            path.is_path_inside_base_dir(local_path.decode(FS_ENCODING),
+                                         media_dir['path'])
             for media_dir in self._media_dirs)


### PR DESCRIPTION
`is_path_inside_base_dir` expects a unicode string, while the strings
from `os.listdir` are 8-bit strings (because `local_path` is one also)
[1].

This fixes the following error:

```
ERROR    FileBackend backend caused an exception.
Traceback (most recent call last):
  File "…/mopidy/mopidy/core/library.py", line 19, in _backend_error_handling
    yield
  File "…/mopidy/mopidy/core/library.py", line 112, in _browse
    result = backend.library.browse(uri).get()
  File "/usr/lib/python2.7/site-packages/pykka/future.py", line 299, in get
    exec('raise exc_info[0], exc_info[1], exc_info[2]')
  File "/usr/lib/python2.7/site-packages/pykka/actor.py", line 200, in _actor_loop
    response = self._handle_receive(message)
  File "/usr/lib/python2.7/site-packages/pykka/actor.py", line 294, in _handle_receive
    return callee(*message['args'], **message['kwargs'])
  File "…/mopidy/mopidy/file/library.py", line 67, in browse
    if not self._is_in_basedir(os.path.realpath(child_path)):
  File "…/mopidy/mopidy/file/library.py", line 136, in _is_in_basedir
    for media_dir in self._media_dirs)
  File "…/mopidy/mopidy/file/library.py", line 136, in <genexpr>
    for media_dir in self._media_dirs)
  File "…/mopidy/mopidy/internal/path.py", line 213, in is_path_inside_base_dir
    common_prefix = os.path.commonprefix([real_base_path, real_path])
  File "…/pyenv/mopidy/lib/python2.7/genericpath.py", line 79, in commonprefix
    s1 = min(m)
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 15: ordinal not in range(128)
```

1: https://docs.python.org/2/howto/unicode.html#unicode-filenames