### PR TITLE
Core API: Remove deprecated methods

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -208,12 +208,6 @@ Deprecated API features
   Though these features still work, they are slated to go away in the next
   major Mopidy release.
 
-PlaybackController
-------------------
-
-.. automethod:: mopidy.core.PlaybackController.get_mute
-.. automethod:: mopidy.core.PlaybackController.get_volume
-
 LibraryController
 -----------------
 

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -200,16 +200,3 @@ Core events
 
 .. autoclass:: mopidy.core.CoreListener
     :members:
-
-Deprecated API features
-=======================
-
-.. warning::
-  Though these features still work, they are slated to go away in the next
-  major Mopidy release.
-
-PlaylistsController
--------------------
-
-.. automethod:: mopidy.core.PlaylistsController.filter
-.. automethod:: mopidy.core.PlaylistsController.get_playlists

--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -208,11 +208,6 @@ Deprecated API features
   Though these features still work, they are slated to go away in the next
   major Mopidy release.
 
-LibraryController
------------------
-
-.. automethod:: mopidy.core.LibraryController.find_exact
-
 PlaylistsController
 -------------------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -23,19 +23,91 @@ Dependencies
 Core API
 --------
 
-- Removed properties that has been deprecated since 1.0, released in 2015.
-  Everything removed has corresponding methods that should be used instead.
-  (Fixes: :issue:`1461`, PR: :issue:`1768`)
+- Removed properties and methods that has been deprecated since 1.0, released
+  in 2015. Everything removed have replacements that should be used instead.
+  See below for a full list of removals and replacements.
+  (Fixes: :issue:`1083`, :issue:`1461`, PR: :issue:`1768`, :issue:`1769`)
+
+Root object
+^^^^^^^^^^^
+
+- Removed properties, use getter/setter instead:
 
   - :attr:`mopidy.core.Core.uri_schemes`
   - :attr:`mopidy.core.Core.version`
+
+Library controller
+^^^^^^^^^^^^^^^^^^
+
+- Removed methods:
+
+  - :meth:`mopidy.core.LibraryController.find_exact`:
+    Use :meth:`~mopidy.core.LibraryController.search`
+    with the keyword argument ``exact=True`` instead.
+
+History controller
+^^^^^^^^^^^^^^^^^^
+
+- (no changes yet)
+
+Mixer controller
+^^^^^^^^^^^^^^^^
+
+- (no changes yet)
+
+Playback controller
+^^^^^^^^^^^^^^^^^^^
+
+- Removed properties, use getter/setter instead:
+
   - :attr:`mopidy.core.PlaybackController.current_tl_track`
   - :attr:`mopidy.core.PlaybackController.current_track`
   - :attr:`mopidy.core.PlaybackController.state`
   - :attr:`mopidy.core.PlaybackController.time_position`
-  - :attr:`mopidy.core.PlaybackController.volume`
-  - :attr:`mopidy.core.PlaybackController.mute`
+
+- Moved to the mixer controller:
+
+  - :meth:`mopidy.core.PlaybackController.get_mute`:
+    Use :meth:`~mopidy.core.MixerController.get_mute`.
+
+  - :meth:`mopidy.core.PlaybackController.get_volume`:
+    Use :meth:`~mopidy.core.MixerController.get_volume`.
+
+  - :meth:`mopidy.core.PlaybackController.set_mute`:
+    Use :meth:`~mopidy.core.MixerController.set_mute`.
+
+  - :meth:`mopidy.core.PlaybackController.set_volume`:
+    Use :meth:`~mopidy.core.MixerController.set_volume`.
+
+  - :attr:`mopidy.core.PlaybackController.mute`:
+    Use :meth:`~mopidy.core.MixerController.get_mute`
+    and :meth:`~mopidy.core.MixerController.set_mute`.
+
+  - :attr:`mopidy.core.PlaybackController.volume`:
+    Use :meth:`~mopidy.core.MixerController.get_volume`
+    and :meth:`~mopidy.core.MixerController.set_volume`.
+
+Playlist controller
+^^^^^^^^^^^^^^^^^^^
+
+- Removed properties, use getter/setter instead:
+
   - :attr:`mopidy.core.PlaylistController.playlists`
