### PR TITLE
audio: Add a config option for queue buffer size

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -169,9 +169,9 @@ Audio
   This should be fixed properly together with :issue:`1222`. (Fixes:
   :issue:`1430`, PR: :issue:`1438`)
 
-- Add a new config option, buffer_time, for setting the buffer time of the
-  GStreamer queue. If you experience buffering before track changes, it may
-  help to increase this. Workaround for :issue:`1409`.
+- Add a new config option, :confval:`audio/buffer_time`, for setting the buffer
+  time of the GStreamer queue. If you experience buffering before track
+  changes, it may help to increase this. Workaround for :issue:`1409`.
 
 Gapless
 -------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -169,6 +169,10 @@ Audio
   This should be fixed properly together with :issue:`1222`. (Fixes:
   :issue:`1430`, PR: :issue:`1438`)
 
+- Add a new config option, buffer_time, for setting the buffer time of the
+  GStreamer queue. If you experience buffering before track changes, it may
+  help to increase this. Workaround for :issue:`1409`.
+
 Gapless
 -------
 

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -155,6 +155,16 @@ These are the available audio configurations. For specific use cases, see
     ``gst-inspect-1.0`` to see what output properties can be set on the sink.
     For example: ``gst-inspect-1.0 shout2send``
 
+.. confval:: audio/buffer_time
+
+    Buffer size in milliseconds.
+
+    Expects an integer above 0.
+
+    Sets the buffer size of the GStreamer queue. If you experience buffering
+    before track changes, it may help to increase this. The default is letting
+    GStreamer decide the size.
+
 
 Logging configuration
 =====================

--- a/docs/config.rst
+++ b/docs/config.rst
@@ -162,8 +162,9 @@ These are the available audio configurations. For specific use cases, see
     Expects an integer above 0.
 
     Sets the buffer size of the GStreamer queue. If you experience buffering
-    before track changes, it may help to increase this. The default is letting
-    GStreamer decide the size.
+    before track changes, it may help to increase this, possibly by at least a
+    few seconds. The default is letting GStreamer decide the size, which at the
+    time of this writing is 1000.
 
 
 Logging configuration

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -470,6 +470,11 @@ class Audio(pykka.ThreadingActor):
         # systems. So leave the default to play it safe.
         queue = Gst.ElementFactory.make('queue')
 
+        if self._config['audio']['buffer_time'] > 0:
+            queue.set_property(
+                'max-size-time',
+                self._config['audio']['buffer_time'] * Gst.MSECOND)
+
         audio_sink.add(queue)
         audio_sink.add(self._outputs)
 

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -38,6 +38,7 @@ _audio_schema['mixer_track'] = Deprecated()
 _audio_schema['mixer_volume'] = Integer(optional=True, minimum=0, maximum=100)
 _audio_schema['output'] = String()
 _audio_schema['visualizer'] = Deprecated()
+_audio_schema['buffer_time'] = Integer(optional=True, minimum=1)
 
 _proxy_schema = ConfigSchema('proxy')
 _proxy_schema['scheme'] = String(optional=True,

--- a/mopidy/config/default.conf
+++ b/mopidy/config/default.conf
@@ -15,6 +15,7 @@ config_file =
 mixer = software
 mixer_volume =
 output = autoaudiosink
+buffer_time =
 
 [proxy]
 scheme =

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -22,6 +22,7 @@ from tests import dummy_audio, path_to_data_dir
 class BaseTest(unittest.TestCase):
     config = {
         'audio': {
+            'buffer_time': None,
             'mixer': 'fakemixer track_max_volume=65536',
             'mixer_track': None,
             'mixer_volume': None,
@@ -38,6 +39,7 @@ class BaseTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
         config = {
             'audio': {
+                'buffer_time': None,
                 'mixer': 'foomixer',
                 'mixer_volume': None,
                 'output': 'testoutput',


### PR DESCRIPTION
It may help to increase this for users that are experiencing buffering
before track changes. Workaround for #1409.

Not sure if I should have added any tests for this, and if so how?