### PR TITLE
Core API: Remove deprecated properties

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -208,37 +208,11 @@ Deprecated API features
   Though these features still work, they are slated to go away in the next
   major Mopidy release.
 
-Core
-----
-
-.. autoattribute:: mopidy.core.Core.version
-.. autoattribute:: mopidy.core.Core.uri_schemes
-
-TracklistController
--------------------
-
-.. autoattribute:: mopidy.core.TracklistController.tl_tracks
-.. autoattribute:: mopidy.core.TracklistController.tracks
-.. autoattribute:: mopidy.core.TracklistController.version
-.. autoattribute:: mopidy.core.TracklistController.length
-
-.. autoattribute:: mopidy.core.TracklistController.consume
-.. autoattribute:: mopidy.core.TracklistController.random
-.. autoattribute:: mopidy.core.TracklistController.repeat
-.. autoattribute:: mopidy.core.TracklistController.single
-
 PlaybackController
 ------------------
 
 .. automethod:: mopidy.core.PlaybackController.get_mute
 .. automethod:: mopidy.core.PlaybackController.get_volume
-
-.. autoattribute:: mopidy.core.PlaybackController.current_tl_track
-.. autoattribute:: mopidy.core.PlaybackController.current_track
-.. autoattribute:: mopidy.core.PlaybackController.state
-.. autoattribute:: mopidy.core.PlaybackController.time_position
-.. autoattribute:: mopidy.core.PlaybackController.mute
-.. autoattribute:: mopidy.core.PlaybackController.volume
 
 LibraryController
 -----------------
@@ -250,5 +224,3 @@ PlaylistsController
 
 .. automethod:: mopidy.core.PlaylistsController.filter
 .. automethod:: mopidy.core.PlaylistsController.get_playlists
-
-.. autoattribute:: mopidy.core.PlaylistsController.playlists

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,7 +23,26 @@ Dependencies
 Core API
 --------
 
-- (no changes yet)
+- Removed properties that has been deprecated since 1.0, released in 2015.
+  Everything removed has corresponding methods that should be used instead.
+
+  - :attr:`mopidy.core.Core.uri_schemes`
+  - :attr:`mopidy.core.Core.version`
+  - :attr:`mopidy.core.PlaybackController.current_tl_track`
+  - :attr:`mopidy.core.PlaybackController.current_track`
+  - :attr:`mopidy.core.PlaybackController.state`
+  - :attr:`mopidy.core.PlaybackController.time_position`
+  - :attr:`mopidy.core.PlaybackController.volume`
+  - :attr:`mopidy.core.PlaybackController.mute`
+  - :attr:`mopidy.core.PlaylistController.playlists`
+  - :attr:`mopidy.core.TracklistController.tl_tracks`
+  - :attr:`mopidy.core.TracklistController.tracks`
+  - :attr:`mopidy.core.TracklistController.length`
+  - :attr:`mopidy.core.TracklistController.version`
+  - :attr:`mopidy.core.TracklistController.consume`
+  - :attr:`mopidy.core.TracklistController.random`
+  - :attr:`mopidy.core.TracklistController.repeat`
+  - :attr:`mopidy.core.TracklistController.single`
 
 Backend API
 -----------

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -18,7 +18,6 @@ from mopidy.core.playback import PlaybackController
 from mopidy.core.playlists import PlaylistsController
 from mopidy.core.tracklist import TracklistController
 from mopidy.internal import path, storage, validation, versioning
-from mopidy.internal.deprecation import deprecated_property
 from mopidy.internal.models import CoreState
 
 
@@ -71,21 +70,9 @@ class Core(
         uri_schemes = itertools.chain(*results)
         return sorted(uri_schemes)
 
-    uri_schemes = deprecated_property(get_uri_schemes)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_uri_schemes` instead.
-    """
-
     def get_version(self):
         """Get version of the Mopidy core API"""
         return versioning.get_version()
-
-    version = deprecated_property(get_version)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_version` instead.
-    """
 
     def reached_end_of_stream(self):
         self.playback._on_end_of_stream()

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -44,8 +44,6 @@ class PlaybackController(object):
         uri_scheme = urllib.parse.urlparse(tl_track.track.uri).scheme
         return self.backends.with_playback.get(uri_scheme, None)
 
-    # Properties
-
     def get_current_tl_track(self):
         """Get the currently playing or selected track.
 
@@ -60,12 +58,6 @@ class PlaybackController(object):
         """
         self._current_tl_track = value
 
-    current_tl_track = deprecation.deprecated_property(get_current_tl_track)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_current_tl_track` instead.
-    """
-
     def get_current_track(self):
         """
         Get the currently playing or selected track.
@@ -75,12 +67,6 @@ class PlaybackController(object):
         Returns a :class:`mopidy.models.Track` or :class:`None`.
         """
         return getattr(self.get_current_tl_track(), 'track', None)
-
-    current_track = deprecation.deprecated_property(get_current_track)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_current_track` instead.
-    """
 
     def get_current_tlid(self):
         """
@@ -127,12 +113,6 @@ class PlaybackController(object):
 
         self._trigger_playback_state_changed(old_state, new_state)
 
-    state = deprecation.deprecated_property(get_state, set_state)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_state` and :meth:`set_state` instead.
-    """
-
     def get_time_position(self):
         """Get time position in milliseconds."""
         if self._pending_position is not None:
@@ -143,12 +123,6 @@ class PlaybackController(object):
             return backend.playback.get_time_position().get()
         else:
             return 0
-
-    time_position = deprecation.deprecated_property(get_time_position)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_time_position` instead.
-    """
 
     def get_volume(self):
         """
@@ -168,15 +142,6 @@ class PlaybackController(object):
         deprecation.warn('core.playback.set_volume')
         return self.core.mixer.set_volume(volume)
 
-    volume = deprecation.deprecated_property(get_volume, set_volume)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`core.mixer.get_volume()
-        <mopidy.core.MixerController.get_volume>` and
-        :meth:`core.mixer.set_volume()
-        <mopidy.core.MixerController.set_volume>` instead.
-    """
-
     def get_mute(self):
         """
         .. deprecated:: 1.0
@@ -194,17 +159,6 @@ class PlaybackController(object):
         """
         deprecation.warn('core.playback.set_mute')
         return self.core.mixer.set_mute(mute)
-
-    mute = deprecation.deprecated_property(get_mute, set_mute)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`core.mixer.get_mute()
-        <mopidy.core.MixerController.get_mute>` and
-        :meth:`core.mixer.set_mute()
-        <mopidy.core.MixerController.set_mute>` instead.
-    """
-
-    # Methods
 
     def _on_end_of_stream(self):
         self.set_state(PlaybackState.STOPPED)

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -301,10 +301,11 @@ class PlaybackController(object):
 
         Used by :class:`mopidy.core.TracklistController`.
         """
-        if not self.core.tracklist.tl_tracks:
+        tl_tracks = self.core.tracklist.get_tl_tracks()
+        if not tl_tracks:
             self.stop()
             self._set_current_tl_track(None)
-        elif self.get_current_tl_track() not in self.core.tracklist.tl_tracks:
+        elif self.get_current_tl_track() not in tl_tracks:
             self._set_current_tl_track(None)
 
     def next(self):
@@ -511,7 +512,7 @@ class PlaybackController(object):
                 'Client seeked to negative position. Seeking to zero.')
             time_position = 0
 
