### PR TITLE
Modify a mistake in annotations

### DIFF
--- a/mopidy/local/translator.py
+++ b/mopidy/local/translator.py
@@ -46,7 +46,7 @@ def path_to_local_track_uri(relpath):
 
 
 def path_to_local_directory_uri(relpath):
-    """Convert path relative to :confval:`local/media_dir` directory URI."""
+    """Convert path relative to :confval:`local/media_dir` to directory URI."""
     if isinstance(relpath, compat.text_type):
         relpath = relpath.encode('utf-8')
     return 'local:directory:%s' % urllib.quote(relpath)


### PR DESCRIPTION
I found this mistake when reading the documentation of Mopidy. Just add
a "to"  to the annotation.
I just want the mopidy better.