### PR TITLE
Randomly selecting the topmost element displayed in file listing

### DIFF
--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -2,9 +2,9 @@ from __future__ import unicode_literals
 
 import logging
 import os
+import random
 import sys
 import urllib2
-import random
 
 from mopidy import backend, exceptions, models
 from mopidy.audio import scan, tags

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -4,6 +4,7 @@ import logging
 import os
 import sys
 import urllib2
+import random
 
 from mopidy import backend, exceptions, models
 from mopidy.audio import scan, tags
@@ -85,7 +86,13 @@ class FileLibraryProvider(backend.LibraryProvider):
             return (item.type != models.Ref.DIRECTORY, item.name)
         result.sort(key=order)
 
-        return result
+        size = len(result)
+        at = random.randint(0, size)
+        arr = [None] * size
+        for x in range(0, size):
+            arr[(x + at) % size] = result[x]
+
+        return arr
 
     def lookup(self, uri):
         logger.debug('Looking up file URI: %s', uri)


### PR DESCRIPTION
I have a collection of thousands of albums and I found myself playing the alphabetically first or last more often than those in the middle. Here is my attempt to fix that by increasing serendipity.

My patch keeps the ordering, but randomly selects the topmost element. As a result I am starting with different albums at the top every day which greatly increases the variety of the music I now listen too.

I offer such change for your consideration.