### PR TITLE
Test cases for checking that unplayable tracks are consumed. 

### DIFF
--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -388,6 +388,25 @@ class CorePlaybackTest(unittest.TestCase):
 
         self.assertNotIn(tl_track, self.core.tracklist.tl_tracks)
 
+    def test_next_in_consume_mode_removes_unplayable_track(self):
+        self.backend1.playback.change_track = mock.PropertyMock()
+        self.backend1.playback.change_track.return_value.get.return_value = \
+            False
+
+        self.backend2.playback.change_track = mock.PropertyMock()
+        self.backend2.playback.change_track.return_value.get.return_value = \
+            False
+        self.core.tracklist.consume = True
+
+        self.core.playback.play(self.tl_tracks[0])
+        self.core.playback.next()
+
+        self.assertNotIn(self.tl_tracks[1], self.core.tracklist.tl_tracks)
+        self.assertNotIn(self.tl_tracks[2], self.core.tracklist.tl_tracks)
+
+        self.backend1.playback.change_track.reset_mock()
+        self.backend2.playback.change_track.reset_mock()
+
     @mock.patch(
         'mopidy.core.playback.listener.CoreListener', spec=core.CoreListener)
     def test_next_emits_events(self, listener_mock):
@@ -789,3 +808,65 @@ class Bug1177RegressionTest(unittest.TestCase):
         c.playback.pause()
         c.playback.next()
         b.playback.change_track.assert_called_once_with(track2)
+
+
+class Bug1358RegressionTest(unittest.TestCase):
+
+    def setUp(self):  # noqa: N802
+        config = {
+            'core': {
+                'max_tracklist_length': 10000,
+            }
+        }
+
+        self.backend1 = mock.Mock()
+        self.backend1.uri_schemes.get.return_value = ['dummy1']
+        self.playback1 = mock.Mock(spec=backend.PlaybackProvider)
+        self.backend1.playback.change_track.return_value.get.return_value = \
+            False
+        self.backend1.playback = self.playback1
+
+        self.backend2 = mock.Mock()
+        self.backend2.uri_schemes.get.return_value = ['dummy2']
+        self.playback2 = mock.Mock(spec=backend.PlaybackProvider)
+        self.backend1.playback.change_track.return_value.get.return_value = \
+            False
+        self.backend2.playback = self.playback2
+
+        self.tracks = [
+            Track(uri='dummy1:a', length=40000),
+            Track(uri='dummy2:a', length=40000),
+        ]
+
+        self.uris = [
+            'dummy1:a', 'dummy2:a']
+
+        self.core = core.Core(config, mixer=None,
+                              backends=[self.backend1, self.backend2])
+
+        def lookup(uris):
+            result = {uri: [] for uri in uris}
+            for track in self.tracks:
+                if track.uri in result:
+                    result[track.uri].append(track)
+            return result
+
+        self.lookup_patcher = mock.patch.object(self.core.library, 'lookup')
+        self.lookup_mock = self.lookup_patcher.start()
+        self.lookup_mock.side_effect = lookup
+
+        self.core.tracklist.add(uris=self.uris)
+
+        self.tl_tracks = self.core.tracklist.tl_tracks
+
+    def tearDown(self):  # noqa: N802
+        self.lookup_patcher.stop()
+
+    def test_next_in_consume_mode_removes_unplayable_track(self):
+        self.core.tracklist.consume = True
+
+        self.core.playback.play(self.tl_tracks[0])
+        self.core.playback.next()
+
+        self.assertNotIn(self.tl_tracks[0], self.core.tracklist.tl_tracks)
+        self.assertNotIn(self.tl_tracks[1], self.core.tracklist.tl_tracks)


### PR DESCRIPTION
So, it turns out this does not work the way I thought after all.

Although ``_mark_unplayable`` does not actually remove the tracks, ``core.PlaybackController.next()`` is eventually called for every track (even unplayable ones), which in turn invokes ``self.core.tracklist._mark_played(original_tl_track)``` to remove the track from the tracklist.

I've written a few test cases to prove the point, for the interested reader.
