### PR TITLE
Fix/gstreamer not pushing tags

### DIFF
--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -147,6 +147,7 @@ def _process(pipeline, timeout_ms):
     mime = None
     have_audio = False
     missing_message = None
+    duration = 0
 
     types = (
         Gst.MessageType.ELEMENT |

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -210,8 +210,11 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.EOS:
             return tags, mime, have_audio
         elif message.type == Gst.MessageType.ASYNC_DONE:
-            if message.src == pipeline:
+            if tags:
                 return tags, mime, have_audio
+            else:
+                # workaround for https://bugzilla.gnome.org/show_bug.cgi?id=763553:
+                pipeline.set_state(Gst.State.PLAYING)
         elif message.type == Gst.MessageType.TAG:
             taglist = message.parse_tag()
             # Note that this will only keep the last tag.
@@ -220,6 +223,9 @@ def _process(pipeline, timeout_ms):
         now = int(time.time() * 1000)
         timeout -= now - previous
         previous = now
+        # workaround for https://bugzilla.gnome.org/show_bug.cgi?id=763553:
+        if tags:
+            pipeline.set_state(Gst.State.PAUSED)
 
     raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)
 

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -61,8 +61,7 @@ class Scanner(object):
 
         try:
             _start_pipeline(pipeline)
-            tags, mime, have_audio = _process(pipeline, timeout)
-            duration = _query_duration(pipeline)
+            tags, mime, have_audio, duration = _process(pipeline, timeout)
             seekable = _query_seekable(pipeline)
         finally:
             signals.clear()
@@ -136,30 +135,6 @@ def _start_pipeline(pipeline):
         pipeline.set_state(Gst.State.PLAYING)
 
 
-def _query_duration(pipeline, timeout=100):
-    # 1. Try and get a duration, return if success.
-    # 2. Some formats need to play some buffers before duration is found.
-    # 3. Wait for a duration change event.
-    # 4. Try and get a duration again.
-
-    success, duration = pipeline.query_duration(Gst.Format.TIME)
-    if success and duration >= 0:
-        return duration // Gst.MSECOND
-
-    result = pipeline.set_state(Gst.State.PLAYING)
-    if result == Gst.StateChangeReturn.FAILURE:
-        return None
-
-    gst_timeout = timeout * Gst.MSECOND
-    bus = pipeline.get_bus()
-    bus.timed_pop_filtered(gst_timeout, Gst.MessageType.DURATION_CHANGED)
-
-    success, duration = pipeline.query_duration(Gst.Format.TIME)
-    if success and duration >= 0:
-        return duration // Gst.MSECOND
-    return None
-
-
 def _query_seekable(pipeline):
     query = Gst.Query.new_seeking(Gst.Format.TIME)
     pipeline.query(query)
@@ -179,12 +154,14 @@ def _process(pipeline, timeout_ms):
         Gst.MessageType.ERROR |
         Gst.MessageType.EOS |
         Gst.MessageType.ASYNC_DONE |
+        Gst.MessageType.DURATION_CHANGED |
         Gst.MessageType.TAG
     )
 
     timeout = timeout_ms
     previous = int(time.time() * 1000)
-    while timeout > 0:
+    done = False
+    while timeout > 0 and not done:
         message = bus.timed_pop_filtered(timeout * Gst.MSECOND, types)
 
         if message is None:
@@ -197,7 +174,7 @@ def _process(pipeline, timeout_ms):
                 mime = message.get_structure().get_value('caps').get_name()
                 if mime and (
                         mime.startswith('text/') or mime == 'application/xml'):
-                    return tags, mime, have_audio
+                    done = True
             elif message.get_structure().get_name() == 'have-audio':
                 have_audio = True
         elif message.type == Gst.MessageType.ERROR:
@@ -205,13 +182,14 @@ def _process(pipeline, timeout_ms):
             if missing_message and not mime:
                 caps = missing_message.get_structure().get_value('detail')
                 mime = caps.get_structure(0).get_name()
-                return tags, mime, have_audio
+                done = True
             raise exceptions.ScannerError(error)
         elif message.type == Gst.MessageType.EOS:
             return tags, mime, have_audio
         elif message.type == Gst.MessageType.ASYNC_DONE:
-            if tags:
-                return tags, mime, have_audio
+            success, duration = pipeline.query_duration(Gst.Format.TIME)
+            if tags and duration > 0:
+                done = True
             else:
                 # workaround for https://bugzilla.gnome.org/show_bug.cgi?id=763553:
                 pipeline.set_state(Gst.State.PLAYING)
