### PR TITLE
Add download flag to playbin

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -21,7 +21,8 @@ logger = logging.getLogger(__name__)
 # set_state() on a pipeline.
 gst_logger = logging.getLogger('mopidy.audio.gst')
 
-_GST_PLAY_FLAGS_AUDIO = 0x02
+# 0x02 specifies "audio" and 0x80 specifies "download"
+_GST_PLAY_FLAGS_AUDIO = 0x02 + 0x80
 
 _GST_STATE_MAPPING = {
     Gst.State.PLAYING: PlaybackState.PLAYING,


### PR DESCRIPTION
This aims to fix mopidy/mopidy-gmusic#161 by grabbing the whole song at once rather than buffering.

I don't know a ton about gstreamer internals, so I hope this doesn't break the buffering mechanism that appears to be built into mopidy... I'd be happy to address any feedback.