### PR TITLE
Fix arbitrary file access in M3U backend

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,9 @@ Feature release.
 - Core: Define return value of `playlists.delete()` to be a bool, :class:`True`
   on success, :class:`False` otherwise. (PR: :issue:`1702`)
 
+- M3U: Ignore all attempts at accessing files outside the
+  :confval:`m3u/playlist_dir`. (Partly fixes: :issue:`1659`, PR: :issue:`1702`)
+
 - File: Change default ordering to show directories first, then files. (PR:
   :issue:`1595`)
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,9 @@ Feature release.
 - Core: Fix crash on `library.lookup(uris=[])`. (Fixes: :issue:`1619`, PR:
   :issue:`1620`)
 
+- Core: Define return value of `playlists.delete()` to be a bool, :class:`True`
+  on success, :class:`False` otherwise. (PR: :issue:`1702`)
+
 - File: Change default ordering to show directories first, then files. (PR:
   :issue:`1595`)
 

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -362,10 +362,16 @@ class PlaylistsProvider(object):
         """
         Delete playlist identified by the URI.
 
+        Returns :class:`True` if deleted, :class:`False` otherwise.
+
         *MUST be implemented by subclass.*
 
         :param uri: URI of the playlist to delete
         :type uri: string
+        :rtype: :class:`bool`
+
+        .. versionchanged:: 2.2
+            Return type defined.
         """
         raise NotImplementedError
 

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -93,6 +93,9 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             os.remove(self._abspath(path))
         except EnvironmentError as e:
             log_environment_error('Error deleting playlist %s' % uri, e)
+            return False
+        else:
+            return True
 
     def get_items(self, uri):
         path = translator.uri_to_path(uri)

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -110,7 +110,9 @@ def dump_items(items, fp):
             print(item.uri, file=fp)
 
 
-def playlist(path, items=[], mtime=None):
+def playlist(path, items=None, mtime=None):
+    if items is None:
+        items = []
     return models.Playlist(
         uri=path_to_uri(path),
         name=name_from_path(path),

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -141,26 +141,30 @@ class PlaylistTest(BasePlaylistsTest):
         self.assertFalse(self.sp2.create.called)
 
     def test_delete_selects_the_dummy1_backend(self):
-        self.core.playlists.delete('dummy1:a')
+        success = self.core.playlists.delete('dummy1:a')
 
+        self.assertTrue(success)
         self.sp1.delete.assert_called_once_with('dummy1:a')
         self.assertFalse(self.sp2.delete.called)
 
     def test_delete_selects_the_dummy2_backend(self):
-        self.core.playlists.delete('dummy2:a')
+        success = self.core.playlists.delete('dummy2:a')
 
+        self.assertTrue(success)
         self.assertFalse(self.sp1.delete.called)
         self.sp2.delete.assert_called_once_with('dummy2:a')
 
     def test_delete_with_unknown_uri_scheme_does_nothing(self):
-        self.core.playlists.delete('unknown:a')
+        success = self.core.playlists.delete('unknown:a')
 
+        self.assertFalse(success)
         self.assertFalse(self.sp1.delete.called)
         self.assertFalse(self.sp2.delete.called)
 
     def test_delete_ignores_backend_without_playlist_support(self):
-        self.core.playlists.delete('dummy3:a')
+        success = self.core.playlists.delete('dummy3:a')
 
+        self.assertFalse(success)
         self.assertFalse(self.sp1.delete.called)
         self.assertFalse(self.sp2.delete.called)
 
@@ -377,7 +381,7 @@ class DeleteBadBackendsTest(MockBackendCorePlaylistsBase):
 
     def test_backend_raises_exception(self, logger):
         self.playlists.delete.return_value.get.side_effect = Exception
-        self.assertIsNone(self.core.playlists.delete('dummy:/1'))
+        self.assertFalse(self.core.playlists.delete('dummy:/1'))
         logger.exception.assert_called_with(mock.ANY, 'DummyBackend')
 
 

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -94,7 +94,8 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.assertEqual(uri, playlist.uri)
         self.assertTrue(os.path.exists(path))
 
-        self.core.playlists.delete(playlist.uri)
+        success = self.core.playlists.delete(playlist.uri)
+        self.assertTrue(success)
         self.assertFalse(os.path.exists(path))
 
     def test_playlist_contents_is_written_to_disk(self):

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -122,7 +122,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
     def test_latin1_playlist_contents_is_written_to_disk(self):
         track = Track(uri=generate_song(1), name='Test\x9f', length=60000)
         playlist = self.core.playlists.create('test')
-        playlist = self.core.playlists.save(playlist.copy(tracks=[track]))
+        playlist = self.core.playlists.save(playlist.replace(tracks=[track]))
         path = os.path.join(self.playlists_dir, b'test.m3u')
 
         with open(path, 'rb') as f:
@@ -132,7 +132,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
     def test_utf8_playlist_contents_is_replaced_and_written_to_disk(self):
         track = Track(uri=generate_song(1), name='Test\u07b4', length=60000)
         playlist = self.core.playlists.create('test')
-        playlist = self.core.playlists.save(playlist.copy(tracks=[track]))
+        playlist = self.core.playlists.save(playlist.replace(tracks=[track]))
         path = os.path.join(self.playlists_dir, b'test.m3u')
 
         with open(path, 'rb') as f:

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -98,6 +98,11 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.assertTrue(success)
         self.assertFalse(os.path.exists(path))
 
+    def test_delete_on_path_outside_playlist_dir_returns_none(self):
+        success = self.core.playlists.delete('m3u:///etc/passwd')
+
+        self.assertFalse(success)
+
     def test_playlist_contents_is_written_to_disk(self):
         track = Track(uri=generate_song(1))
         playlist = self.core.playlists.create('test')
@@ -217,6 +222,11 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         self.assertEqual(original_playlist, looked_up_playlist)
 
+    def test_lookup_on_path_outside_playlist_dir_returns_none(self):
+        result = self.core.playlists.lookup('m3u:///etc/passwd')
+
+        self.assertIsNone(result)
+
     def test_refresh(self):
         playlist = self.core.playlists.create('test')
         self.assertEqual(playlist, self.core.playlists.lookup(playlist.uri))
@@ -251,6 +261,10 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.core.playlists.save(Playlist(uri=uri))
         path = os.path.join(self.playlists_dir, b'test.m3u')
         self.assertTrue(os.path.exists(path))
+
+    def test_save_on_path_outside_playlist_dir_returns_none(self):
+        result = self.core.playlists.save(Playlist(uri='m3u:///tmp/test.m3u'))
+        self.assertIsNone(result)
 
     def test_playlist_with_unknown_track(self):
         track = Track(uri='file:///dev/null')
@@ -328,6 +342,11 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
     def test_get_items_of_unknown_playlist_returns_none(self):
         item_refs = self.core.playlists.get_items('dummy:unknown')
+
+        self.assertIsNone(item_refs)
+
+    def test_get_items_from_file_outside_playlist_dir_returns_none(self):
+        item_refs = self.core.playlists.get_items('m3u:///etc/passwd')
 
         self.assertIsNone(item_refs)
 


### PR DESCRIPTION
This PR:

- Defines the return value of `core.playlists.delete()` to be a success bool.
- Updates the M3U backend to use `mopidy.internal.path.is_path_inside_base_dir()` to check if any received URI/path is inside the `m3u/playlist_dir` directory. If not, the request is treated as if the path doesn't exist.

This should plug the last part of #1659 and make us ready to release Mopidy 2.2.