### PR TITLE
Skip over unplayable tracks when paused

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -21,7 +21,15 @@ Bug fix release.
 
 - Core: Fix bug in playback controller. If changing to another track while
   the player is paused, the new track would not be added to the history or
-  marked as currently playing. (Fixes: :issue:`1352`)
+  marked as currently playing. (Fixes: :issue:`1352`) Also skips over
+  unplayable tracks if the user attempts to change tracks while paused.
+  (Fixes :issue:`1378`).
+
+- Main: Catch errors when loading :confval:`logging/config_file`. (Fixes:
+  :issue:`1320`)
+
+- MPD: Don't return tracks with empty URIs. (Partly fixes: :issue:`1340`, PR:
+  :issue:`1343`)
 
 - Main: Catch errors when loading :confval:`logging/config_file`. (Fixes:
   :issue:`1320`)

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,12 +31,6 @@ Bug fix release.
 - MPD: Don't return tracks with empty URIs. (Partly fixes: :issue:`1340`, PR:
   :issue:`1343`)
 
-- Main: Catch errors when loading :confval:`logging/config_file`. (Fixes:
-  :issue:`1320`)
-
-- MPD: Don't return tracks with empty URIs. (Partly fixes: :issue:`1340`, PR:
-  :issue:`1343`)
-
 
 v1.1.1 (2015-09-14)
 ===================

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -217,8 +217,7 @@ class PlaybackController(object):
                     self.core.tracklist._mark_playing(tl_track)
                     self.core.history._add_track(tl_track.track)
                 else:
-                    self.core.tracklist._mark_unplayable(
-                        self.get_current_tl_track())
+                    self.core.tracklist._mark_unplayable(tl_track)
                     if on_error_step == 1:
                         # TODO: can cause an endless loop for single track
                         # repeat.

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -207,8 +207,8 @@ class PlaybackController(object):
         if old_state == PlaybackState.PLAYING:
             self._play(on_error_step=on_error_step)
         elif old_state == PlaybackState.PAUSED:
-            # NOTE: this is just a quick hack to fix #1177 and #1352 as this
-            # code has already been killed in the gapless branch.
+            # NOTE: this is just a quick hack to fix #1177, #1352, and #1378
+            # as this code has already been killed in the gapless branch.
             backend = self._get_backend()
             if backend:
                 backend.playback.prepare_change()
@@ -216,7 +216,16 @@ class PlaybackController(object):
                 if success:
                     self.core.tracklist._mark_playing(tl_track)
                     self.core.history._add_track(tl_track.track)
-            self.pause()
+                else:
+                    self.core.tracklist._mark_unplayable(
+                        self.get_current_tl_track())
+                    if on_error_step == 1:
+                        # TODO: can cause an endless loop for single track
+                        # repeat.
+                        self.next()
+                    elif on_error_step == -1:
+                        self.previous()
+                self.pause()
 
     # TODO: this is not really end of track, this is on_need_next_track
     def _on_end_of_track(self):


### PR DESCRIPTION
Proposed fixes for https://github.com/mopidy/mopidy/issues/1378.

This PR is based on https://github.com/mopidy/mopidy/pull/1356 as the changes overlap somewhat, so should probably be merged in that sequence.

The quick fix in ```PlaybackController._change_track``` is becoming little messy as it now includes hacks for three issues :( But a lot of this has changed in gapless so should be ok if there are no further changes?