### PR TITLE
Scanner: Set date to track and album: fix #1471

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,9 @@ Feature release.
 - MPD: Add ``nextsong`` and ``nextsongid`` to the response of MPD ``status`` command.
   (Fixes: :issue:`1133`, :issue:`1516`, PR: :issue:`1523`)
 
+- Audio: The scanner set the date to :attr:`mopidy.models.Track.date` and
+  :attr:`mopidy.models.Album.date`
+  (Fixes: :issue:`1741`)
 
 v2.0.1 (2016-08-16)
 ===================

--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -124,6 +124,7 @@ def convert_tags_to_track(tags):
         datetime = tags.get(Gst.TAG_DATE_TIME, [None])[0]
         if datetime is not None:
             album_kwargs['date'] = datetime.split('T')[0]
+    track_kwargs['date'] = album_kwargs['date']
 
     # Clear out any empty values we found
     track_kwargs = {k: v for k, v in track_kwargs.items() if v}

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -120,7 +120,7 @@ class TagsToTrackTest(unittest.TestCase):
                       num_tracks=2, num_discs=3,
                       musicbrainz_id='albumid', artists=[albumartist])
 
-        self.track = Track(name='track',
+        self.track = Track(name='track', date='2006-01-01',
                            genre='genre', track_no=1, disc_no=2,
                            comment='comment', musicbrainz_id='trackid',
                            album=album, bitrate=1000, artists=[artist],
@@ -184,7 +184,9 @@ class TagsToTrackTest(unittest.TestCase):
     def test_missing_track_date(self):
         del self.tags['date']
         self.check(
-            self.track.replace(album=self.track.album.replace(date=None)))
+            self.track.replace(
+                album=self.track.album.replace(date=None)
+            ).replace(date=None))
 
     def test_multiple_track_date(self):
         self.tags['date'].append('2030-01-01')

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -183,10 +183,9 @@ class TagsToTrackTest(unittest.TestCase):
 
     def test_missing_track_date(self):
         del self.tags['date']
-        self.check(
-            self.track.replace(
-                album=self.track.album.replace(date=None)
-            ).replace(date=None))
+        self.check(self.track.replace(
+            album=self.track.album.replace(date=None),
+            date=None))
 
     def test_multiple_track_date(self):
         self.tags['date'].append('2030-01-01')


### PR DESCRIPTION
Replacement for #1495

The `Models.Track.date` member has to be set correctly. mpd (and other code, see #1495) relies on it.