### PR TITLE
Make sure the stream backend playback/library handle URIs the same way

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -110,6 +110,12 @@ M3U backend
   - Improve reliability of playlist updates using the core playlist API by
     applying the write-replace pattern for file updates.
 
+Stream backend
+--------------
+
+- Make sure both lookup and playback correctly handle playlists and our
+  blacklist support. (Fixes: :issue:`1445`, PR: :issue:`1447`)
+
 MPD frontend
 ------------
 

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -60,15 +60,13 @@ class StreamLibraryProvider(backend.LibraryProvider):
             logger.debug('URI matched metadata lookup blacklist: %s', uri)
             return [Track(uri=uri)]
 
-        result = _unwrap_stream(
-            uri,
-            timeout=self.backend._timeout,
-            scanner=self.backend._scanner,
-            requests_session=self.backend._session)[1]
+        _, scan_result = _unwrap_stream(
+            uri, timeout=self.backend._timeout, scanner=self.backend._scanner,
+            requests_session=self.backend._session)
 
-        if result:
-            track = tags.convert_tags_to_track(result.tags).replace(
-                uri=uri, length=result.duration)
+        if scan_result:
+            track = tags.convert_tags_to_track(scan_result.tags).replace(
+                uri=uri, length=scan_result.duration)
         else:
             logger.warning('Problem looking up %s: %s', uri)
             track = Track(uri=uri)
@@ -86,11 +84,10 @@ class StreamPlaybackProvider(backend.PlaybackProvider):
             logger.debug('URI matched metadata lookup blacklist: %s', uri)
             return uri
 
-        return _unwrap_stream(
-            uri,
-            timeout=self.backend._timeout,
-            scanner=self.backend._scanner,
-            requests_session=self.backend._session)[0]
+        unwrapped_uri, _ = _unwrap_stream(
+            uri, timeout=self.backend._timeout, scanner=self.backend._scanner,
+            requests_session=self.backend._session)
+        return unwrapped_uri
 
 
 # TODO: cleanup the return value of this.

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -25,10 +25,19 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
             timeout=config['stream']['timeout'],
             proxy_config=config['proxy'])
 
-        self.library = StreamLibraryProvider(
-            backend=self, blacklist=config['stream']['metadata_blacklist'])
-        self.playback = StreamPlaybackProvider(
-            audio=audio, backend=self, config=config)
+        self._session = http.get_requests_session(
+            proxy_config=config['proxy'],
+            user_agent='%s/%s' % (
+                stream.Extension.dist_name, stream.Extension.version))
+
+        blacklist = config['stream']['metadata_blacklist']
+        self._blacklist_re = re.compile(
+            r'^(%s)$' % '|'.join(fnmatch.translate(u) for u in blacklist))
+
+        self._timeout = config['stream']['timeout']
+
+        self.library = StreamLibraryProvider(backend=self)
+        self.playback = StreamPlaybackProvider(audio=audio, backend=self)
         self.playlists = None
 
         self.uri_schemes = audio_lib.supported_uri_schemes(
@@ -43,23 +52,16 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
 
 
 class StreamLibraryProvider(backend.LibraryProvider):
-
-    def __init__(self, backend, blacklist):
-        super(StreamLibraryProvider, self).__init__(backend)
-        self._scanner = backend._scanner
-        self._blacklist_re = re.compile(
-            r'^(%s)$' % '|'.join(fnmatch.translate(u) for u in blacklist))
-
     def lookup(self, uri):
         if urllib.parse.urlsplit(uri).scheme not in self.backend.uri_schemes:
             return []
 
-        if self._blacklist_re.match(uri):
+        if self.backend._blacklist_re.match(uri):
             logger.debug('URI matched metadata lookup blacklist: %s', uri)
             return [Track(uri=uri)]
 
         try:
-            result = self._scanner.scan(uri)
+            result = self.backend._scanner.scan(uri)
             track = tags.convert_tags_to_track(result.tags).replace(
                 uri=uri, length=result.duration)
         except exceptions.ScannerError as e:
@@ -71,21 +73,12 @@ class StreamLibraryProvider(backend.LibraryProvider):
 
 class StreamPlaybackProvider(backend.PlaybackProvider):
 
-    def __init__(self, audio, backend, config):
-        super(StreamPlaybackProvider, self).__init__(audio, backend)
-        self._config = config
-        self._scanner = backend._scanner
-        self._session = http.get_requests_session(
-            proxy_config=config['proxy'],
-            user_agent='%s/%s' % (
-                stream.Extension.dist_name, stream.Extension.version))
-
     def translate_uri(self, uri):
         return _unwrap_stream(
             uri,
-            timeout=self._config['stream']['timeout'],
-            scanner=self._scanner,
-            requests_session=self._session)
+            timeout=self.backend._timeout,
+            scanner=self.backend._scanner,
+            requests_session=self.backend._session)
 
 
 def _unwrap_stream(uri, timeout, scanner, requests_session):

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -74,6 +74,13 @@ class StreamLibraryProvider(backend.LibraryProvider):
 class StreamPlaybackProvider(backend.PlaybackProvider):
 
     def translate_uri(self, uri):
+        if urllib.parse.urlsplit(uri).scheme not in self.backend.uri_schemes:
+            return None
+
+        if self.backend._blacklist_re.match(uri):
+            logger.debug('URI matched metadata lookup blacklist: %s', uri)
+            return uri
+
         return _unwrap_stream(
             uri,
             timeout=self.backend._timeout,

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -38,7 +38,7 @@ def track_uri():
 
 def test_lookup_ignores_unknown_scheme(audio, config):
     backend = actor.StreamBackend(audio=audio, config=config)
-    backend.library.lookup('http://example.com') == []
+    assert backend.library.lookup('http://example.com') == []
 
 
 def test_lookup_respects_blacklist(audio, config, track_uri):

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -30,7 +30,7 @@ def config():
         'stream': {
             'timeout': TIMEOUT,
             'metadata_blacklist': [],
-            'protocols': ['file'],
+            'protocols': ['http'],
         },
         'file': {
             'enabled': False


### PR DESCRIPTION
Probably replaces #1446. Main thing missing for 2.0 is a changelog, but it's time for bed now...