+
+- Removed methods:
+
+  - :meth:`mopidy.core.PlaylistsController.filter`:
+    Use :meth:`~mopidy.core.PlaylistsController.as_list` and filter yourself.
+
+  - :meth:`mopidy.core.PlaylistsController.get_playlists`:
+    Use :meth:`~mopidy.core.PlaylistsController.as_list` and
+    :meth:`~mopidy.core.PlaylistsController.get_items`.
+
+Tracklist controller
+^^^^^^^^^^^^^^^^^^^^
+
+- Removed properties, use getter/setter instead:
+
   - :attr:`mopidy.core.TracklistController.tl_tracks`
   - :attr:`mopidy.core.TracklistController.tracks`
   - :attr:`mopidy.core.TracklistController.length`
@@ -44,37 +116,6 @@ Core API
   - :attr:`mopidy.core.TracklistController.random`
   - :attr:`mopidy.core.TracklistController.repeat`
   - :attr:`mopidy.core.TracklistController.single`
-
-- Removed the deprecated method
-  :meth:`mopidy.core.LibraryController.find_exact`.
-  Use :meth:`~mopidy.core.LibraryController.search`
-  with the keyword argument ``exact=True`` instead.
-  (Fixes: :issue:`1461`, PR: :issue:`1769`)
-
-- Removed deprecated methods from the playback controller.
-  (Fixes: :issue:`1461`, PR: :issue:`1769`)
-
-  - Removed :meth:`mopidy.core.PlaybackController.get_mute`,
-    use :meth:`mopidy.core.MixerController.get_mute`.
-
-  - Removed :meth:`mopidy.core.PlaybackController.get_volume`,
-    use :meth:`mopidy.core.MixerController.get_volume`.
-
-  - Removed :meth:`mopidy.core.PlaybackController.set_mute`,
-    use :meth:`mopidy.core.MixerController.set_mute`.
-
-  - Removed :meth:`mopidy.core.PlaybackController.set_volume`,
-    use :meth:`mopidy.core.MixerController.set_volume`.
-
-- Removed deprecated methods from the playlists controller.
-  (Fixes: :issue:`1461`, PR: :issue:`1769`)
-
-  - Removed :meth:`mopidy.core.PlaylistsController.filter`,
-    use :meth:`~mopidy.core.PlaylistsController.as_list` and filter yourself.
-
-  - Removed :meth:`mopidy.core.PlaylistsController.get_playlists`,
-    use :meth:`~mopidy.core.PlaylistsController.as_list` and
-    :meth:`~mopidy.core.PlaylistsController.get_items`.
 
 Backend API
 -----------
@@ -99,7 +140,7 @@ HTTP frontend
 - Stop bundling Mopidy.js and serving it at ``/mopidy/mopidy.js`` and
   ``/mopidy/mopidy.min.js``. All Mopidy web clients must use Mopidy.js from npm
   or vendor their own copy of the library.
-  (Fixes: :issue:`1460`, PR: :issue:`1708`)
+  (Fixes: :issue:`1083`, :issue:`1460`, PR: :issue:`1708`)
 
 - Remove support for serving arbitrary files over HTTP through the use of
   :confval:`http/static_dir`, which has been deprecated since 1.0. (Fixes:
@@ -1116,7 +1157,7 @@ the API as those parts will be removed in Mopidy 2.0.
   mute. (Fixes: :issue:`962`)
 
 Core library controller
-~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^
 
 - **Deprecated:** :meth:`mopidy.core.LibraryController.find_exact`. Use
   :meth:`mopidy.core.LibraryController.search` with the ``exact`` keyword
@@ -1145,7 +1186,7 @@ Core library controller
   :issue:`981`, :issue:`992` and :issue:`1013`)
 
 Core playlist controller
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 - **Deprecated:** :meth:`mopidy.core.PlaylistsController.get_playlists`. Use
   :meth:`~mopidy.core.PlaylistsController.as_list` and
@@ -1162,7 +1203,7 @@ Core playlist controller
   PR: :issue:`1075`)
 
 Core tracklist controller
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - **Removed:** The following methods were documented as internal. They are now
   fully private and unavailable outside the core actor. (Fixes: :issue:`1058`,
@@ -1177,7 +1218,7 @@ Core tracklist controller
   :issue:`1060`, PR: :issue:`1065`)
 
 Core playback controller
