### PR TITLE
Ignore position of _on_position_changed callback. Fixes #1462

### DIFF
--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -230,7 +230,7 @@ class PlaybackController(object):
                 self._seek(self._pending_position)
 
     def _on_position_changed(self, position):
-        if self._pending_position:
+        if self._pending_position is not None:
             self._trigger_seeked(self._pending_position)
             self._pending_position = None
 

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -230,8 +230,8 @@ class PlaybackController(object):
                 self._seek(self._pending_position)
 
     def _on_position_changed(self, position):
-        if self._pending_position == position:
-            self._trigger_seeked(position)
+        if self._pending_position:
+            self._trigger_seeked(self._pending_position)
             self._pending_position = None
 
     def _on_about_to_finish_callback(self):

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -734,6 +734,7 @@ class EventEmissionTest(BaseTest):
 
         self.core.playback.play(tl_tracks[0])
         self.trigger_about_to_finish(replay_until='stream_changed')
+        self.replay_events()
         listener_mock.reset_mock()
 
         self.core.playback.seek(1000)


### PR DESCRIPTION
@adamcik Is there a reason why you check for position match in `_on_position_changed`? It seems there is only one `_on_position_changed` for each `seek`. (I tried to, but didn't get two simultaneous seeks)

Fixes #1462.