### PR TITLE
Close MPD connection following an exception in handler.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,15 @@ This changelog is used to track all major changes to Mopidy.
 For older releases, see :ref:`history`.
 
 
+v2.2.4 (UNRELEASED)
+===================
+
+Bug fix release.
+
+- Network: Close connection following an exception in the protocol handler.
+  (Fixes: :issue:`1762`, PR: :issue:`1765`)
+
+
 v2.2.3 (2019-06-20)
 ===================
 

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -425,8 +425,12 @@ class LineProtocol(pykka.ThreadingActor):
         if not self.prevent_timeout:
             self.connection.enable_timeout()
 
+    def on_failure(self, exception_type, exception_value, traceback):
+        """Clean up connection resouces when actor fails."""
+        self.connection.stop('Actor failed.')
+
     def on_stop(self):
-        """Ensure that cleanup when actor stops."""
+        """Clean up connection resouces when actor stops."""
         self.connection.stop('Actor is shutting down.')
 
     def parse_lines(self):

--- a/tests/internal/network/test_lineprotocol.py
+++ b/tests/internal/network/test_lineprotocol.py
@@ -121,6 +121,12 @@ class LineProtocolTest(unittest.TestCase):
             self.mock, {'received': 'line1\nline2\n'})
         self.assertEqual(2, self.mock.on_line_received.call_count)
 
+    def test_on_failure_calls_stop(self):
+        self.mock.connection = Mock(spec=network.Connection)
+
+        network.LineProtocol.on_failure(self.mock, None, None, None)
+        self.mock.connection.stop.assert_called_once_with('Actor failed.')
+
     def test_parse_lines_emtpy_buffer(self):
         self.mock.delimiter = re.compile(r'\n')
         self.mock.recv_buffer = ''


### PR DESCRIPTION
This goes towards fixing #1762. Needs some tests and changelog etc.