### PR TITLE
m3u: Derive track name from file name for non-extended M3U playlists.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,12 @@ Local backend
 - Made :confval:`local/data_dir` really deprecated. This change breaks older
   versions of Mopidy-Local-SQLite and Mopidy-Local-Images.
 
+M3U backend
+-----------
+
+- Derive track name from file name for non-extended M3U
+  playlists. (Fixes: :issue:`1364`, PR: :issue:`1369`)
+
 MPD frontend
 ------------
 

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -99,7 +99,9 @@ def parse_m3u(file_path, media_dir=None):
             if extended and line.startswith('#EXTINF'):
                 track = m3u_extinf_to_track(line)
             continue
-
+        if not track.name:
+            name = os.path.basename(os.path.splitext(line)[0])
+            track = track.replace(name=urllib.parse.unquote(name))
         if urllib.parse.urlsplit(line).scheme:
             tracks.append(track.replace(uri=line))
         elif os.path.normpath(line) == os.path.abspath(line):

--- a/tests/data/comment-ext.m3u
+++ b/tests/data/comment-ext.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
 # test
-#EXTINF:-1,song1
+#EXTINF:-1,Song #1
 # test
 song1.mp3

--- a/tests/data/one-ext.m3u
+++ b/tests/data/one-ext.m3u
@@ -1,3 +1,3 @@
 #EXTM3U
-#EXTINF:-1,song1
+#EXTINF:-1,Song #1
 song1.mp3

--- a/tests/data/two-ext.m3u
+++ b/tests/data/two-ext.m3u
@@ -1,5 +1,5 @@
 #EXTM3U
-#EXTINF:-1,song1
+#EXTINF:-1,Song #1
 song1.mp3
-#EXTINF:60,song2
+#EXTINF:60,Song #2
 song2.mp3

--- a/tests/m3u/test_translator.py
+++ b/tests/m3u/test_translator.py
@@ -20,13 +20,15 @@ encoded_path = path_to_data_dir('æøå.mp3')
 song1_uri = path.path_to_uri(song1_path)
 song2_uri = path.path_to_uri(song2_path)
 song3_uri = path.path_to_uri(song3_path)
+song4_uri = 'http://example.com/foo%20bar.mp3'
 encoded_uri = path.path_to_uri(encoded_path)
-song1_track = Track(uri=song1_uri)
-song2_track = Track(uri=song2_uri)
-song3_track = Track(uri=song3_uri)
-encoded_track = Track(uri=encoded_uri)
-song1_ext_track = song1_track.replace(name='song1')
-song2_ext_track = song2_track.replace(name='song2', length=60000)
+song1_track = Track(name='song1', uri=song1_uri)
+song2_track = Track(name='song2', uri=song2_uri)
+song3_track = Track(name='φοο', uri=song3_uri)
+song4_track = Track(name='foo bar', uri=song4_uri)
+encoded_track = Track(name='æøå', uri=encoded_uri)
+song1_ext_track = song1_track.replace(name='Song #1')
+song2_ext_track = song2_track.replace(name='Song #2', length=60000)
 encoded_ext_track = encoded_track.replace(name='æøå')
 
 
@@ -84,9 +86,11 @@ class M3UToUriTest(unittest.TestCase):
     def test_file_with_uri(self):
         with tempfile.NamedTemporaryFile(delete=False) as tmp:
             tmp.write(song1_uri)
+            tmp.write('\n')
+            tmp.write(song4_uri)
         try:
             tracks = self.parse(tmp.name)
-            self.assertEqual([song1_track], tracks)
+            self.assertEqual([song1_track, song4_track], tracks)
         finally:
             if os.path.exists(tmp.name):
                 os.remove(tmp.name)


### PR DESCRIPTION
Basically just @Joolee's patch for providing a sensible track name for non-extended M3Us; see #1364.
Other issues from #1364 will be addressed separately in #1370.