### PR TITLE
point installation instructions to the rtfd homepage

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -47,7 +47,7 @@ Mopidy extension. The cassettes have NFC tags used to select playlists from
 Spotify.
 
 To get started with Mopidy, check out
-`the installation docs <http://docs.mopidy.com/en/latest/installation/>`_.
+`the installation docs <http://mopidy.readthedocs.io/en/latest/installation/>`_.
 
 - `Documentation <https://docs.mopidy.com/>`_
 - `Discussion forum <https://discuss.mopidy.com/>`_


### PR DESCRIPTION
As it is now it's a broken link.

sure, I coulda just made an issue, but figured this was easy for me to fix on my own.