### PR TITLE
Disable buffering handling during track change. (Fixes #1722)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,9 @@ Bug fix release.
 - Audio: Fix switching between tracks with different sample rates. (Fixes:
   :issue:`1528`, PR: :issue:`1735`)
 
+- Audio: Prevent buffering handling interfering with track changes. (Fixes:
+  :issue:`1722`, PR: :issue:`1740`)
+
 v2.2.2 (2018-12-29)
 ===================
 

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -256,7 +256,7 @@ class _Handler(object):
         target_state = _GST_STATE_MAPPING.get(self._audio._target_state)
         if target_state is None:
             # XXX: Workaround for #1430, to be fixed properly by #1222.
-            logger.debug('Race condition happened. See #1222 and #1430.')
+            logger.warn('Race condition happened. See #1222 and #1430.')
             return
         if target_state == new_state:
             target_state = None


### PR DESCRIPTION
Successor to #1734 which retains our GST `BUFFERING` message handling but prevents it from erroneously setting the pipeline state `PLAYING`/`PAUSED` when we want to stay in `READY` (during track changes).