### PR TITLE
Handle missing or empty 'port' configuration parameter.

### DIFF
--- a/mopidy/httpclient.py
+++ b/mopidy/httpclient.py
@@ -21,8 +21,8 @@ def format_proxy(proxy_config, auth=True):
     if not proxy_config.get('hostname'):
         return None
 
-    port = proxy_config.get('port', 80)
-    if port < 0:
+    port = proxy_config.get('port')
+    if not port or port < 0:
         port = 80
 
     if proxy_config.get('username') and proxy_config.get('password') and auth:

--- a/tests/test_httpclient.py
+++ b/tests/test_httpclient.py
@@ -9,6 +9,7 @@ from mopidy import httpclient
 
 @pytest.mark.parametrize("config,expected", [
     ({}, None),
+    ({'hostname': ''}, None),
     ({'hostname': 'proxy.lan'}, 'http://proxy.lan:80'),
     ({'scheme': None, 'hostname': 'proxy.lan'}, 'http://proxy.lan:80'),
     ({'scheme': 'https', 'hostname': 'proxy.lan'}, 'https://proxy.lan:80'),
@@ -16,6 +17,8 @@ from mopidy import httpclient
     ({'password': 'pass', 'hostname': 'proxy.lan'}, 'http://proxy.lan:80'),
     ({'hostname': 'proxy.lan', 'port': 8080}, 'http://proxy.lan:8080'),
     ({'hostname': 'proxy.lan', 'port': -1}, 'http://proxy.lan:80'),
+    ({'hostname': 'proxy.lan', 'port': None}, 'http://proxy.lan:80'),
+    ({'hostname': 'proxy.lan', 'port': ''}, 'http://proxy.lan:80'),
     ({'username': 'user', 'password': 'pass', 'hostname': 'proxy.lan'},
      'http://user:pass@proxy.lan:80'),
 ])


### PR DESCRIPTION
Logic and test case to handle situation where the ```port``` parameter is either missing from the configuration file entirely, or set to an empty string.