### PR TITLE
Fill mpd date from album.date. Fix #1471

### DIFF
--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -114,11 +114,11 @@ def convert_tags_to_track(tags):
     album_kwargs['num_discs'] = tags.get(Gst.TAG_ALBUM_VOLUME_COUNT, [None])[0]
     album_kwargs['musicbrainz_id'] = tags.get('musicbrainz-albumid', [None])[0]
 
-    album_kwargs['date'] = tags.get(Gst.TAG_DATE, [None])[0]
-    if not album_kwargs['date']:
+    track_kwargs['date'] = tags.get(Gst.TAG_DATE, [None])[0]
+    if not track_kwargs['date']:
         datetime = tags.get(Gst.TAG_DATE_TIME, [None])[0]
         if datetime is not None:
-            album_kwargs['date'] = datetime.split('T')[0]
+            track_kwargs['date'] = datetime.split('T')[0]
 
     # Clear out any empty values we found
     track_kwargs = {k: v for k, v in track_kwargs.items() if v}

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -58,6 +58,9 @@ def track_to_mpd_format(track, position=None, stream_title=None):
 
     if track.date:
         result.append(('Date', track.date))
+    else:
+        if track.album is not None and track.album.date:
+            result.append(('Date', track.album.date))
 
     if track.album is not None and track.album.num_tracks is not None:
         result.append(('Track', '%d/%d' % (

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -58,9 +58,6 @@ def track_to_mpd_format(track, position=None, stream_title=None):
 
     if track.date:
         result.append(('Date', track.date))
-    else:
-        if track.album is not None and track.album.date:
-            result.append(('Date', track.album.date))
 
     if track.album is not None and track.album.num_tracks is not None:
         result.append(('Track', '%d/%d' % (

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -108,11 +108,11 @@ class TagsToTrackTest(unittest.TestCase):
         albumartist = Artist(name='albumartist',
                              musicbrainz_id='albumartistid')
 
-        album = Album(name='album', date='2006-01-01',
+        album = Album(name='album',
                       num_tracks=2, num_discs=3,
                       musicbrainz_id='albumid', artists=[albumartist])
 
-        self.track = Track(name='track',
+        self.track = Track(name='track', date='2006-01-01',
                            genre='genre', track_no=1, disc_no=2,
                            comment='comment', musicbrainz_id='trackid',
                            album=album, bitrate=1000, artists=[artist],
@@ -176,7 +176,7 @@ class TagsToTrackTest(unittest.TestCase):
     def test_missing_track_date(self):
         del self.tags['date']
         self.check(
-            self.track.replace(album=self.track.album.replace(date=None)))
+            self.track.replace(date=None))
 
     def test_multiple_track_date(self):
         self.tags['date'].append('2030-01-01')


### PR DESCRIPTION
In 9657004b7705e69b317b3482d688921c3b4df44c the date was moved from `track_kwargs` to `album_kwargs`. 

If it is intended to have a `album.date` (not `track.date`) then this is one possible fix.


