### PR TITLE
mpd: fix protocol for replay_gain_status

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -38,6 +38,9 @@ Bug fix release.
   where a :confval:`file/media_dirs` path contained non-ASCII characters.
   (Fixes: :issue:`1345`, PR: :issue:`1493`)
 
+- MPD: Fix MPD protocol for ``replay_gain_status`` command. The actual command
+  remains unimplemented. (PR: :issue:`1520`)
+
 
 v2.0.0 (2016-02-15)
 ===================

--- a/mopidy/mpd/protocol/playback.py
+++ b/mopidy/mpd/protocol/playback.py
@@ -325,7 +325,7 @@ def replay_gain_status(context):
         Prints replay gain options. Currently, only the variable
         ``replay_gain_mode`` is returned.
     """
-    return 'off'  # TODO
+    return 'replay_gain_mode: off'  # TODO
 
 
 @protocol.commands.add('seek', songpos=protocol.UINT, seconds=protocol.UINT)

--- a/tests/mpd/protocol/test_playback.py
+++ b/tests/mpd/protocol/test_playback.py
@@ -115,7 +115,7 @@ class PlaybackOptionsHandlerTest(protocol.BaseTestCase):
     def test_replay_gain_status_default(self):
         self.send_request('replay_gain_status')
         self.assertInResponse('OK')
-        self.assertInResponse('off')
+        self.assertInResponse('replay_gain_mode: off')
 
     def test_mixrampdb(self):
         self.send_request('mixrampdb "10"')


### PR DESCRIPTION
I found an error in the implementation of the MPD protocol:

* with `mpd` 0.19.5:
```
$ telnet 127.0.0.1 6600
...
OK MPD 0.19.0
replay_gain_status
replay_gain_mode: off
OK
```
* with `mopidy` df0d534a56fd10682816b87f8f3145ee4c7162ac (current `develop` branch):
```
$ telnet 127.0.0.1 6600
...
OK MPD 0.19.0
replay_gain_status
off
OK
```

This led to the [following issue](https://github.com/kstep/rust-mpd/issues/5). This PR is a simple attempt at solving the issue (without implementing actual replay gain support).