-        if not self.core.tracklist.tracks:
+        if not self.core.tracklist.get_length():
             return False
 
         if self.get_state() == PlaybackState.STOPPED:
@@ -558,7 +559,7 @@ class PlaybackController(object):
 
     def _trigger_track_playback_paused(self):
         logger.debug('Triggering track playback paused event')
-        if self.current_track is None:
+        if self.get_current_tl_track() is None:
             return
         listener.CoreListener.send(
             'track_playback_paused',
@@ -567,7 +568,7 @@ class PlaybackController(object):
 
     def _trigger_track_playback_resumed(self):
         logger.debug('Triggering track playback resumed event')
-        if self.current_track is None:
+        if self.get_current_tl_track() is None:
             return
         listener.CoreListener.send(
             'track_playback_resumed',

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -133,12 +133,6 @@ class PlaylistsController(object):
             return [
                 Playlist(uri=r.uri, name=r.name) for r in playlist_refs]
 
-    playlists = deprecation.deprecated_property(get_playlists)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`as_list` and :meth:`get_items` instead.
-    """
-
     def create(self, name, uri_scheme=None):
         """
         Create a new playlist.

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -238,7 +238,7 @@ class PlaylistsController(object):
         validation.check_query(
             criteria, validation.PLAYLIST_FIELDS, list_values=False)
 
-        matches = self.playlists  # TODO: stop using self playlists
+        matches = self.get_playlists()
         for (key, value) in criteria.iteritems():
             matches = filter(lambda p: getattr(p, key) == value, matches)
         return matches

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -23,37 +23,17 @@ class TracklistController(object):
 
         self._shuffled = []
 
-    # Properties
-
     def get_tl_tracks(self):
         """Get tracklist as list of :class:`mopidy.models.TlTrack`."""
         return self._tl_tracks[:]
-
-    tl_tracks = deprecation.deprecated_property(get_tl_tracks)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_tl_tracks` instead.
-    """
 
     def get_tracks(self):
         """Get tracklist as list of :class:`mopidy.models.Track`."""
         return [tl_track.track for tl_track in self._tl_tracks]
 
-    tracks = deprecation.deprecated_property(get_tracks)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_tracks` instead.
-    """
-
     def get_length(self):
         """Get length of the tracklist."""
         return len(self._tl_tracks)
-
-    length = deprecation.deprecated_property(get_length)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_length` instead.
-    """
 
     def get_version(self):
         """
@@ -68,12 +48,6 @@ class TracklistController(object):
         self._version += 1
         self.core.playback._on_tracklist_change()
         self._trigger_tracklist_changed()
-
-    version = deprecation.deprecated_property(get_version)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_version` instead.
-    """
 
     def get_consume(self):
         """Get consume mode.
@@ -97,12 +71,6 @@ class TracklistController(object):
         if self.get_consume() != value:
             self._trigger_options_changed()
         return setattr(self, '_consume', value)
-
-    consume = deprecation.deprecated_property(get_consume, set_consume)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_consume` and :meth:`set_consume` instead.
-    """
 
     def get_random(self):
         """Get random mode.
@@ -129,12 +97,6 @@ class TracklistController(object):
             self._shuffled = self.get_tl_tracks()
             random.shuffle(self._shuffled)
         return setattr(self, '_random', value)
-
-    random = deprecation.deprecated_property(get_random, set_random)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_random` and :meth:`set_random` instead.
-    """
 
     def get_repeat(self):
         """
@@ -163,12 +125,6 @@ class TracklistController(object):
             self._trigger_options_changed()
         return setattr(self, '_repeat', value)
 
-    repeat = deprecation.deprecated_property(get_repeat, set_repeat)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_repeat` and :meth:`set_repeat` instead.
-    """
-
     def get_single(self):
         """
         Get single mode.
@@ -193,14 +149,6 @@ class TracklistController(object):
         if self.get_single() != value:
             self._trigger_options_changed()
         return setattr(self, '_single', value)
-
-    single = deprecation.deprecated_property(get_single, set_single)
-    """
-    .. deprecated:: 1.0
-        Use :meth:`get_single` and :meth:`set_single` instead.
-    """
-
-    # Methods
 
     def index(self, tl_track=None, tlid=None):
         """

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -84,17 +84,3 @@ def ignore(ids=None):
         else:
             warnings.filterwarnings('ignore', category=DeprecationWarning)
         yield
-
-
-def deprecated_property(
-        getter=None, setter=None, message='Property is deprecated'):
-
-    # During development, this is a convenient place to add logging, emit
-    # warnings, or ``assert False`` to ensure you are not using any of the
-    # deprecated properties.
-    #
-    # Using inspect to find the call sites to emit proper warnings makes
-    # parallel execution of our test suite slower than serial execution. Thus,
-    # we don't want to add any extra overhead here by default.
-
-    return property(getter, setter)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,3 +1,8 @@
+[tool:pytest]
+filterwarnings =
+    error::DeprecationWarning
+
+
 [flake8]
 application-import-names = mopidy,tests
 exclude = .git,.tox,build,js,tmp
@@ -5,6 +10,7 @@ exclude = .git,.tox,build,js,tmp
 # - E402 module level import not at top of file
 # - W504 line break after binary operator
 ignore = E402, W504
+
 
 [wheel]
 universal = 1

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -34,7 +34,7 @@ class CoreActorTest(unittest.TestCase):
         pykka.ActorRegistry.stop_all()
 
     def test_uri_schemes_has_uris_from_all_backends(self):
-        result = self.core.uri_schemes
+        result = self.core.get_uri_schemes()
 
         self.assertIn('dummy1', result)
         self.assertIn('dummy2', result)
@@ -49,7 +49,7 @@ class CoreActorTest(unittest.TestCase):
             Core, mixer=None, backends=[self.backend1, self.backend2])
 
     def test_version(self):
-        self.assertEqual(self.core.version, versioning.get_version())
+        self.assertEqual(self.core.get_version(), versioning.get_version())
 
 
 class CoreActorSaveLoadStateTest(unittest.TestCase):

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -50,7 +50,7 @@ class TracklistTest(unittest.TestCase):
         self.library.lookup.assert_called_once_with('dummy1:a')
         self.assertEqual(1, len(tl_tracks))
         self.assertEqual(self.tracks[0], tl_tracks[0].track)
-        self.assertEqual(tl_tracks, self.core.tracklist.tl_tracks[-1:])
+        self.assertEqual(tl_tracks, self.core.tracklist.get_tl_tracks()[-1:])
 
     def test_add_by_uris_looks_up_uris_in_library(self):
         self.library.lookup.reset_mock()
@@ -68,7 +68,7 @@ class TracklistTest(unittest.TestCase):
         self.assertEqual(self.tracks[1], tl_tracks[1].track)
         self.assertEqual(self.tracks[2], tl_tracks[2].track)
         self.assertEqual(
-            tl_tracks, self.core.tracklist.tl_tracks[-len(tl_tracks):])
+            tl_tracks, self.core.tracklist.get_tl_tracks()[-len(tl_tracks):])
 
     def test_remove_removes_tl_tracks_matching_query(self):
         tl_tracks = self.core.tracklist.remove({'name': ['foo']})
