### PR TITLE
Fix errors and warnings when importing Gst with gst-python >= 1.5.2

### DIFF
--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -7,8 +7,7 @@ import textwrap
 try:
     import gi
     gi.require_version('Gst', '1.0')
-    gi.require_version('GstPbutils', '1.0')
-    from gi.repository import GLib, GObject, Gst, GstPbutils
+    from gi.repository import GLib, GObject, Gst
 except ImportError:
     print(textwrap.dedent("""
         ERROR: A GObject Python package was not found.
@@ -23,6 +22,8 @@ except ImportError:
     raise
 else:
     Gst.init([])
+    gi.require_version('GstPbutils', '1.0')
+    from gi.repository import GstPbutils
 
 
 REQUIRED_GST_VERSION = (1, 2, 3)

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -22,7 +22,7 @@ except ImportError:
     """))
     raise
 else:
-    Gst.is_initialized() or Gst.init([])
+    Gst.init([])
 
 
 REQUIRED_GST_VERSION = (1, 2, 3)

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -22,7 +22,7 @@ except ImportError:
     """))
     raise
 else:
-    Gst.is_initialized() or Gst.init()
+    Gst.is_initialized() or Gst.init([])
 
 
 REQUIRED_GST_VERSION = (1, 2, 3)


### PR DESCRIPTION
With gst-python >= 1.5.2, a NotInitialized exception is thrown if Gst.is_initialized is called before Gst.init. This removes the Gst.is_initialized check, as Gst.init should be a noop if run again after the first call. This also adds an argument to Gst.init as gst-python >= 1.5.2 requires that as well.

Additionally, after fixing that, I got some warnings when importing GstPbutils before calling Gst.init, so that import is moved below the init, which removed the warnings.

This fixes #1432.