### PR TITLE
Specifying 'trace' level logging through the loglevels config

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -209,8 +209,8 @@ Logging configuration
     The ``loglevels`` config section can be used to change the log level for
     specific parts of Mopidy during development or debugging. Each key in the
     config section should match the name of a logger. The value is the log
-    level to use for that logger, one of ``debug``, ``info``, ``warning``,
-    ``error``, or ``critical``.
+    level to use for that logger, one of ``trace``, ``debug``, ``info``,
+    ``warning``, ``error``, or ``critical``.
 
 .. confval:: logcolors/*
 

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -233,6 +233,7 @@ class LogLevel(ConfigValue):
         b'warning': logging.WARNING,
         b'info': logging.INFO,
         b'debug': logging.DEBUG,
+        b'trace': log.TRACE_LOG_LEVEL,
         b'all': logging.NOTSET,
     }
 

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -10,6 +10,7 @@ import mock
 
 from mopidy import compat
 from mopidy.config import types
+from mopidy.internal import log
 
 # TODO: DecodeTest and EncodeTest
 
@@ -293,6 +294,7 @@ class LogLevelTest(unittest.TestCase):
         'warning': logging.WARNING,
         'info': logging.INFO,
         'debug': logging.DEBUG,
+        'trace': log.TRACE_LOG_LEVEL,
         'all': logging.NOTSET,
     }
 


### PR DESCRIPTION
I don't know if we want to expose our internal custom log level but I have found this very useful recently. 