### PR TITLE
remove leftover utf-8 encode from path handling

### DIFF
--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -141,5 +141,5 @@ class FileLibraryProvider(backend.LibraryProvider):
     def _is_in_basedir(self, local_path):
         return any(
             path.is_path_inside_base_dir(
-                local_path, media_dir['path'].encode('utf-8'))
+                local_path, media_dir['path'])
             for media_dir in self._media_dirs)


### PR DESCRIPTION
Leaving the .encode in the code causes folders with non-ASCII symbols (tested with some German umlauts) to show up empty in "browse".

After removing, the folder contents show up fine.

(If this gets merged, I don't have to patch my kids' three mediaplayers for their "Hörspiele" (audiobooks) folder everytime a new Mopidy version gets installed. It's just daddy, trying to save some of his time... ;-) )