### PR TITLE
Fix/1599 catch unicode decoding errors in encoding.locale_decode()

### DIFF
--- a/mopidy/internal/encoding.py
+++ b/mopidy/internal/encoding.py
@@ -9,4 +9,7 @@ def locale_decode(bytestr):
     try:
         return compat.text_type(bytestr)
     except UnicodeError:
-        return bytes(bytestr).decode(locale.getpreferredencoding())
+        try:
+            return bytes(bytestr).decode(locale.getpreferredencoding())
+        except UnicodeDecodeError:
+            return bytes(bytestr).decode('UTF-8', errors='replace')

--- a/tests/internal/test_encoding.py
+++ b/tests/internal/test_encoding.py
@@ -43,3 +43,11 @@ class LocaleDecodeTest(unittest.TestCase):
         encoding.locale_decode('abc')
 
         self.assertFalse(mock.called)
+
+    def test_failed_decoding(self, mock):
+        # Checks that local_decode() can handle ascii locale
+        mock.return_value = 'ascii'
+
+        bytestr = b'\xc3'
+        expected = u'\ufffd'
+        self.assertEqual(expected, encoding.locale_decode(bytestr))


### PR DESCRIPTION
This exception can happen when locale is unset, which effectively means that ascii char set is used.
