### PR TITLE
Include Gstreamer mp3 plugins in Travis environment.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ env:
 
 before_install:
   - "sudo apt-get update -qq"
-  - "sudo apt-get install -y gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 graphviz-dev gstreamer1.0-plugins-good gstreamer1.0-plugins-bad python-gst-1.0"
+  - "sudo apt-get install -y gir1.2-gst-plugins-base-1.0 gir1.2-gstreamer-1.0 graphviz-dev gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly python-gst-1.0"
 
 install:
   - "pip install tox"

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -46,8 +46,6 @@ class ScannerTest(unittest.TestCase):
     def test_tags_is_set(self):
         self.scan(self.find('scanner/simple'))
 
-        self.check_if_missing_plugin()
-
         self.assert_(self.result.values()[0].tags)
 
     def test_errors_is_not_set(self):


### PR DESCRIPTION
Can remove all the `check_if_missing_plugin()` calls if we are aiming to always have mp3 support. 

Probably need to force a few Travis runs to make sure this actually worked.