### PR TITLE
local, file: exclude .pdf and .zip in default config

### DIFF
--- a/mopidy/file/ext.conf
+++ b/mopidy/file/ext.conf
@@ -7,5 +7,7 @@ show_dotfiles = false
 excluded_file_extensions =
   .jpg
   .jpeg
+  .pdf
+  .zip
 follow_symlinks = false
 metadata_timeout = 1000

--- a/mopidy/local/ext.conf
+++ b/mopidy/local/ext.conf
@@ -14,3 +14,5 @@ excluded_file_extensions =
   .nfo
   .png
   .txt
+  .pdf
+  .zip


### PR DESCRIPTION
Hi - my local music collection is littered with PDF and Zip and it seems to me there's no reason not to exclude them, right? JPEGs are excluded by default (e.g. cover art) and actually that's the same reason why I have PDFs - "liner notes" etc. I hope this proposed pull is appropriate. Thanks for your work.