### PR TITLE
Get correct track position on change events

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,7 +42,12 @@ Bug fix release.
   remains unimplemented. (PR: :issue:`1520`)
 
 - MPD: Add ``nextsong`` and ``nextsongid`` to the response of MPD ``status`` command.
-  (Fixes: :issue:`1133` :issue:`1516`, PR: :issue:`1523`)
+  (Fixes: :issue:`1133`, :issue:`1516`, PR: :issue:`1523`)
+
+- Core: Correctly record the last position of a track when switching to another
+  one. Particularly relevant for `mopidy-scrobbler` users, as before it was
+  essentially unusable. (Fixes: :issue:`1456`, PR: :issue:`1534`)
+
 
 v2.0.0 (2016-02-15)
 ===================

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -251,6 +251,10 @@ class PlaybackController(object):
         if self._state == PlaybackState.STOPPED:
             return
 
+        # Unless overridden by other calls (e.g. next / previous / stop) this
+        # will be the last position recorded until the track gets reassigned.
+        self._last_position = self._current_tl_track.track.length
+
         pending = self.core.tracklist.eot_track(self._current_tl_track)
         # avoid endless loop if 'repeat' is 'true' and no track is playable
         # * 2 -> second run to get all playable track in a shuffled playlist
@@ -393,6 +397,10 @@ class PlaybackController(object):
         backend = self._get_backend(pending_tl_track)
         if not backend:
             return False
+
+        # This must happen before prepare_change gets called, otherwise the
+        # backend flushes the information of the track.
+        self._last_position = self.get_time_position()
 
         # TODO: Wrap backend call in error handling.
         backend.playback.prepare_change()

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -253,6 +253,8 @@ class PlaybackController(object):
 
         # Unless overridden by other calls (e.g. next / previous / stop) this
         # will be the last position recorded until the track gets reassigned.
+        # TODO: Check if case when track.length isn't populated needs to be
+        # handled.
         self._last_position = self._current_tl_track.track.length
 
         pending = self.core.tracklist.eot_track(self._current_tl_track)


### PR DESCRIPTION
Playback callbacks now correctly handle the following cases:

1. the track finishes and switches to the next one in the list;
2. user presses next / previous

Fixes #1456 (and therefore should also close mopidy/mopidy-scrobbler#20).