### PR TITLE
docs: Update OSX Homebrew installation instructions.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -90,6 +90,8 @@ Bug fix release.
 - Files: Fix crash due to mix of text and bytes in paths that come from
   ``$XDG_CONFIG_HOME/user-dirs.dirs``. (Fixes: :issue:`1676`, :issue:`1725`)
 
+- Docs: update OSX Homebrew installation instructions.
+
 
 v2.2.1 (2018-10-15)
 ===================

--- a/docs/installation/osx.rst
+++ b/docs/installation/osx.rst
@@ -9,9 +9,6 @@ If you are running OS X, you can install everything needed with Homebrew.
 
        xcode-select --install
 
-#. Install `XQuartz <http://xquartz.macosforge.org/>`_. This is needed by
-   GStreamer which Mopidy use heavily.
-
 #. Install `Homebrew <https://github.com/Homebrew/homebrew>`_.
 
 #. If you are already using Homebrew, make sure your installation is up to
@@ -51,6 +48,19 @@ If you are running OS X, you can install everything needed with Homebrew.
    Homebrew tap, run::
 
        brew tap mopidy/mopidy
+
+   .. note::
+
+       Mopidy currently requires that a few of its dependencies be built with
+       Python 2 support via the ``--with-python@2`` build option. To ensure
+       that this is done for your installation, it is recommended to
+       uninstall the dependencies first with::
+
+            brew uninstall --ignore-dependencies gst-python pygobject3
+
+
+       These dependencies will be re-installed automatically when mopidy is
+       installed.
 
 #. To install Mopidy, run::
 

--- a/docs/installation/osx.rst
+++ b/docs/installation/osx.rst
@@ -59,7 +59,7 @@ If you are running OS X, you can install everything needed with Homebrew.
             brew uninstall --ignore-dependencies gst-python pygobject3
 
 
-       These dependencies will be re-installed automatically when mopidy is
+       These dependencies will be re-installed automatically when Mopidy is
        installed.
 
 #. To install Mopidy, run::


### PR DESCRIPTION
Seems to me that we should no longer be recommending installing Quartz as a dependency, since the Mopidy Homebrew formula already installs ``gst-python`` and ``pygobject3``?

I have also updated the documentation to include the recommendations in https://github.com/mopidy/homebrew-mopidy/issues/29#issuecomment-448410504.