### PR TITLE
http: allow local files to access websocket (Fixes #1711)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 This changelog is used to track all major changes to Mopidy.
 
 
+v2.2.1 (UNRELEASED)
+===================
+
+- HTTP: Stop blocking connections where the network location part of the Origin
+  header is empty, such as websocket connections originating from local files.
+  (Fixes: :issue:`1711`, PR: :issue:`1712`)
+
+
 v2.2.0 (2018-09-30)
 ===================
 

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import unittest
 
 import mock
 
@@ -86,3 +87,42 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
         for client in handlers.WebSocketHandler.clients:
             client.ws_connection = None
         handlers.WebSocketHandler.broadcast('message')
+
+
+class CheckOriginTests(unittest.TestCase):
+
+    def setUp(self):
+        self.headers = {'Host': 'localhost:6680'}
+        self.allowed = set()
+
+    def test_missing_origin_blocked(self):
+        self.assertFalse(handlers.check_origin(
+            None, self.headers, self.allowed))
+
+    def test_empty_origin_allowed(self):
+        self.assertTrue(handlers.check_origin('', self.headers, self.allowed))
+
+    def test_chrome_file_origin_allowed(self):
+        self.assertTrue(handlers.check_origin(
+            'file://', self.headers, self.allowed))
+
+    def test_firefox_null_origin_allowed(self):
+        self.assertTrue(handlers.check_origin(
+            'null', self.headers, self.allowed))
+
+    def test_same_host_origin_allowed(self):
+        self.assertTrue(handlers.check_origin(
+            'http://localhost:6680', self.headers, self.allowed))
+
+    def test_different_host_origin_blocked(self):
+        self.assertFalse(handlers.check_origin(
+            'http://other:6680', self.headers, self.allowed))
+
+    def test_different_port_blocked(self):
+        self.assertFalse(handlers.check_origin(
+            'http://localhost:80', self.headers, self.allowed))
+
+    def test_extra_origin_allowed(self):
+        self.allowed.add('other:6680')
+        self.assertTrue(handlers.check_origin(
+            'http://other:6680', self.headers, self.allowed))


### PR DESCRIPTION
check_origin() still ensures the Origin header is set but now only blocks
when missing from the allowed list *if* a network location was extracted
from the header. This prevents websocket connections originating from
local files (common in Apache Cordova apps such as Mopidy-Mobile) from
being blocked; these files don't really have a sensible value for Origin
so the client browser sets the header to something like 'file://' or
'null'.

Also added some tests for check_origin().