### PR TITLE
audio: Wait for state change instead of async done in scanner.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,7 +35,7 @@ Feature release.
 
 - Audio: Fix handling of MMS (and any other streams) that can't switch to
   playing ``ASYNC``. Previously we would time out trying to get a duration from
-  these. (Fixes: :issue:`1553`, PR :issue:`1575`)
+  these. (Fixes: :issue:`1553`, PR :issue:`1575`, :issue:`1576`)
 
 
 v2.0.1 (2016-08-16)


### PR DESCRIPTION
This increases the robustness by quite a bit, we no longer:
- Fail on elements such as mmssrc that can't go to playing ASYNC.
- Try going to playing if we've already tried before.