### PR TITLE
Remove double-quotes around PLS File# entries

### DIFF
--- a/mopidy/internal/playlists.py
+++ b/mopidy/internal/playlists.py
@@ -84,7 +84,7 @@ def parse_pls(data):
         if section.lower() != 'playlist':
             continue
         for i in range(cp.getint(section, 'numberofentries')):
-            yield cp.get(section, 'file%d' % (i + 1))
+            yield cp.get(section, 'file%d' % (i + 1)).strip('\"\'')
 
 
 def parse_xspf(data):

--- a/tests/internal/test_playlists.py
+++ b/tests/internal/test_playlists.py
@@ -31,11 +31,11 @@ file:///tmp/baz
 
 PLS = b"""[Playlist]
 NumberOfEntries=3
-File1=file:///tmp/foo
+File1="file:///tmp/foo"
 Title1=Sample Title
 Length1=123
 
-File2=file:///tmp/bar
+File2='file:///tmp/bar'
 Title2=Example \xc5\xa7\xc5\x95
 Length2=321
 File3=file:///tmp/baz


### PR DESCRIPTION
`File#` entries of PLS playlists may be found double quoted in the wild, since the "standard" is loosely defined. The resulting URI is then incorrect and makes mopidy fail to load the content, so let's make sure we strip them.
Fixes #1770