@@ -76,8 +76,9 @@ class TracklistTest(unittest.TestCase):
         self.assertEqual(2, len(tl_tracks))
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
-        self.assertEqual(1, self.core.tracklist.length)
-        self.assertListEqual(self.tl_tracks[2:], self.core.tracklist.tl_tracks)
+        self.assertEqual(1, self.core.tracklist.get_length())
+        self.assertListEqual(
+            self.tl_tracks[2:], self.core.tracklist.get_tl_tracks())
 
     def test_remove_works_with_dict_instead_of_kwargs(self):
         tl_tracks = self.core.tracklist.remove({'name': ['foo']})
@@ -85,8 +86,9 @@ class TracklistTest(unittest.TestCase):
         self.assertEqual(2, len(tl_tracks))
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
-        self.assertEqual(1, self.core.tracklist.length)
-        self.assertListEqual(self.tl_tracks[2:], self.core.tracklist.tl_tracks)
+        self.assertEqual(1, self.core.tracklist.get_length())
+        self.assertListEqual(
+            self.tl_tracks[2:], self.core.tracklist.get_tl_tracks())
 
     def test_filter_returns_tl_tracks_matching_query(self):
         tl_tracks = self.core.tracklist.filter({'name': ['foo']})

--- a/tests/local/test_tracklist.py
+++ b/tests/local/test_tracklist.py
@@ -254,8 +254,8 @@ class LocalTracklistProviderTest(unittest.TestCase):
             self.controller.move(2, 1, 0).get()
 
     def test_tracks_attribute_is_immutable(self):
-        tracks1 = self.controller.tracks.get()
-        tracks2 = self.controller.tracks.get()
+        tracks1 = self.controller.get_tracks().get()
+        tracks2 = self.controller.get_tracks().get()
         self.assertNotEqual(id(tracks1), id(tracks2))
 
     @populate_tracklist

--- a/tests/mpd/protocol/test_current_playlist.py
+++ b/tests/mpd/protocol/test_current_playlist.py
@@ -24,8 +24,9 @@ class AddCommandsTest(protocol.BaseTestCase):
         for track in [self.tracks[0], self.tracks[0], self.tracks[1]]:
             self.send_request('add "%s"' % track.uri)
 
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 3)
-        self.assertEqual(self.core.tracklist.tracks.get()[2], self.tracks[1])
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 3)
+        self.assertEqual(
+            self.core.tracklist.get_tracks().get()[2], self.tracks[1])
         self.assertEqualResponse('OK')
 
     def test_add_with_uri_not_found_in_library_should_ack(self):
@@ -38,7 +39,7 @@ class AddCommandsTest(protocol.BaseTestCase):
             'dummy:/': [self.refs['/a']]}
 
         self.send_request('add ""')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 0)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 0)
         self.assertInResponse('OK')
 
     def test_add_with_library_should_recurse(self):
@@ -47,7 +48,7 @@ class AddCommandsTest(protocol.BaseTestCase):
             'dummy:/foo': [self.refs['/foo/b']]}
 
         self.send_request('add "/dummy"')
