### PR TITLE
Called prepare_change() before set_uri() as mentioned in audio/actor.py.

### DIFF
--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -248,6 +248,7 @@ class PlaybackProvider(object):
                 'Backend translated URI from %s to %s', track.uri, uri)
         if not uri:
             return False
+        self.audio.prepare_change()
         self.audio.set_uri(uri).get()
         return True
 


### PR DESCRIPTION
See "discourse" https://discourse.mopidy.com/t/mopidy-mpd-status-not-always-updated-with-gmusic/2842/2

Fixes playing the same track even after track change.