### PR TITLE
test: Skips scanner tags test when there's no mp3 support.

### DIFF
--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -45,6 +45,9 @@ class ScannerTest(unittest.TestCase):
 
     def test_tags_is_set(self):
         self.scan(self.find('scanner/simple'))
+
+        self.check_if_missing_plugin()
+
         self.assert_(self.result.values()[0].tags)
 
     def test_errors_is_not_set(self):


### PR DESCRIPTION
The file order returned by .find is not deterministic which made
testing the first scanner result fail when it happened to be an unsupported
media format (e.g. mp3).