### PR TITLE
Start mopidy after the snapcast server

### DIFF
--- a/extra/systemd/mopidy.service
+++ b/extra/systemd/mopidy.service
@@ -6,6 +6,7 @@ After=network.target
 After=nss-lookup.target
 After=pulseaudio.service
 After=remote-fs.target
+After=snapserver.service
 After=sound.target
 
 [Service]


### PR DESCRIPTION
Snapserver uses a fifo to communicate with Mopidy:
https://github.com/badaix/snapcast/blob/master/doc/player_setup.md#mopidy

Right now Mopidy doesn't support creating fifos, but is able to access them,
so we need snapserver to start before mopidy else we might end up with a
plain file instead of a fifo and the music would just loop for a few
seconds when playback stops. Like e.g. shown in this bug report:
https://github.com/badaix/snapcast/issues/96

Or one for Mopidy itself (about creating proper fifos)
https://github.com/mopidy/mopidy/issues/1636

For the time being this would be a proper workaround.