-        self.assertEqual(self.core.tracklist.tracks.get(), self.tracks)
+        self.assertEqual(self.core.tracklist.get_tracks().get(), self.tracks)
         self.assertInResponse('OK')
 
     def test_add_root_should_not_add_anything_and_ok(self):
@@ -55,13 +56,13 @@ class AddCommandsTest(protocol.BaseTestCase):
             'dummy:/': [self.refs['/a']]}
 
         self.send_request('add "/"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 0)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 0)
         self.assertInResponse('OK')
 
     def test_addid_without_songpos(self):
         for track in [self.tracks[0], self.tracks[0], self.tracks[1]]:
             self.send_request('addid "%s"' % track.uri)
-        tl_tracks = self.core.tracklist.tl_tracks.get()
+        tl_tracks = self.core.tracklist.get_tl_tracks().get()
 
         self.assertEqual(len(tl_tracks), 3)
         self.assertEqual(tl_tracks[2].track, self.tracks[1])
@@ -72,7 +73,7 @@ class AddCommandsTest(protocol.BaseTestCase):
         for track in [self.tracks[0], self.tracks[0]]:
             self.send_request('add "%s"' % track.uri)
         self.send_request('addid "%s" "1"' % self.tracks[1].uri)
-        tl_tracks = self.core.tracklist.tl_tracks.get()
+        tl_tracks = self.core.tracklist.get_tl_tracks().get()
 
         self.assertEqual(len(tl_tracks), 3)
         self.assertEqual(tl_tracks[1].track, self.tracks[1])
@@ -105,55 +106,55 @@ class DeleteCommandsTest(BasePopulatedTracklistTestCase):
 
     def test_clear(self):
         self.send_request('clear')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 0)
-        self.assertEqual(self.core.playback.current_track.get(), None)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 0)
+        self.assertEqual(self.core.playback.get_current_track().get(), None)
         self.assertInResponse('OK')
 
     def test_delete_songpos(self):
-        tl_tracks = self.core.tracklist.tl_tracks.get()
+        tl_tracks = self.core.tracklist.get_tl_tracks().get()
         self.send_request('delete "%d"' % tl_tracks[1].tlid)
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 5)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 5)
         self.assertInResponse('OK')
 
     def test_delete_songpos_out_of_bounds(self):
         self.send_request('delete "8"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 6)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 6)
         self.assertEqualResponse('ACK [2@0] {delete} Bad song index')
 
     def test_delete_open_range(self):
         self.send_request('delete "1:"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 1)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 1)
         self.assertInResponse('OK')
 
     # TODO: check how this should work.
     # def test_delete_open_upper_range(self):
     #     self.send_request('delete ":8"')
-    #     self.assertEqual(len(self.core.tracklist.tracks.get()), 0)
+    #     self.assertEqual(len(self.core.tracklist.get_tracks().get()), 0)
     #     self.assertInResponse('OK')
 
     def test_delete_closed_range(self):
         self.send_request('delete "1:3"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 4)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 4)
         self.assertInResponse('OK')
 
     def test_delete_entire_range_out_of_bounds(self):
         self.send_request('delete "8:9"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 6)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 6)
         self.assertEqualResponse('ACK [2@0] {delete} Bad song index')
 
     def test_delete_upper_range_out_of_bounds(self):
         self.send_request('delete "5:9"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 5)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 5)
         self.assertEqualResponse('OK')
 
     def test_deleteid(self):
         self.send_request('deleteid "1"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 5)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 5)
         self.assertInResponse('OK')
 
     def test_deleteid_does_not_exist(self):
         self.send_request('deleteid "12345"')
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 6)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 6)
         self.assertEqualResponse('ACK [50@0] {deleteid} No such song')
 
 
@@ -161,25 +162,25 @@ class MoveCommandsTest(BasePopulatedTracklistTestCase):
 
     def test_move_songpos(self):
         self.send_request('move "1" "0"')
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result, ['b', 'a', 'c', 'd', 'e', 'f'])
         self.assertInResponse('OK')
 
     def test_move_open_range(self):
         self.send_request('move "2:" "0"')
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result, ['c', 'd', 'e', 'f', 'a', 'b'])
         self.assertInResponse('OK')
 
     def test_move_closed_range(self):
         self.send_request('move "1:3" "0"')
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result, ['b', 'c', 'a', 'd', 'e', 'f'])
         self.assertInResponse('OK')
 
     def test_moveid(self):
         self.send_request('moveid "5" "2"')
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result, ['a', 'b', 'e', 'c', 'd', 'f'])
         self.assertInResponse('OK')
 
@@ -345,7 +346,7 @@ class PlChangeCommandTest(BasePopulatedTracklistTestCase):
         self.assertInResponse('OK')
 
     def test_plchanges_with_equal_version_returns_nothing(self):
-        self.assertEqual(self.core.tracklist.version.get(), 1)
+        self.assertEqual(self.core.tracklist.get_version().get(), 1)
         self.send_request('plchanges "1"')
         self.assertNotInResponse('Title: a')
         self.assertNotInResponse('Title: b')
@@ -353,7 +354,7 @@ class PlChangeCommandTest(BasePopulatedTracklistTestCase):
         self.assertInResponse('OK')
 
     def test_plchanges_with_greater_version_returns_nothing(self):
-        self.assertEqual(self.core.tracklist.version.get(), 1)
+        self.assertEqual(self.core.tracklist.get_version().get(), 1)
         self.send_request('plchanges "2"')
         self.assertNotInResponse('Title: a')
         self.assertNotInResponse('Title: b')
@@ -376,7 +377,7 @@ class PlChangeCommandTest(BasePopulatedTracklistTestCase):
 
     def test_plchangesposid(self):
         self.send_request('plchangesposid "0"')
