### PR TITLE
audio: Workaround crash caused by race

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -165,6 +165,10 @@ Audio
   should prevent seeking in Mopidy-Spotify from glitching.
   (Fixes: :issue:`1404`)
 
+- Workaround crash caused by a race that does not seem to affect functionality.
+  This should be fixed properly together with :issue:`1222`. (Fixes:
+  :issue:`1430`, PR: :issue:`1438`)
+
 Gapless
 -------
 

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -257,7 +257,11 @@ class _Handler(object):
         new_state = _GST_STATE_MAPPING[new_state]
         old_state, self._audio.state = self._audio.state, new_state
 
-        target_state = _GST_STATE_MAPPING[self._audio._target_state]
+        target_state = _GST_STATE_MAPPING.get(self._audio._target_state)
+        if target_state is None:
+            # XXX: Workaround for #1430, to be fixed properly by #1222.
+            logger.debug('Race condition happened. See #1222 and #1430.')
+            return
         if target_state == new_state:
             target_state = None
 


### PR DESCRIPTION
Fixes #1430. See #1222 for explanation and proper fix.