### PR TITLE
audio: be more tolerant of gstreamer states and order. Fix #1453

### DIFF
--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -184,14 +184,6 @@ def _process(pipeline, timeout_ms):
 
     timeout = timeout_ms
     previous = int(time.time() * 1000)
-
-    # Note 1: Lines commented with "Note 1" are a workaround for upstream
-    # bug https://bugzilla.gnome.org/show_bug.cgi?id=762660 which causes
-    # gstreamer to not send tag data for some flac files when PAUSED.
-    # TODO: remove all lines tagged # Note 1 once upstream issue is fixed.
-
-    playing = False                                      # Note1
-
     while timeout > 0:
         message = bus.timed_pop_filtered(timeout * Gst.MSECOND, types)
 
@@ -218,13 +210,8 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.EOS:
             return tags, mime, have_audio
         elif message.type == Gst.MessageType.ASYNC_DONE:
-            if tags or playing:                          # Note 1
-                if playing:                              # Note 1
-                    pipeline.set_state(Gst.State.PAUSED) # Note 1
+            if message.src == pipeline:
                 return tags, mime, have_audio
-            else:                                        # Note 1
-                pipeline.set_state(Gst.State.PLAYING)    # Note 1
-                playing = True                           # Note 1
         elif message.type == Gst.MessageType.TAG:
             taglist = message.parse_tag()
             # Note that this will only keep the last tag.

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -225,10 +225,7 @@ def _process(pipeline, timeout_ms):
         timeout -= now - previous
         previous = now
 
-    if tags:
-        return tags, mime, have_audio
-    else:
-        raise exceptions.ScannerError('Timeout after %dms with no tags' % timeout_ms)
+    raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)
 
 
 if __name__ == '__main__':

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -184,6 +184,14 @@ def _process(pipeline, timeout_ms):
 
     timeout = timeout_ms
     previous = int(time.time() * 1000)
+
+    # Note 1: Lines commented with "Note 1" are a workaround for upstream
+    # bug https://bugzilla.gnome.org/show_bug.cgi?id=762660 which causes
+    # gstreamer to not send tag data for some flac files when PAUSED.
+    # TODO: remove all lines tagged # Note 1 once upstream issue is fixed.
+
+    playing = False                                      # Note1
+
     while timeout > 0:
         message = bus.timed_pop_filtered(timeout * Gst.MSECOND, types)
 
@@ -210,8 +218,13 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.EOS:
             return tags, mime, have_audio
         elif message.type == Gst.MessageType.ASYNC_DONE:
-            if message.src == pipeline:
+            if tags or playing:                          # Note 1
+                if playing:                              # Note 1
+                    pipeline.set_state(Gst.State.PAUSED) # Note 1
                 return tags, mime, have_audio
+            else:                                        # Note 1
+                pipeline.set_state(Gst.State.PLAYING)    # Note 1
+                playing = True                           # Note 1
         elif message.type == Gst.MessageType.TAG:
             taglist = message.parse_tag()
             # Note that this will only keep the last tag.

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -134,6 +134,10 @@ def _start_pipeline(pipeline):
     result = pipeline.set_state(Gst.State.PAUSED)
     if result == Gst.StateChangeReturn.NO_PREROLL:
         pipeline.set_state(Gst.State.PLAYING)
+    elif result == Gst.StateChangeReturn.ASYNC:
+        # TODO: should probably have error check here like
+        # https://cgit.freedesktop.org/gstreamer/gstreamer/tree/tools/gst-launch.c#n1075 ??
+        pipeline.set_state(Gst.State.PLAYING)
 
 
 def _query_duration(pipeline, timeout=100):
@@ -210,7 +214,7 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.EOS:
             return tags, mime, have_audio
         elif message.type == Gst.MessageType.ASYNC_DONE:
-            if message.src == pipeline:
+            if message.src == pipeline and tags:
                 return tags, mime, have_audio
         elif message.type == Gst.MessageType.TAG:
             taglist = message.parse_tag()

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -210,8 +210,16 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.EOS:
             return tags, mime, have_audio
         elif message.type == Gst.MessageType.ASYNC_DONE:
-            if message.src == pipeline:
+            # Note 1: Lines commented with "Note 1" are a workaround for upstream
+            # bug https://bugzilla.gnome.org/show_bug.cgi?id=762660 which causes
+            # gstreamer to not send tag data for some flac files when PAUSED.
+            # Switching to PLAYING and back to PAUSED seems to unclog it.
+            # TODO: remove all lines tagged # Note 1 once upstream issue is fixed.
+            if tags:                          # Note 1
                 return tags, mime, have_audio
+            else:                                        # Note 1
+                pipeline.set_state(Gst.State.PLAYING)    # Note 1
+                pipeline.set_state(Gst.State.PAUSED)     # Note 1
         elif message.type == Gst.MessageType.TAG:
             taglist = message.parse_tag()
             # Note that this will only keep the last tag.

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -134,10 +134,6 @@ def _start_pipeline(pipeline):
     result = pipeline.set_state(Gst.State.PAUSED)
     if result == Gst.StateChangeReturn.NO_PREROLL:
         pipeline.set_state(Gst.State.PLAYING)
-    elif result == Gst.StateChangeReturn.ASYNC:
-        # TODO: should probably have error check here like
-        # https://cgit.freedesktop.org/gstreamer/gstreamer/tree/tools/gst-launch.c#n1075 ??
-        pipeline.set_state(Gst.State.PLAYING)
 
 
 def _query_duration(pipeline, timeout=100):
@@ -214,7 +210,7 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.EOS:
             return tags, mime, have_audio
         elif message.type == Gst.MessageType.ASYNC_DONE:
-            if message.src == pipeline and tags:
+            if message.src == pipeline:
                 return tags, mime, have_audio
         elif message.type == Gst.MessageType.TAG:
             taglist = message.parse_tag()

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -225,7 +225,10 @@ def _process(pipeline, timeout_ms):
         timeout -= now - previous
         previous = now
 
-    raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)
+    if tags:
+        return tags, mime, have_audio
+    else:
+        raise exceptions.ScannerError('Timeout after %dms with no tags' % timeout_ms)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Gstreamer's behaviour when parsing flac files seems to have changed slightly as of https://cgit.freedesktop.org/gstreamer/gst-plugins-good/commit/?id=a042a9815967b0a6c0dfb65f33d78e02ee1ffb43.

This pull request tries to accommodate this.

Refer also https://bugzilla.gnome.org/show_bug.cgi?id=762660