### PR TITLE
Remove Deezer backend

### DIFF
--- a/docs/ext/backends.rst
+++ b/docs/ext/backends.rst
@@ -48,15 +48,6 @@ Provides a backend for playing music from your `Beets
 <http://beets.radbox.org/>`_ music library through Beets' web extension.
 
 
-Mopidy-Deezer
-=============
-
-https://github.com/rusty-dev/mopidy-deezer
-
-Extension for playing music from the `Deezer <http://www.deezer.com/>`_ music
-streaming service.
-
-
 Mopidy-Dirble
 =============
 


### PR DESCRIPTION
The Deezer extension has been removed from Github at Deezer's request, so is no longer available.

https://github/dmca/blob/master/2018/2018-01-12-Deezer.md