### PR TITLE
docs: Provide details on PR procedure for bug fix releases

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -126,3 +126,11 @@ Pull request guidelines
 
 #. Send a pull request to the ``develop`` branch. See the `GitHub pull request
    docs <https://help.github.com/articles/using-pull-requests>`_ for help.
+
+.. note::
+
+    If you are contributing a bug fix for a specific minor version of Mopidy
+    you should create the branch based on ``release-x.y`` instead of
+    ``develop``. When the release is done the changes will be merged back into
+    ``develop`` automatically as part of the normal release process. See
+    :ref:`creating-releases`.

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -6,6 +6,7 @@ Here we try to keep an up to date record of how Mopidy releases are made. This
 documentation serves both as a checklist, to reduce the project's dependency on
 key individuals, and as a stepping stone to more automation.
 
+.. _creating-releases:
 
 Creating releases
 =================


### PR DESCRIPTION
Adds a note that describes the process for submitting a bug fix PR for an existing minor release of Mopidy.

Contains the proposed changes required for https://github.com/mopidy/mopidy/issues/1355.

I thought just adding a note at the bottom of the page was sufficient instead of starting a whole new section (as the process is so similar to submitting a PR for 'develop')?