### PR TITLE
Fix documentation typos and inconsistencies.

### DIFF
--- a/docs/clients/mpd.rst
+++ b/docs/clients/mpd.rst
@@ -167,5 +167,5 @@ projects are a real match made in heaven."
 Partify
 -------
 
-`Partify <https://github.com/fhats/partify>`_ is a web based MPD client focusing on
+`Partify <https://github.com/fhats/partify>`_ is a web based MPD client focussing on
 making music playing collaborative and social.

--- a/docs/ext/frontends.rst
+++ b/docs/ext/frontends.rst
@@ -81,4 +81,4 @@ Mopidy-Webhooks
 https://github.com/paddycarey/mopidy-webhooks
 
 Extension for sending HTTP POST requests with JSON payloads to a remote server
-on when Mopidy core triggers an event and on regular intervals.
+when Mopidy core triggers an event and on regular intervals.

--- a/docs/ext/mixers.rst
+++ b/docs/ext/mixers.rst
@@ -17,7 +17,7 @@ Mopidy-ALSAMixer
 
 https://github.com/mopidy/mopidy-alsamixer
 
-Extension for controlling volume one a Linux system using ALSA.
+Extension for controlling volume on a Linux system using ALSA.
 
 
 Mopidy-Arcam

--- a/docs/ext/web.rst
+++ b/docs/ext/web.rst
@@ -35,8 +35,8 @@ Mopidy-Local-Images
 
 https://github.com/tkem/mopidy-local-images
 
-Not a full-featured Web client, but rather a local library and Web
-extension which allows other Web clients access to album art embedded
+Not a full-featured web client, but rather a local library and web
+extension which allows other web clients access to album art embedded
 in local media files.
 
 .. image:: /ext/local_images.jpg
@@ -69,7 +69,7 @@ Mopidy-Mobile
 
 https://github.com/tkem/mopidy-mobile
 
-A Mopidy Web client extension and hybrid mobile app, made with Ionic,
+A Mopidy web client extension and hybrid mobile app, made with Ionic,
 AngularJS and Apache Cordova by Thomas Kemmer.
 
 .. image:: /ext/mobile.png
@@ -132,18 +132,6 @@ To install, run::
 
     pip install Mopidy-MusicBox-Webclient
 
-Mopidy-Party
-============
-
-https://github.com/Lesterpig/mopidy-party
-
-Minimal web client designed for collaborative music management during parties.
-
-.. image:: /ext/mopidy_party.png
-
-To install, run::
-
-    pip install Mopidy-Party
 
 Mopidy-Party
 ============


### PR DESCRIPTION
Fixes a few typos I came across while going through the documentation.

The entry for Mopidy-Party was duplicated, so I've removed one of those as well.

