### PR TITLE
config: remove 10000 tracks limitation in playlists

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,8 @@ Feature release.
 - Set GLib program and application name, so that we show up as "Mopidy" in
   PulseAudio instead of "python ...". (PR: :issue:`1626`)
 
+- Remove limitation of 10000 tracks in playlists. (PR: :issue:`1600`) 
+
 
 v2.1.0 (2017-01-02)
 ===================

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -23,7 +23,7 @@ _core_schema['cache_dir'] = Path()
 _core_schema['config_dir'] = Path()
 _core_schema['data_dir'] = Path()
 # MPD supports at most 10k tracks, some clients segfault when this is exceeded.
-_core_schema['max_tracklist_length'] = Integer(minimum=1, maximum=10000)
+_core_schema['max_tracklist_length'] = Integer(minimum=1)
 _core_schema['restore_state'] = Boolean(optional=True)
 
 _logging_schema = ConfigSchema('logging')

--- a/tests/config/test_defaults.py
+++ b/tests/config/test_defaults.py
@@ -23,4 +23,3 @@ def test_core_schema_has_max_tracklist_length():
     max_tracklist_length_schema = config._core_schema['max_tracklist_length']
     assert isinstance(max_tracklist_length_schema, config.Integer)
     assert max_tracklist_length_schema._minimum == 1
-    assert max_tracklist_length_schema._maximum == 10000


### PR DESCRIPTION
This pull request remove the hard 10000 tracks limitation in playlists #1600 