-~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^
 
 - **Removed:** Remove several internal parts that were leaking into the public
   API and was never intended to be used externally. (Fixes: :issue:`1070`, PR:
@@ -1226,7 +1267,7 @@ to be compatible with Mopidy 1.0 before the release. New versions of the
 backends will be released shortly after Mopidy itself.
 
 Backend library providers
-~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - **Removed:** Remove :meth:`mopidy.backend.LibraryProvider.find_exact`.
 
@@ -1235,7 +1276,7 @@ Backend library providers
   :meth:`~mopidy.backend.LibraryProvider.find_exact` method.
 
 Backend playlist providers
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - **Removed:** Remove default implementation of
   :attr:`mopidy.backend.PlaylistsProvider.playlists`. This is potentially
@@ -1252,7 +1293,7 @@ Backend playlist providers
   - Remove :attr:`mopidy.backend.PlaylistsProvider.playlists` property.
 
 Backend playback providers
-~~~~~~~~~~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 - Changed the API for :class:`mopidy.backend.PlaybackProvider`. Note that this
   change is **not** backwards compatible for certain backends. These changes
@@ -1347,7 +1388,7 @@ Local backend
   use and can be removed from your config.
 
 Local library API
-~~~~~~~~~~~~~~~~~
+^^^^^^^^^^^^^^^^^
 
 - Implementors of :meth:`mopidy.local.Library.lookup` should now return a list
   of :class:`~mopidy.models.Track` instead of a single track, just like the

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,20 @@ Core API
   - :attr:`mopidy.core.TracklistController.repeat`
   - :attr:`mopidy.core.TracklistController.single`
 
+- Removed deprecated methods from the playback controller:
+
+  - Removed :meth:`mopidy.core.PlaybackController.get_mute`,
+    use :meth:`mopidy.core.MixerController.get_mute`.
+
+  - Removed :meth:`mopidy.core.PlaybackController.get_volume`,
+    use :meth:`mopidy.core.MixerController.get_volume`.
+
+  - Removed :meth:`mopidy.core.PlaybackController.set_mute`,
+    use :meth:`mopidy.core.MixerController.set_mute`.
+
+  - Removed :meth:`mopidy.core.PlaybackController.set_volume`,
+    use :meth:`mopidy.core.MixerController.set_volume`.
+
 Backend API
 -----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,11 @@ Core API
   - :attr:`mopidy.core.TracklistController.repeat`
   - :attr:`mopidy.core.TracklistController.single`
 
+- Removed the deprecated method
+  :meth:`mopidy.core.LibraryController.find_exact`.
+  Use :meth:`~mopidy.core.LibraryController.search`
+  with the keyword argument ``exact=True`` instead.
+
 - Removed deprecated methods from the playback controller:
 
   - Removed :meth:`mopidy.core.PlaybackController.get_mute`,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,7 @@ Core API
 
 - Removed properties that has been deprecated since 1.0, released in 2015.
   Everything removed has corresponding methods that should be used instead.
+  (Fixes: :issue:`1461`, PR: :issue:`1768`)
 
   - :attr:`mopidy.core.Core.uri_schemes`
   - :attr:`mopidy.core.Core.version`
@@ -48,8 +49,10 @@ Core API
   :meth:`mopidy.core.LibraryController.find_exact`.
   Use :meth:`~mopidy.core.LibraryController.search`
   with the keyword argument ``exact=True`` instead.
+  (Fixes: :issue:`1461`, PR: :issue:`1769`)
 
-- Removed deprecated methods from the playback controller:
+- Removed deprecated methods from the playback controller.
+  (Fixes: :issue:`1461`, PR: :issue:`1769`)
 
   - Removed :meth:`mopidy.core.PlaybackController.get_mute`,
     use :meth:`mopidy.core.MixerController.get_mute`.
@@ -63,7 +66,8 @@ Core API
   - Removed :meth:`mopidy.core.PlaybackController.set_volume`,
     use :meth:`mopidy.core.MixerController.set_volume`.
 
-- Removed deprecated methods from the playlists controller:
+- Removed deprecated methods from the playlists controller.
+  (Fixes: :issue:`1461`, PR: :issue:`1769`)
 
   - Removed :meth:`mopidy.core.PlaylistsController.filter`,
     use :meth:`~mopidy.core.PlaylistsController.as_list` and filter yourself.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -63,6 +63,15 @@ Core API
   - Removed :meth:`mopidy.core.PlaybackController.set_volume`,
     use :meth:`mopidy.core.MixerController.set_volume`.
 
+- Removed deprecated methods from the playlists controller:
+
+  - Removed :meth:`mopidy.core.PlaylistsController.filter`,
+    use :meth:`~mopidy.core.PlaylistsController.as_list` and filter yourself.
+
+  - Removed :meth:`mopidy.core.PlaylistsController.get_playlists`,
+    use :meth:`~mopidy.core.PlaylistsController.as_list` and
+    :meth:`~mopidy.core.PlaylistsController.get_items`.
+
 Backend API
 -----------
 

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -182,15 +182,6 @@ class LibraryController(object):
                     results[uri] += tuple(images)
         return results
 
-    def find_exact(self, query=None, uris=None, **kwargs):
-        """Search the library for tracks where ``field`` is ``values``.
-
-        .. deprecated:: 1.0
-            Use :meth:`search` with ``exact`` set.
-        """
-        deprecation.warn('core.library.find_exact')
-        return self.search(query=query, uris=uris, exact=True, **kwargs)
-
     def lookup(self, uri=None, uris=None):
         """
         Lookup the given URIs.
@@ -308,7 +299,7 @@ class LibraryController(object):
         :rtype: list of :class:`mopidy.models.SearchResult`
 
         .. versionadded:: 1.0
-            The ``exact`` keyword argument, which replaces :meth:`find_exact`.
+            The ``exact`` keyword argument.
 
         .. deprecated:: 1.0
             Previously, if the query was empty, and the backend could support

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -124,42 +124,6 @@ class PlaybackController(object):
         else:
             return 0
 
-    def get_volume(self):
-        """
-        .. deprecated:: 1.0
-            Use :meth:`core.mixer.get_volume()
-            <mopidy.core.MixerController.get_volume>` instead.
-        """
-        deprecation.warn('core.playback.get_volume')
-        return self.core.mixer.get_volume()
-
-    def set_volume(self, volume):
-        """
-        .. deprecated:: 1.0
-            Use :meth:`core.mixer.set_volume()
-            <mopidy.core.MixerController.set_volume>` instead.
-        """
-        deprecation.warn('core.playback.set_volume')
-        return self.core.mixer.set_volume(volume)
-
-    def get_mute(self):
-        """
-        .. deprecated:: 1.0
-            Use :meth:`core.mixer.get_mute()
-            <mopidy.core.MixerController.get_mute>` instead.
-        """
-        deprecation.warn('core.playback.get_mute')
-        return self.core.mixer.get_mute()
-
-    def set_mute(self, mute):
-        """
-        .. deprecated:: 1.0
-            Use :meth:`core.mixer.set_mute()
-            <mopidy.core.MixerController.set_mute>` instead.
-        """
-        deprecation.warn('core.playback.set_mute')
-        return self.core.mixer.set_mute(mute)
-
     def _on_end_of_stream(self):
         self.set_state(PlaybackState.STOPPED)
         if self._current_tl_track:

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -6,7 +6,7 @@ import logging
 from mopidy import exceptions
 from mopidy.compat import urllib
 from mopidy.core import listener
-from mopidy.internal import deprecation, validation
+from mopidy.internal import validation
 from mopidy.models import Playlist, Ref
 
 logger = logging.getLogger(__name__)
@@ -104,35 +104,6 @@ class PlaylistsController(object):
 
         return None
 
-    def get_playlists(self, include_tracks=True):
-        """
-        Get the available playlists.
-
-        :rtype: list of :class:`mopidy.models.Playlist`
-
-        .. versionchanged:: 1.0
-            If you call the method with ``include_tracks=False``, the
-            :attr:`~mopidy.models.Playlist.last_modified` field of the returned
-            playlists is no longer set.
-
-        .. deprecated:: 1.0
-            Use :meth:`as_list` and :meth:`get_items` instead.
-        """
-        deprecation.warn('core.playlists.get_playlists')
-
-        playlist_refs = self.as_list()
-
-        if include_tracks:
-            playlists = {r.uri: self.lookup(r.uri) for r in playlist_refs}
-            # Use the playlist name from as_list() because it knows about any
-            # playlist folder hierarchy, which lookup() does not.
-            return [
-                playlists[r.uri].replace(name=r.name)
-                for r in playlist_refs if playlists[r.uri] is not None]
-        else:
-            return [
-                Playlist(uri=r.uri, name=r.name) for r in playlist_refs]
-
     def create(self, name, uri_scheme=None):
         """
         Create a new playlist.
@@ -203,39 +174,6 @@ class PlaylistsController(object):
             listener.CoreListener.send('playlist_deleted', uri=uri)
 
         return success
-
-    def filter(self, criteria=None, **kwargs):
-        """
-        Filter playlists by the given criterias.
-
-        Examples::
-
-            # Returns track with name 'a'
-            filter({'name': 'a'})
-
-            # Returns track with URI 'xyz'
-            filter({'uri': 'xyz'})
-
-            # Returns track with name 'a' and URI 'xyz'
-            filter({'name': 'a', 'uri': 'xyz'})
-
-        :param criteria: one or more criteria to match by
-        :type criteria: dict
-        :rtype: list of :class:`mopidy.models.Playlist`
-
-        .. deprecated:: 1.0
-            Use :meth:`as_list` and filter yourself.
-        """
-        deprecation.warn('core.playlists.filter')
-
-        criteria = criteria or kwargs
-        validation.check_query(
-            criteria, validation.PLAYLIST_FIELDS, list_values=False)
-
-        matches = self.get_playlists()
-        for (key, value) in criteria.iteritems():
-            matches = filter(lambda p: getattr(p, key) == value, matches)
-        return matches
 
     def lookup(self, uri):
         """

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -26,10 +26,6 @@ _MESSAGES = {
         'library.search() with empty "query" argument deprecated',
 
     # Deprecated features in core playback:
-    'core.playback.get_mute': 'playback.get_mute() is deprecated',
-    'core.playback.set_mute': 'playback.set_mute() is deprecated',
-    'core.playback.get_volume': 'playback.get_volume() is deprecated',
-    'core.playback.set_volume': 'playback.set_volume() is deprecated',
     'core.playback.play:tl_track_kwargs':
         'playback.play() with "tl_track" argument is pending deprecation use '
         '"tlid" instead',

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -17,7 +17,6 @@ _MESSAGES = {
         'Do not use this, instead use playlistinfo',
 
     # Deprecated features in core libary:
-    'core.library.find_exact': 'library.find_exact() is deprecated',
     'core.library.lookup:uri_arg':
         'library.lookup() "uri" argument is deprecated',
     'core.library.search:kwargs_query':

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -29,10 +29,6 @@ _MESSAGES = {
         'playback.play() with "tl_track" argument is pending deprecation use '
         '"tlid" instead',
 
-    # Deprecated features in core playlists:
-    'core.playlists.filter': 'playlists.filter() is deprecated',
-    'core.playlists.get_playlists': 'playlists.get_playlists() is deprecated',
-
     # Deprecated features in core tracklist:
     'core.tracklist.add:tracks_arg':
         'tracklist.add() "tracks" argument is deprecated',

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -5,7 +5,6 @@ import unittest
 import mock
 
 from mopidy import backend, core
-from mopidy.internal import deprecation
 from mopidy.models import Playlist, Ref, Track
 
 
@@ -255,55 +254,6 @@ class PlaylistTest(BasePlaylistsTest):
     def test_get_uri_schemes(self):
         result = self.core.playlists.get_uri_schemes()
         self.assertEquals(result, ['dummy1', 'dummy2'])
-
-
-class DeprecatedFilterPlaylistsTest(BasePlaylistsTest):
-
-    def run(self, result=None):
-        with deprecation.ignore(ids=['core.playlists.filter',
-                                     'core.playlists.get_playlists']):
-            return super(DeprecatedFilterPlaylistsTest, self).run(result)
-
-    def test_filter_returns_matching_playlists(self):
-        result = self.core.playlists.filter({'name': 'A'})
-
-        self.assertEqual(2, len(result))
-
-    def test_filter_accepts_dict_instead_of_kwargs(self):
-        result = self.core.playlists.filter({'name': 'A'})
-
-        self.assertEqual(2, len(result))
-
-
-class DeprecatedGetPlaylistsTest(BasePlaylistsTest):
-
-    def run(self, result=None):
-        with deprecation.ignore('core.playlists.get_playlists'):
-            return super(DeprecatedGetPlaylistsTest, self).run(result)
-
-    def test_get_playlists_combines_result_from_backends(self):
-        result = self.core.playlists.get_playlists()
-
-        self.assertIn(self.pl1a, result)
-        self.assertIn(self.pl1b, result)
-        self.assertIn(self.pl2a, result)
-        self.assertIn(self.pl2b, result)
-
-    def test_get_playlists_includes_tracks_by_default(self):
-        result = self.core.playlists.get_playlists()
-
-        self.assertEqual(result[0].name, 'A')
-        self.assertEqual(len(result[0].tracks), 1)
-        self.assertEqual(result[1].name, 'B')
-        self.assertEqual(len(result[1].tracks), 1)
-
-    def test_get_playlist_can_strip_tracks_from_returned_playlists(self):
-        result = self.core.playlists.get_playlists(include_tracks=False)
-
-        self.assertEqual(result[0].name, 'A')
-        self.assertEqual(len(result[0].tracks), 0)
-        self.assertEqual(result[1].name, 'B')
-        self.assertEqual(len(result[1].tracks), 0)
 
 
 class MockBackendCorePlaylistsBase(unittest.TestCase):

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -650,9 +650,9 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
         self.assertIn('core.playback.next', methods)
         self.assertEqual(len(methods['core.playback.next']['params']), 0)
 
-        self.assertIn('core.playlists.get_playlists', methods)
+        self.assertIn('core.playlists.as_list', methods)
         self.assertEqual(
-            len(methods['core.playlists.get_playlists']['params']), 1)
+            len(methods['core.playlists.as_list']['params']), 0)
 
         self.assertIn('core.tracklist.filter', methods.keys())
         self.assertEqual(

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -11,7 +11,6 @@ import unittest
 import pykka
 
 from mopidy import core
-from mopidy.internal import deprecation
 from mopidy.m3u.backend import M3UBackend
 from mopidy.models import Playlist, Track
 
@@ -356,36 +355,3 @@ class M3UPlaylistsProviderBaseDirectoryTest(M3UPlaylistsProviderTest):
     def setUp(self):  # noqa: N802
         self.config['m3u']['base_dir'] = tempfile.mkdtemp()
         super(M3UPlaylistsProviderBaseDirectoryTest, self).setUp()
-
-
-class DeprecatedM3UPlaylistsProviderTest(M3UPlaylistsProviderTest):
-
-    def run(self, result=None):
-        with deprecation.ignore(ids=['core.playlists.filter',
-                                     'core.playlists.filter:kwargs_criteria',
-                                     'core.playlists.get_playlists']):
-            return super(DeprecatedM3UPlaylistsProviderTest, self).run(result)
-
-    def test_filter_without_criteria(self):
-        self.assertEqual(self.core.playlists.get_playlists(),
-                         self.core.playlists.filter())
-
-    def test_filter_with_wrong_criteria(self):
-        self.assertEqual([], self.core.playlists.filter(name='foo'))
-
-    def test_filter_with_right_criteria(self):
-        playlist = self.core.playlists.create('test')
-        playlists = self.core.playlists.filter(name='test')
-        self.assertEqual([playlist], playlists)
-
-    def test_filter_by_name_returns_single_match(self):
-        self.core.playlists.create('a')
-        playlist = self.core.playlists.create('b')
-
-        self.assertEqual([playlist], self.core.playlists.filter(name='b'))
-
-    def test_filter_by_name_returns_no_matches(self):
-        self.core.playlists.create('a')
-        self.core.playlists.create('b')
-
-        self.assertEqual([], self.core.playlists.filter(name='c'))


### PR DESCRIPTION
This removes all methods in the Core API that was deprecated in 1.0.

As the previous PR, this contributes to #1461 without resolving it fully.