-        tl_tracks = self.core.tracklist.tl_tracks.get()
+        tl_tracks = self.core.tracklist.get_tl_tracks().get()
         self.assertInResponse('cpos: 0')
         self.assertInResponse('Id: %d' % tl_tracks[0].tlid)
         self.assertInResponse('cpos: 2')
@@ -408,29 +409,29 @@ class RangeIdCommandTest(protocol.BaseTestCase):
 class ShuffleCommandTest(BasePopulatedTracklistTestCase):
 
     def test_shuffle_without_range(self):
-        version = self.core.tracklist.version.get()
+        version = self.core.tracklist.get_version().get()
 
         self.send_request('shuffle')
-        self.assertLess(version, self.core.tracklist.version.get())
+        self.assertLess(version, self.core.tracklist.get_version().get())
         self.assertInResponse('OK')
 
     def test_shuffle_with_open_range(self):
-        version = self.core.tracklist.version.get()
+        version = self.core.tracklist.get_version().get()
 
         self.send_request('shuffle "4:"')
-        self.assertLess(version, self.core.tracklist.version.get())
+        self.assertLess(version, self.core.tracklist.get_version().get())
 
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result[:4], ['a', 'b', 'c', 'd'])
         self.assertInResponse('OK')
 
     def test_shuffle_with_closed_range(self):
-        version = self.core.tracklist.version.get()
+        version = self.core.tracklist.get_version().get()
 
         self.send_request('shuffle "1:3"')
-        self.assertLess(version, self.core.tracklist.version.get())
+        self.assertLess(version, self.core.tracklist.get_version().get())
 
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result[:1], ['a'])
         self.assertEqual(result[3:], ['d', 'e', 'f'])
         self.assertInResponse('OK')
@@ -440,13 +441,13 @@ class SwapCommandTest(BasePopulatedTracklistTestCase):
 
     def test_swap(self):
         self.send_request('swap "1" "4"')
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result, ['a', 'e', 'c', 'd', 'b', 'f'])
         self.assertInResponse('OK')
 
     def test_swapid(self):
         self.send_request('swapid "2" "5"')
-        result = [t.name for t in self.core.tracklist.tracks.get()]
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
         self.assertEqual(result, ['a', 'e', 'c', 'd', 'b', 'f'])
         self.assertInResponse('OK')
 

--- a/tests/mpd/protocol/test_music_db.py
+++ b/tests/mpd/protocol/test_music_db.py
@@ -94,23 +94,25 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
     def test_findadd(self):
         self.backend.library.dummy_find_exact_result = SearchResult(
             tracks=[Track(uri='dummy:a', name='A')])
-        self.assertEqual(self.core.tracklist.length.get(), 0)
+        self.assertEqual(self.core.tracklist.get_length().get(), 0)
 
         self.send_request('findadd "title" "A"')
 
-        self.assertEqual(self.core.tracklist.length.get(), 1)
-        self.assertEqual(self.core.tracklist.tracks.get()[0].uri, 'dummy:a')
+        self.assertEqual(self.core.tracklist.get_length().get(), 1)
+        self.assertEqual(
+            self.core.tracklist.get_tracks().get()[0].uri, 'dummy:a')
         self.assertInResponse('OK')
 
     def test_searchadd(self):
         self.backend.library.dummy_search_result = SearchResult(
             tracks=[Track(uri='dummy:a', name='A')])
-        self.assertEqual(self.core.tracklist.length.get(), 0)
+        self.assertEqual(self.core.tracklist.get_length().get(), 0)
 
         self.send_request('searchadd "title" "a"')
 
-        self.assertEqual(self.core.tracklist.length.get(), 1)
-        self.assertEqual(self.core.tracklist.tracks.get()[0].uri, 'dummy:a')
+        self.assertEqual(self.core.tracklist.get_length().get(), 1)
+        self.assertEqual(
+            self.core.tracklist.get_tracks().get()[0].uri, 'dummy:a')
         self.assertInResponse('OK')
 
     def test_searchaddpl_appends_to_existing_playlist(self):

--- a/tests/mpd/protocol/test_playback.py
+++ b/tests/mpd/protocol/test_playback.py
@@ -18,22 +18,22 @@ class PlaybackOptionsHandlerTest(protocol.BaseTestCase):
 
     def test_consume_off(self):
         self.send_request('consume "0"')
-        self.assertFalse(self.core.tracklist.consume.get())
+        self.assertFalse(self.core.tracklist.get_consume().get())
         self.assertInResponse('OK')
 
     def test_consume_off_without_quotes(self):
         self.send_request('consume 0')
-        self.assertFalse(self.core.tracklist.consume.get())
+        self.assertFalse(self.core.tracklist.get_consume().get())
         self.assertInResponse('OK')
 
     def test_consume_on(self):
         self.send_request('consume "1"')
-        self.assertTrue(self.core.tracklist.consume.get())
+        self.assertTrue(self.core.tracklist.get_consume().get())
         self.assertInResponse('OK')
 
     def test_consume_on_without_quotes(self):
         self.send_request('consume 1')
-        self.assertTrue(self.core.tracklist.consume.get())
+        self.assertTrue(self.core.tracklist.get_consume().get())
         self.assertInResponse('OK')
 
     def test_crossfade(self):
@@ -42,62 +42,62 @@ class PlaybackOptionsHandlerTest(protocol.BaseTestCase):
 
     def test_random_off(self):
         self.send_request('random "0"')
-        self.assertFalse(self.core.tracklist.random.get())
+        self.assertFalse(self.core.tracklist.get_random().get())
         self.assertInResponse('OK')
 
     def test_random_off_without_quotes(self):
         self.send_request('random 0')
-        self.assertFalse(self.core.tracklist.random.get())
+        self.assertFalse(self.core.tracklist.get_random().get())
         self.assertInResponse('OK')
 
     def test_random_on(self):
         self.send_request('random "1"')
