### PR TITLE
Change Playback state to Stopped when clearing the tracklist or remov…

### DIFF
--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -568,7 +568,11 @@ class TracklistController(object):
         tl_tracks = self.filter(criteria or kwargs)
         for tl_track in tl_tracks:
             if tl_track.tlid == self.core.playback.get_current_tlid():
-                self.core.playback.stop()
+                if self.get_consume() and self.next_track(tl_track) is not None:
+                    #pass
+                    logger.debug("Removing current track with consume enaled")
+                else:
+                    self.core.playback.stop()
             position = self._tl_tracks.index(tl_track)
             del self._tl_tracks[position]
         self._increase_version()

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -464,6 +464,7 @@ class TracklistController(object):
 
         Triggers the :meth:`mopidy.core.CoreListener.tracklist_changed` event.
         """
+        self.core.playback.stop()
         self._tl_tracks = []
         self._increase_version()
 
@@ -566,6 +567,8 @@ class TracklistController(object):
 
         tl_tracks = self.filter(criteria or kwargs)
         for tl_track in tl_tracks:
+            if tl_track.tlid == self.core.playback.get_current_tlid():
+                self.core.playback.stop()
             position = self._tl_tracks.index(tl_track)
             del self._tl_tracks[position]
         self._increase_version()


### PR DESCRIPTION
…ing the current tl_track.

This addresses an issue where removing the current tl_track while it is  playing means that track actually keeps playing but no longer exists in the tracklist.

This partially addresses #1690 but I found that this specific part of the issue affects all types of track, not just streams, so it seemed better as an individual PR. I will keep working on the stream issue.