### PR TITLE
Do not scan first-level dirs starting with .

### DIFF
--- a/mopidy/local/commands.py
+++ b/mopidy/local/commands.py
@@ -118,7 +118,7 @@ class ScanCommand(commands.Command):
             relpath = os.path.relpath(abspath, media_dir)
             uri = translator.path_to_local_track_uri(relpath)
 
-            if b'/.' in relpath:
+            if b'/.' in relpath or relpath.startswith(b'.'):
                 logger.debug('Skipped %s: Hidden directory/file.', uri)
             elif relpath.lower().endswith(excluded_file_extensions):
                 logger.debug('Skipped %s: File extension excluded.', uri)


### PR DESCRIPTION
 - Currently the code skips directories with level > 1 starting with .,
   but does not skip first-level directories starting with .; fix this
   by matching for files/directories which start with . in addition to
   those that contain /.