### PR TITLE
Fix local unicode file / folder error

### DIFF
--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -1,5 +1,10 @@
 from __future__ import absolute_import, unicode_literals
 
+# Fix unicode path
+import sys
+reload(sys)  # Reload does the trick!
+sys.setdefaultencoding('UTF8')
+
 import logging
 import os
 import stat


### PR DESCRIPTION
Caused by local file / folder have unicode characters

 `UnicodeDecodeError: 'ascii' codec can't decode byte 0xe1 in position 34: ordinal not in range(128)`