### PR TITLE
Find images in audio files

### DIFF
--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -53,6 +53,12 @@ gstreamer-GstTagList.html
                 result[tag].append(value.decode('utf-8', 'replace'))
             elif isinstance(value, (compat.text_type, bool, numbers.Number)):
                 result[tag].append(value)
+            elif isinstance(value, Gst.Sample):
+                buf = value.get_buffer()
+                (found, mapinfo) = buf.map(Gst.MapFlags.READ)
+                if found:
+                    result[tag].append(bytes(mapinfo.data))
+                    buf.unmap(mapinfo)
             else:
                 logger.log(
                     log.TRACE_LOG_LEVEL,

--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -57,8 +57,10 @@ gstreamer-GstTagList.html
                 buf = value.get_buffer()
                 (found, mapinfo) = buf.map(Gst.MapFlags.READ)
                 if found:
-                    result[tag].append(bytes(mapinfo.data))
-                    buf.unmap(mapinfo)
+                    try:
+                        result[tag].append(bytes(mapinfo.data))
+                    finally:
+                        buf.unmap(mapinfo)
             else:
                 logger.log(
                     log.TRACE_LOG_LEVEL,


### PR DESCRIPTION
Handle Gst.Sample as image in audio file tags (scanned with Gst1.0).

Fixes #1469

This patch works well on my RPi with raspbian.

On my Ubuntu 14.04 the `Gst.Buffer.map()` fail with a c error. 
```
** (python:10510): CRITICAL **: Unable to determine array length for 0x7fa0901c0e90
```
Any Idea? Corrupted Ubuntu?