### PR TITLE
fix/1521 download timeout sec 

### DIFF
--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -142,7 +142,7 @@ def _unwrap_stream(uri, timeout, scanner, requests_session):
                 uri, timeout)
             return None, None
         content = http.download(
-            requests_session, uri, timeout=download_timeout/1000)
+            requests_session, uri, timeout=download_timeout / 1000)
 
         if content is None:
             logger.info(

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -68,7 +68,7 @@ class StreamLibraryProvider(backend.LibraryProvider):
             track = tags.convert_tags_to_track(scan_result.tags).replace(
                 uri=uri, length=scan_result.duration)
         else:
-            logger.warning('Problem looking up %s: %s', uri)
+            logger.warning('Problem looking up %s', uri)
             track = Track(uri=uri)
 
         return [track]
@@ -142,7 +142,7 @@ def _unwrap_stream(uri, timeout, scanner, requests_session):
                 uri, timeout)
             return None, None
         content = http.download(
-            requests_session, uri, timeout=download_timeout)
+            requests_session, uri, timeout=download_timeout/1000)
 
         if content is None:
             logger.info(


### PR DESCRIPTION
default timeout is converted from ms to seconds for http download and warning has correct number of arguments. Fix avoids blocking of mopidy while it is busy downloading whole stream for a unfortunately long period.