-        self.assertTrue(self.core.tracklist.random.get())
+        self.assertTrue(self.core.tracklist.get_random().get())
         self.assertInResponse('OK')
 
     def test_random_on_without_quotes(self):
         self.send_request('random 1')
-        self.assertTrue(self.core.tracklist.random.get())
+        self.assertTrue(self.core.tracklist.get_random().get())
         self.assertInResponse('OK')
 
     def test_repeat_off(self):
         self.send_request('repeat "0"')
-        self.assertFalse(self.core.tracklist.repeat.get())
+        self.assertFalse(self.core.tracklist.get_repeat().get())
         self.assertInResponse('OK')
 
     def test_repeat_off_without_quotes(self):
         self.send_request('repeat 0')
-        self.assertFalse(self.core.tracklist.repeat.get())
+        self.assertFalse(self.core.tracklist.get_repeat().get())
         self.assertInResponse('OK')
 
     def test_repeat_on(self):
         self.send_request('repeat "1"')
-        self.assertTrue(self.core.tracklist.repeat.get())
+        self.assertTrue(self.core.tracklist.get_repeat().get())
         self.assertInResponse('OK')
 
     def test_repeat_on_without_quotes(self):
         self.send_request('repeat 1')
-        self.assertTrue(self.core.tracklist.repeat.get())
+        self.assertTrue(self.core.tracklist.get_repeat().get())
         self.assertInResponse('OK')
 
     def test_single_off(self):
         self.send_request('single "0"')
-        self.assertFalse(self.core.tracklist.single.get())
+        self.assertFalse(self.core.tracklist.get_single().get())
         self.assertInResponse('OK')
 
     def test_single_off_without_quotes(self):
         self.send_request('single 0')
-        self.assertFalse(self.core.tracklist.single.get())
+        self.assertFalse(self.core.tracklist.get_single().get())
         self.assertInResponse('OK')
 
     def test_single_on(self):
         self.send_request('single "1"')
-        self.assertTrue(self.core.tracklist.single.get())
+        self.assertTrue(self.core.tracklist.get_single().get())
         self.assertInResponse('OK')
 
     def test_single_on_without_quotes(self):
         self.send_request('single 1')
-        self.assertTrue(self.core.tracklist.single.get())
+        self.assertTrue(self.core.tracklist.get_single().get())
         self.assertInResponse('OK')
 
     def test_replay_gain_mode_off(self):
@@ -156,174 +156,174 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
         self.send_request('play "0"')
         self.send_request('pause "1"')
         self.send_request('pause "0"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
     def test_pause_on(self):
         self.send_request('play "0"')
         self.send_request('pause "1"')
-        self.assertEqual(PAUSED, self.core.playback.state.get())
+        self.assertEqual(PAUSED, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
     def test_pause_toggle(self):
         self.send_request('play "0"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
         with deprecation.ignore('mpd.protocol.playback.pause:state_arg'):
             self.send_request('pause')
-            self.assertEqual(PAUSED, self.core.playback.state.get())
+            self.assertEqual(PAUSED, self.core.playback.get_state().get())
             self.assertInResponse('OK')
 
             self.send_request('pause')
-            self.assertEqual(PLAYING, self.core.playback.state.get())
+            self.assertEqual(PLAYING, self.core.playback.get_state().get())
             self.assertInResponse('OK')
 
     def test_play_without_pos(self):
         self.send_request('play')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
     def test_play_with_pos(self):
         self.send_request('play "0"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
     def test_play_with_pos_without_quotes(self):
         self.send_request('play 0')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
     def test_play_with_pos_out_of_bounds(self):
         self.core.tracklist.clear().get()
         self.send_request('play "0"')
-        self.assertEqual(STOPPED, self.core.playback.state.get())
+        self.assertEqual(STOPPED, self.core.playback.get_state().get())
         self.assertInResponse('ACK [2@0] {play} Bad song index')
 
     def test_play_minus_one_plays_first_in_playlist_if_no_current_track(self):
-        self.assertEqual(self.core.playback.current_track.get(), None)
+        self.assertEqual(self.core.playback.get_current_track().get(), None)
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertEqual(
-            'dummy:a', self.core.playback.current_track.get().uri)
+            'dummy:a', self.core.playback.get_current_track().get().uri)
         self.assertInResponse('OK')
 
     def test_play_minus_one_plays_current_track_if_current_track_is_set(self):
-        self.assertEqual(self.core.playback.current_track.get(), None)
+        self.assertEqual(self.core.playback.get_current_track().get(), None)
         self.core.playback.play()
         self.core.playback.next()
         self.core.playback.stop().get()
-        self.assertNotEqual(self.core.playback.current_track.get(), None)
+        self.assertNotEqual(self.core.playback.get_current_track().get(), None)
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertEqual(
-            'dummy:b', self.core.playback.current_track.get().uri)
+            'dummy:b', self.core.playback.get_current_track().get().uri)
         self.assertInResponse('OK')
 
     def test_play_minus_one_on_empty_playlist_does_not_ack(self):
         self.core.tracklist.clear()
 
         self.send_request('play "-1"')
-        self.assertEqual(STOPPED, self.core.playback.state.get())
-        self.assertEqual(None, self.core.playback.current_track.get())
+        self.assertEqual(STOPPED, self.core.playback.get_state().get())
+        self.assertEqual(None, self.core.playback.get_current_track().get())
         self.assertInResponse('OK')
 
     def test_play_minus_is_ignored_if_playing(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+            self.core.playback.get_time_position().get(), 30000)
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_play_minus_one_resumes_if_paused(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+            self.core.playback.get_time_position().get(), 30000)
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.core.playback.pause()
-        self.assertEqual(PAUSED, self.core.playback.state.get())
+        self.assertEqual(PAUSED, self.core.playback.get_state().get())
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_playid(self):
         self.send_request('playid "1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
     def test_playid_without_quotes(self):
         self.send_request('playid 1')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
     def test_playid_minus_1_plays_first_in_playlist_if_no_current_track(self):
-        self.assertEqual(self.core.playback.current_track.get(), None)
+        self.assertEqual(self.core.playback.get_current_track().get(), None)
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertEqual(
-            'dummy:a', self.core.playback.current_track.get().uri)
+            'dummy:a', self.core.playback.get_current_track().get().uri)
         self.assertInResponse('OK')
 
     def test_playid_minus_1_plays_current_track_if_current_track_is_set(self):
-        self.assertEqual(self.core.playback.current_track.get(), None)
+        self.assertEqual(self.core.playback.get_current_track().get(), None)
         self.core.playback.play().get()
         self.core.playback.next().get()
         self.core.playback.stop()
-        self.assertNotEqual(None, self.core.playback.current_track.get())
+        self.assertNotEqual(None, self.core.playback.get_current_track().get())
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertEqual(
-            'dummy:b', self.core.playback.current_track.get().uri)
+            'dummy:b', self.core.playback.get_current_track().get().uri)
         self.assertInResponse('OK')
 
     def test_playid_minus_one_on_empty_playlist_does_not_ack(self):
         self.core.tracklist.clear()
 
         self.send_request('playid "-1"')
-        self.assertEqual(STOPPED, self.core.playback.state.get())
-        self.assertEqual(None, self.core.playback.current_track.get())
+        self.assertEqual(STOPPED, self.core.playback.get_state().get())
+        self.assertEqual(None, self.core.playback.get_current_track().get())
         self.assertInResponse('OK')
 
     def test_playid_minus_is_ignored_if_playing(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+            self.core.playback.get_time_position().get(), 30000)
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_playid_minus_one_resumes_if_paused(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+            self.core.playback.get_time_position().get(), 30000)
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.core.playback.pause()
-        self.assertEqual(PAUSED, self.core.playback.state.get())
+        self.assertEqual(PAUSED, self.core.playback.get_state().get())
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.state.get())
+        self.assertEqual(PLAYING, self.core.playback.get_state().get())
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_playid_which_does_not_exist(self):
@@ -340,19 +340,19 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         self.send_request('seek "0" "30"')
 
