### PR TITLE
core: Add PlaylistsController.get_uri_schemes().

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -161,6 +161,8 @@ Playlists controller
 
 .. class:: mopidy.core.PlaylistsController
 
+.. automethod:: mopidy.core.PlaylistsController.get_uri_schemes
+
 Fetching
 --------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,9 @@ Core API
   seek target while a seek is in progress.  This gives better results than just
   failing the position query. (Fixes: :issue:`312` PR: :issue:`1346`)
 
+- Add :meth:`mopidy.core.PlaylistsController.get_uri_schemes`. (PR:
+  :issue:`1362`)
+
 Models
 ------
 

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -33,6 +33,16 @@ class PlaylistsController(object):
         self.backends = backends
         self.core = core
 
+    def get_uri_schemes(self):
+        """
+        Get the list of URI schemes that support playlists.
+
+        :rtype: list of string
+
+        .. versionadded:: 1.2
+        """
+        return list(sorted(self.backends.with_playlists.keys()))
+
     def as_list(self):
         """
         Get a list of the currently available playlists.

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -248,6 +248,10 @@ class PlaylistTest(BasePlaylistsTest):
         self.assertFalse(self.sp1.save.called)
         self.assertFalse(self.sp2.save.called)
 
+    def test_get_uri_schemes(self):
+        result = self.core.playlists.get_uri_schemes()
+        self.assertEquals(result, ['dummy1', 'dummy2'])
+
 
 class DeprecatedFilterPlaylistsTest(BasePlaylistsTest):
 


### PR DESCRIPTION
Adds a new method `PlaylistsController.get_uri_schemes()` which mirrors `Core.get_uri_schemes()`, but only returns schemes for backends with a playlists provider.

This can be used by clients which want to pass the optional `uri_scheme` parameter to `PlaylistsController.create()`. Without this, clients will usually

- do not use the `uri_scheme` parameter at all, so playlists get created by the *first* backend that provides playlists (not always what's desired, and there need not be a playlist-aware backend installed)

- set `uri_scheme` to a hard-coded value, for example `m3u`, which may not even be available

- let the user choose from the URI schemes provided by `Core.get_uri_schemes()`, which reports backends that don't provide playlist support, too

See also https://github.com/tkem/mopidy-mobile/issues/146 for the original motivation for this.

Would be nice if this could be included in v1.2.
