### PR TITLE
http: use current Tornado IOLoop when stopping. (Fixes #1715).

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,13 @@ Changelog
 This changelog is used to track all major changes to Mopidy.
 
 
+v2.2.2 (UNRELEASED)
+===================
+
+- HTTP: Fix hang on exit due to change in Tornado v5.0 IOLoop. (Fixes:
+  :issue:`1715`, PR: :issue:`1716`)
+
+
 v2.2.1 (2018-10-15)
 ===================
 

--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -100,20 +100,21 @@ class HttpServer(threading.Thread):
 
         self.app = None
         self.server = None
+        self.io_loop = None
 
     def run(self):
         self.app = tornado.web.Application(self._get_request_handlers())
         self.server = tornado.httpserver.HTTPServer(self.app)
         self.server.add_sockets(self.sockets)
 
-        tornado.ioloop.IOLoop.instance().start()
+        self.io_loop = tornado.ioloop.IOLoop.current()
+        self.io_loop.start()
 
         logger.debug('Stopped HTTP server')
 
     def stop(self):
         logger.debug('Stopping HTTP server')
-        tornado.ioloop.IOLoop.instance().add_callback(
-            tornado.ioloop.IOLoop.instance().stop)
+        self.io_loop.add_callback(self.io_loop.stop)
 
     def _get_request_handlers(self):
         request_handlers = []


### PR DESCRIPTION
From Tornado v5.0:
> IOLoop.instance is now a deprecated alias for IOLoop.current. Applications that need the cross-thread communication behavior facilitated by IOLoop.instance should use their own global variable instead.

We were using IOLoop.instance to stop the HTTP server thread from a different thread. 