-        current_track = self.core.playback.current_track.get()
+        current_track = self.core.playback.get_current_track().get()
         self.assertEqual(current_track, self.tracks[0])
-        self.assertGreaterEqual(self.core.playback.time_position, 30000)
+        self.assertGreaterEqual(self.core.playback.get_time_position(), 30000)
         self.assertInResponse('OK')
 
     def test_seek_in_another_track(self):
         self.core.playback.play()
-        current_track = self.core.playback.current_track.get()
+        current_track = self.core.playback.get_current_track().get()
         self.assertNotEqual(current_track, self.tracks[1])
 
         self.send_request('seek "1" "30"')
 
-        current_track = self.core.playback.current_track.get()
+        current_track = self.core.playback.get_current_track().get()
         self.assertEqual(current_track, self.tracks[1])
         self.assertInResponse('OK')
 
@@ -361,7 +361,7 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         self.send_request('seek 0 30')
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_seekid_in_current_track(self):
@@ -369,10 +369,10 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         self.send_request('seekid "1" "30"')
 
-        current_track = self.core.playback.current_track.get()
+        current_track = self.core.playback.get_current_track().get()
         self.assertEqual(current_track, self.tracks[0])
         self.assertGreaterEqual(
-            self.core.playback.time_position.get(), 30000)
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_seekid_in_another_track(self):
@@ -380,7 +380,7 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         self.send_request('seekid "2" "30"')
 
-        current_tl_track = self.core.playback.current_tl_track.get()
+        current_tl_track = self.core.playback.get_current_tl_track().get()
         self.assertEqual(current_tl_track.tlid, 2)
         self.assertEqual(current_tl_track.track, self.tracks[1])
         self.assertInResponse('OK')
@@ -390,33 +390,38 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         self.send_request('seekcur "30"')
 
-        self.assertGreaterEqual(self.core.playback.time_position.get(), 30000)
+        self.assertGreaterEqual(
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_seekcur_positive_diff(self):
         self.core.playback.play().get()
         self.core.playback.seek(10000)
-        self.assertGreaterEqual(self.core.playback.time_position.get(), 10000)
+        self.assertGreaterEqual(
+            self.core.playback.get_time_position().get(), 10000)
 
         self.send_request('seekcur "+20"')
 
-        self.assertGreaterEqual(self.core.playback.time_position.get(), 30000)
+        self.assertGreaterEqual(
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_seekcur_negative_diff(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
-        self.assertGreaterEqual(self.core.playback.time_position.get(), 30000)
+        self.assertGreaterEqual(
+            self.core.playback.get_time_position().get(), 30000)
 
         self.send_request('seekcur "-20"')
 
-        self.assertLessEqual(self.core.playback.time_position.get(), 15000)
+        self.assertLessEqual(
+            self.core.playback.get_time_position().get(), 15000)
         self.assertInResponse('OK')
 
     def test_stop(self):
         self.core.tracklist.clear().get()
         self.send_request('stop')
-        self.assertEqual(STOPPED, self.core.playback.state.get())
+        self.assertEqual(STOPPED, self.core.playback.get_state().get())
         self.assertInResponse('OK')
 
 

--- a/tests/mpd/protocol/test_regression.py
+++ b/tests/mpd/protocol/test_regression.py
@@ -39,21 +39,21 @@ class IssueGH17RegressionTest(protocol.BaseTestCase):
 
         self.send_request('play')
         self.assertEqual(
-            'dummy:a', self.core.playback.current_track.get().uri)
+            'dummy:a', self.core.playback.get_current_track().get().uri)
         self.send_request('random "1"')
         self.send_request('next')
         self.assertEqual(
-            'dummy:b', self.core.playback.current_track.get().uri)
+            'dummy:b', self.core.playback.get_current_track().get().uri)
         self.send_request('next')
         # Should now be at track 'c', but playback fails and it skips ahead
         self.assertEqual(
-            'dummy:f', self.core.playback.current_track.get().uri)
+            'dummy:f', self.core.playback.get_current_track().get().uri)
         self.send_request('next')
         self.assertEqual(
-            'dummy:d', self.core.playback.current_track.get().uri)
+            'dummy:d', self.core.playback.get_current_track().get().uri)
         self.send_request('next')
         self.assertEqual(
-            'dummy:e', self.core.playback.current_track.get().uri)
+            'dummy:e', self.core.playback.get_current_track().get().uri)
 
 
 class IssueGH18RegressionTest(protocol.BaseTestCase):
