### PR TITLE
Stop mopidy if it receives a SIGTERM.

### DIFF
--- a/mopidy/internal/process.py
+++ b/mopidy/internal/process.py
@@ -1,12 +1,11 @@
 from __future__ import absolute_import, unicode_literals
 
 import logging
+import os
 import signal
 import threading
 
 import pykka
-
-from mopidy.compat import thread
 
 
 logger = logging.getLogger(__name__)
@@ -19,7 +18,7 @@ SIGNALS = dict(
 
 def exit_process():
     logger.debug('Interrupting main...')
-    thread.interrupt_main()
+    os.kill(os.getpid(), signal.SIGINT)
     logger.debug('Interrupted main')
 
 


### PR DESCRIPTION
thread.interrupt_main() does not stop mopidy.
Use os.kill(SIGINT) instead.
Fixes #1435 

I am not sure that this is the correct solution. Please reject it if there is a better way.