### PR TITLE
docs: Remove link to the Mopidy-LeftAsRain plugin

### DIFF
--- a/docs/ext/backends.rst
+++ b/docs/ext/backends.rst
@@ -97,15 +97,6 @@ Extension for playing music and audio from the `Internet Archive
 <https://archive.org/>`_.
 
 
-Mopidy-LeftAsRain
-=================
-
-https://github.com/naglis/mopidy-leftasrain
-
-Extension for playing music from the `leftasrain.com
-<http://leftasrain.com/>`_ music blog.
-
-
 Mopidy-Local
 ============
 


### PR DESCRIPTION
Hello all,

quite a while ago the leftasrain.com maintainers have changed the way the serve song files (requiring a time-limited token to access the song every time). I guess it would still be possible (but more complicated) to implement in a Mopidy plugin, but I don't think that it's woth the effort, which leaves the [Mopidy-LeftAsRain](https://github.com/naglis/mopidy-leftasrain) plugin broken, so I think it would be best to remove the link from the documentation.

Thanks!