@@ -219,15 +197,21 @@ def _process(pipeline, timeout_ms):
             taglist = message.parse_tag()
             # Note that this will only keep the last tag.
             tags.update(tags_lib.convert_taglist(taglist))
+        elif message.type == Gst.MessageType.DURATION_CHANGED:
+            success, duration = pipeline.query_duration(Gst.Format.TIME)
+
 
         now = int(time.time() * 1000)
         timeout -= now - previous
         previous = now
         # workaround for https://bugzilla.gnome.org/show_bug.cgi?id=763553:
-        if tags:
+        if tags and duration > 0:
             pipeline.set_state(Gst.State.PAUSED)
 
-    raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)
+    if done:
+        return tags, mime, have_audio, duration
+    else:
+        raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)
 
 
 if __name__ == '__main__':

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -159,7 +159,7 @@ def _process(pipeline, timeout_ms):
     )
 
     timeout = timeout_ms
-    previous = int(time.time() * 1000)
+    start = int(time.time() * 1000)
     done = False
     while timeout > 0 and not done:
         message = bus.timed_pop_filtered(timeout * Gst.MSECOND, types)
@@ -200,10 +200,8 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.DURATION_CHANGED:
             success, duration = pipeline.query_duration(Gst.Format.TIME)
 
+        timeout = timeout_ms - ( int(time.time() * 1000) - start )
 
-        now = int(time.time() * 1000)
-        timeout -= now - previous
-        previous = now
         # workaround for https://bugzilla.gnome.org/show_bug.cgi?id=763553:
         if tags and duration > 0:
             pipeline.set_state(Gst.State.PAUSED)

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -208,6 +208,7 @@ def _process(pipeline, timeout_ms):
             pipeline.set_state(Gst.State.PAUSED)
 
     if done:
+        success, duration = pipeline.query_duration(Gst.Format.TIME)
         return tags, mime, have_audio, duration // Gst.MSECOND
     else:
         raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -186,7 +186,7 @@ def _process(pipeline, timeout_ms):
                 done = True
             raise exceptions.ScannerError(error)
         elif message.type == Gst.MessageType.EOS:
-            return tags, mime, have_audio
+            done = True
         elif message.type == Gst.MessageType.ASYNC_DONE:
             success, duration = pipeline.query_duration(Gst.Format.TIME)
             if tags and duration > 0:

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -208,7 +208,7 @@ def _process(pipeline, timeout_ms):
             pipeline.set_state(Gst.State.PAUSED)
 
     if done:
-        return tags, mime, have_audio, duration
+        return tags, mime, have_audio, duration // Gst.MSECOND
     else:
         raise exceptions.ScannerError('Timeout after %dms' % timeout_ms)
 

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -192,7 +192,8 @@ def _process(pipeline, timeout_ms):
             if tags and duration > 0:
                 done = True
             else:
-                # workaround for https://bugzilla.gnome.org/show_bug.cgi?id=763553:
+                # workaround for
+                # https://bugzilla.gnome.org/show_bug.cgi?id=763553:
                 pipeline.set_state(Gst.State.PLAYING)
         elif message.type == Gst.MessageType.TAG:
             taglist = message.parse_tag()
@@ -201,7 +202,8 @@ def _process(pipeline, timeout_ms):
         elif message.type == Gst.MessageType.DURATION_CHANGED:
             success, duration = pipeline.query_duration(Gst.Format.TIME)
 
-        timeout = timeout_ms - ( int(time.time() * 1000) - start )
+        timeout = timeout_ms - (
+                  int(time.time() * 1000) - start )
 
         # workaround for https://bugzilla.gnome.org/show_bug.cgi?id=763553:
         if tags and duration > 0:


### PR DESCRIPTION
This applies a workaround for #935, #1453, #1474 and #1480 until [gstreamer upstream fix](https://cgit.freedesktop.org/gstreamer/gstreamer/commit/?id=87c0513569b92a34ca325ff1af61f9cbe3b29886) percolates down (gstreamer 1.6.4 or 1.7.91).

I tested on my Arch box with previously problematic .flac files and gstreamer 1.6.3.  All tags were picked up and there was no apparent loss of speed (relative to gstreamer compiled from git master).

The main fix is in 2eb43f2, the other two commits are just economising a bit of code and so can be left off if desired.
