### PR TITLE
test: flake8 to ignore camelcase usage in our deps.

### DIFF
--- a/mopidy/internal/playlists.py
+++ b/mopidy/internal/playlists.py
@@ -6,9 +6,9 @@ from mopidy.compat import configparser
 from mopidy.internal import validation
 
 try:
-    import xml.etree.cElementTree as elementtree
+    import xml.etree.cElementTree as elementtree  # noqa: N813
 except ImportError:
-    import xml.etree.ElementTree as elementtree
+    import xml.etree.ElementTree as elementtree  # noqa: N813
 
 
 def parse(data):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -164,7 +164,7 @@ __HASH10__ = foo # = should all be treated as a comment."""
 
 
 class PreProcessorTest(unittest.TestCase):
-    maxDiff = None  # Show entire diff.
+    maxDiff = None  # Show entire diff.  # noqa: N815
 
     def test_empty_config(self):
         result = config._preprocess('')
@@ -230,7 +230,7 @@ class PreProcessorTest(unittest.TestCase):
 
 
 class PostProcessorTest(unittest.TestCase):
-    maxDiff = None  # Show entire diff.
+    maxDiff = None  # Show entire diff.  # noqa: N815
 
     def test_empty_config(self):
         result = config._postprocess('[__COMMENTS__]')

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -542,7 +542,7 @@ class TestCurrentAndPendingTlTrack(BaseTest):
     'mopidy.core.playback.listener.CoreListener', spec=core.CoreListener)
 class EventEmissionTest(BaseTest):
 
-    maxDiff = None
+    maxDiff = None  # noqa: N815
 
     def test_play_when_stopped_emits_events(self, listener_mock):
         tl_tracks = self.core.tracklist.get_tl_tracks()

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -237,7 +237,7 @@ class ExpandPathTest(unittest.TestCase):
 
 
 class FindMTimesTest(unittest.TestCase):
-    maxDiff = None
+    maxDiff = None  # noqa: N815
 
     def setUp(self):  # noqa: N802
         self.tmpdir = tempfile.mkdtemp(b'.mopidy-tests')

--- a/tests/local/test_json.py
+++ b/tests/local/test_json.py
@@ -9,7 +9,7 @@ from tests import path_to_data_dir
 
 
 class BrowseCacheTest(unittest.TestCase):
-    maxDiff = None
+    maxDiff = None  # noqa: N815
 
     def setUp(self):  # noqa: N802
         self.uris = ['local:track:foo/bar/song1',


### PR DESCRIPTION
Ignore N813 when importing the c version of xml.etree.ElementTree.

Ignore N815 when controlling failure diff length in unittest.