### PR TITLE
model documentation: update 'composers' and 'performers' type

### DIFF
--- a/mopidy/models/__init__.py
+++ b/mopidy/models/__init__.py
@@ -192,9 +192,9 @@ class Track(ValidatedImmutableObject):
     :param album: track album
     :type album: :class:`Album`
     :param composers: track composers
-    :type composers: string
+    :type composers: list of :class:`Artist`
     :param performers: track performers
-    :type performers: string
+    :type performers: list of :class:`Artist`
     :param genre: track genre
     :type genre: string
     :param track_no: track number in album


### PR DESCRIPTION
the doc string was not consistent with the current type definition