### PR TITLE
core: Make lookup() ignore tracks without URI

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,9 @@ Bug fix release.
 - MPD: Don't return tracks with empty URIs. (Partly fixes: :issue:`1340`, PR:
   :issue:`1343`)
 
+- Core: Make :meth:`~mopidy.core.LibraryController.lookup` ignore tracks with
+  empty URIs. (Partly fixes: :issue:`1340`, PR: :issue:`1381`)
+
 
 v1.1.1 (2015-09-14)
 ===================

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -236,6 +236,8 @@ class LibraryController(object):
                 result = future.get()
                 if result is not None:
                     validation.check_instances(result, models.Track)
+                    # TODO Consider making Track.uri field mandatory, and
+                    # then remove this filtering of tracks without URIs.
                     results[u] = [r for r in result if r.uri]
 
         if uri:

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -236,7 +236,7 @@ class LibraryController(object):
                 result = future.get()
                 if result is not None:
                     validation.check_instances(result, models.Track)
-                    results[u] = result
+                    results[u] = [r for r in result if r.uri]
 
         if uri:
             return results[uri]

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -153,8 +153,8 @@ class CoreLibraryTest(BaseCoreLibraryTest):
             self.core.library.lookup('dummy1:a', ['dummy2:a'])
 
     def test_lookup_can_handle_uris(self):
-        track1 = Track(name='abc')
-        track2 = Track(name='def')
+        track1 = Track(uri='dummy1:a', name='abc')
+        track2 = Track(uri='dummy2:a', name='def')
 
         self.library1.lookup().get.return_value = [track1]
         self.library2.lookup().get.return_value = [track2]
@@ -168,6 +168,15 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         self.assertEqual(result, {'dummy3:a': []})
         self.assertFalse(self.library1.lookup.called)
         self.assertFalse(self.library2.lookup.called)
+
+    def test_lookup_ignores_tracks_without_uri_set(self):
+        track1 = Track(uri='dummy1:a', name='abc')
+        track2 = Track()
+
+        self.library1.lookup().get.return_value = [track1, track2]
+
+        result = self.core.library.lookup(uris=['dummy1:a'])
+        self.assertEqual(result, {'dummy1:a': [track1]})
 
     def test_refresh_with_uri_selects_dummy1_backend(self):
         self.core.library.refresh('dummy1:a')


### PR DESCRIPTION
Fixes #1340