### PR TITLE
audio: removed unused fakesink. (Fixes #1528)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -5,6 +5,14 @@ Changelog
 This changelog is used to track all major changes to Mopidy.
 
 
+v2.2.3 (UNRELEASED)
+===================
+
+Bug fix release.
+
+- Audio: Fix switching between tracks with different sample rates. (Fixes:
+  :issue:`1528`, PR: :issue:`1735`)
+
 v2.2.2 (2018-12-29)
 ===================
 

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -114,12 +114,6 @@ class _Outputs(Gst.Bin):
         ghost_pad = Gst.GhostPad.new('sink', self._tee.get_static_pad('sink'))
         self.add_pad(ghost_pad)
 
-        # Add an always connected fakesink which respects the clock so the tee
-        # doesn't fail even if we don't have any outputs.
-        fakesink = Gst.ElementFactory.make('fakesink')
-        fakesink.set_property('sync', True)
-        self._add(fakesink)
-
     def add_output(self, description):
         # XXX This only works for pipelines not in use until #790 gets done.
         try:


### PR DESCRIPTION
The 'always connected fakesink' is causing problems when switching
between tracks with different sample rates and with some custom
output pipelines. Since it's only there to support dynamic outputs,
which we don't yet support, we might as well remove it for now.