### PR TITLE
audio: Prevent double seeks in appsrc (fixes: #1404)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -156,6 +156,10 @@ Audio
   argument is no longer in use and will be removed in the future. As far as we
   know, this is only used by Mopidy-Spotify.
 
+- Duplicate seek events getting to AppSrc based backends is now fixed. This
+  should prevent seeking in Mopidy-Spotify from glitching.
+  (Fixes: :issue:`1404`)
+
 Gapless
 -------
 


### PR DESCRIPTION
Sending the seek event to the playbin forwards it to all sinks. Which in turn
means on seek event per sink. To avoid this we inject the seek event in an
element before the tee.