@@ -85,11 +85,11 @@ class IssueGH18RegressionTest(protocol.BaseTestCase):
         self.send_request('next')
 
         self.send_request('next')
-        tl_track_1 = self.core.playback.current_tl_track.get()
+        tl_track_1 = self.core.playback.get_current_tl_track().get()
         self.send_request('next')
-        tl_track_2 = self.core.playback.current_tl_track.get()
+        tl_track_2 = self.core.playback.get_current_tl_track().get()
         self.send_request('next')
-        tl_track_3 = self.core.playback.current_tl_track.get()
+        tl_track_3 = self.core.playback.get_current_tl_track().get()
 
         self.assertNotEqual(tl_track_1, tl_track_2)
         self.assertNotEqual(tl_track_2, tl_track_3)

--- a/tests/mpd/protocol/test_stored_playlists.py
+++ b/tests/mpd/protocol/test_stored_playlists.py
@@ -177,13 +177,13 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.backend.library.dummy_library = tracks
         self.core.tracklist.add(uris=['dummy:a', 'dummy:b']).get()
 
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 2)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 2)
         self.backend.playlists.set_dummy_playlists([
             Playlist(name='A-list', uri='dummy:A-list', tracks=tracks[2:])])
 
         self.send_request('load "A-list"')
 
-        tracks = self.core.tracklist.tracks.get()
+        tracks = self.core.tracklist.get_tracks().get()
         self.assertEqual(5, len(tracks))
         self.assertEqual('dummy:a', tracks[0].uri)
         self.assertEqual('dummy:b', tracks[1].uri)
@@ -203,13 +203,13 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.backend.library.dummy_library = tracks
         self.core.tracklist.add(uris=['dummy:a', 'dummy:b']).get()
 
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 2)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 2)
         self.backend.playlists.set_dummy_playlists([
             Playlist(name='A-list', uri='dummy:A-list', tracks=tracks[2:])])
 
         self.send_request('load "A-list" "1:2"')
 
-        tracks = self.core.tracklist.tracks.get()
+        tracks = self.core.tracklist.get_tracks().get()
         self.assertEqual(3, len(tracks))
         self.assertEqual('dummy:a', tracks[0].uri)
         self.assertEqual('dummy:b', tracks[1].uri)
@@ -227,13 +227,13 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.backend.library.dummy_library = tracks
         self.core.tracklist.add(uris=['dummy:a', 'dummy:b']).get()
 
-        self.assertEqual(len(self.core.tracklist.tracks.get()), 2)
+        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 2)
         self.backend.playlists.set_dummy_playlists([
             Playlist(name='A-list', uri='dummy:A-list', tracks=tracks[2:])])
 
         self.send_request('load "A-list" "1:"')
 
-        tracks = self.core.tracklist.tracks.get()
+        tracks = self.core.tracklist.get_tracks().get()
         self.assertEqual(4, len(tracks))
         self.assertEqual('dummy:a', tracks[0].uri)
         self.assertEqual('dummy:b', tracks[1].uri)
@@ -244,7 +244,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
     def test_load_unknown_playlist_acks(self):
         self.send_request('load "unknown playlist"')
 
-        self.assertEqual(0, len(self.core.tracklist.tracks.get()))
+        self.assertEqual(0, len(self.core.tracklist.get_tracks().get()))
         self.assertEqualResponse('ACK [50@0] {load} No such playlist')
 
         # No invalid name check for load.
@@ -262,7 +262,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
 
         self.send_request('load "A-list"')
 
-        tracks = self.core.tracklist.tracks.get()
+        tracks = self.core.tracklist.get_tracks().get()
         self.assertEqual(len(tracks), 1)
         self.assertEqual(tracks[0].uri, 'dummy:a')
         self.assertEqual(tracks[0].name, 'Track A')

--- a/tests/mpd/test_status.py
+++ b/tests/mpd/test_status.py
@@ -135,20 +135,20 @@ class StatusHandlerTest(unittest.TestCase):
         self.assertGreaterEqual(int(result['xfade']), 0)
 
     def test_status_method_contains_state_is_play(self):
-        self.core.playback.state = PLAYING
+        self.core.playback.set_state(PLAYING)
         result = dict(status.status(self.context))
         self.assertIn('state', result)
         self.assertEqual(result['state'], 'play')
 
     def test_status_method_contains_state_is_stop(self):
-        self.core.playback.state = STOPPED
+        self.core.playback.set_state(STOPPED)
         result = dict(status.status(self.context))
         self.assertIn('state', result)
         self.assertEqual(result['state'], 'stop')
 
     def test_status_method_contains_state_is_pause(self):
-        self.core.playback.state = PLAYING
-        self.core.playback.state = PAUSED
+        self.core.playback.set_state(PLAYING)
+        self.core.playback.set_state(PAUSED)
         result = dict(status.status(self.context))
         self.assertIn('state', result)
         self.assertEqual(result['state'], 'pause')


### PR DESCRIPTION
This removes all the properties in the Core API that have been deprecated since 1.0.

This is a large part of #1083 and #1461, but does not completely resolve those.