### PR TITLE
Core API: Remove deprecated args

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -27,8 +27,9 @@ Dependencies
 Core API
 --------
 
-- Removed properties and methods that has been deprecated since 1.0, released
-  in 2015. Everything removed have replacements that should be used instead.
+- Removed properties, methods, and arguments that have been deprecated since
+  1.0, released in 2015.
+  Everything removed have replacements that should be used instead.
   See below for a full list of removals and replacements.
   (Fixes: :issue:`1083`, :issue:`1461`, PR: :issue:`1768`, :issue:`1769`)
 
@@ -120,6 +121,10 @@ Tracklist controller
   - :attr:`mopidy.core.TracklistController.random`
   - :attr:`mopidy.core.TracklistController.repeat`
   - :attr:`mopidy.core.TracklistController.single`
+
+- Removed the ``uri`` argument to
+  :meth:`mopidy.core.TracklistController.add`.
+  Use the ``uris`` argument instead.
 
 Backend API
 -----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -130,6 +130,9 @@ Tracklist controller
   :meth:`mopidy.core.TracklistController.filter`.
   Use the ``criteria`` argument instead.
 
+- Removed the support for passing filter criterias as keyword arguments to
+  :meth:`mopidy.core.TracklistController.remove`.
+  Use the ``criteria`` argument instead.
 
 Backend API
 -----------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -126,6 +126,11 @@ Tracklist controller
   :meth:`mopidy.core.TracklistController.add`.
   Use the ``uris`` argument instead.
 
+- Removed the support for passing filter criterias as keyword arguments to
+  :meth:`mopidy.core.TracklistController.filter`.
+  Use the ``criteria`` argument instead.
+
+
 Backend API
 -----------
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -179,7 +179,8 @@ HTTP frontend
 MPD frontend
 ------------
 
-- (no changes yet)
+- Improved the ``swap`` command to swap the tracks without rebuilding
+  the full tracklist.
 
 File backend
 ------------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,11 @@ Library controller
   :meth:`mopidy.core.LibraryController.lookup`.
   Use the ``uris`` argument instead.
 
+- :meth:`mopidy.core.LibraryController.search` now returns an empty result
+  if there is no ``query``. Previously, it returned the full music library.
+  This does not work with online music services,
+  and have thus been deprecated since 1.0.
+
 History controller
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -50,6 +50,10 @@ Library controller
     Use :meth:`~mopidy.core.LibraryController.search`
     with the keyword argument ``exact=True`` instead.
 
+- Removed the ``uri`` argument to
+  :meth:`mopidy.core.LibraryController.lookup`.
+  Use the ``uris`` argument instead.
+
 History controller
 ^^^^^^^^^^^^^^^^^^
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,10 @@ Library controller
   :meth:`mopidy.core.LibraryController.lookup`.
   Use the ``uris`` argument instead.
 
+- Removed the support for passing the search query as keyword arguments to
+  :meth:`mopidy.core.LibraryController.search`.
+  Use the ``query`` argument instead.
+
 - :meth:`mopidy.core.LibraryController.search` now returns an empty result
   if there is no ``query``. Previously, it returned the full music library.
   This does not work with online music services,

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -7,7 +7,7 @@ import operator
 
 from mopidy import compat, exceptions, models
 from mopidy.compat import urllib
-from mopidy.internal import deprecation, validation
+from mopidy.internal import validation
 
 
 logger = logging.getLogger(__name__)
@@ -239,7 +239,7 @@ class LibraryController(object):
             with _backend_error_handling(backend):
                 future.get()
 
-    def search(self, query=None, uris=None, exact=False, **kwargs):
+    def search(self, query, uris=None, exact=False):
         """
         Search the library for tracks where ``field`` contains ``values``.
 
@@ -280,18 +280,12 @@ class LibraryController(object):
 
         .. versionadded:: 1.0
             The ``exact`` keyword argument.
-
-        .. deprecated:: 1.1
-            Providing the search query via ``kwargs`` is no longer supported.
         """
-        query = _normalize_query(query or kwargs)
+        query = _normalize_query(query)
 
         uris is None or validation.check_uris(uris)
-        query is None or validation.check_query(query)
+        validation.check_query(query)
         validation.check_boolean(exact)
-
-        if kwargs:
-            deprecation.warn('core.library.search:kwargs_query')
 
         if not query:
             return []

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -242,9 +242,10 @@ class LibraryController(object):
     def search(self, query=None, uris=None, exact=False, **kwargs):
         """
         Search the library for tracks where ``field`` contains ``values``.
+
         ``field`` can be one of ``uri``, ``track_name``, ``album``, ``artist``,
         ``albumartist``, ``composer``, ``performer``, ``track_no``, ``genre``,
-        ``date``, ``comment`` or ``any``.
+        ``date``, ``comment``, or ``any``.
 
         If ``uris`` is given, the search is limited to results from within the
         URI roots. For example passing ``uris=['file:']`` will limit the search
@@ -280,12 +281,6 @@ class LibraryController(object):
         .. versionadded:: 1.0
             The ``exact`` keyword argument.
 
-        .. deprecated:: 1.0
-            Previously, if the query was empty, and the backend could support
-            it, all available tracks were returned. This has not changed, but
-            it is strongly discouraged. No new code should rely on this
-            behavior.
-
         .. deprecated:: 1.1
             Providing the search query via ``kwargs`` is no longer supported.
         """
@@ -299,7 +294,7 @@ class LibraryController(object):
             deprecation.warn('core.library.search:kwargs_query')
 
         if not query:
-            deprecation.warn('core.library.search:empty_query')
+            return []
 
         futures = {}
         for backend, backend_uris in self._get_backends_to_uris(uris).items():

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -182,37 +182,18 @@ class LibraryController(object):
                     results[uri] += tuple(images)
         return results
 
-    def lookup(self, uri=None, uris=None):
+    def lookup(self, uris):
         """
         Lookup the given URIs.
 
         If the URI expands to multiple tracks, the returned list will contain
         them all.
 
-        :param uri: track URI
-        :type uri: string or :class:`None`
         :param uris: track URIs
-        :type uris: list of string or :class:`None`
-        :rtype: list of :class:`mopidy.models.Track` if uri was set or
-            {uri: list of :class:`mopidy.models.Track`} if uris was set.
-
-        .. versionadded:: 1.0
-            The ``uris`` argument.
-
-        .. deprecated:: 1.0
-            The ``uri`` argument. Use ``uris`` instead.
+        :type uris: list of string
+        :rtype: {uri: list of :class:`mopidy.models.Track`}
         """
-        if sum(o is not None for o in [uri, uris]) != 1:
-            raise ValueError('Exactly one of "uri" or "uris" must be set')
-
-        uris is None or validation.check_uris(uris)
-        uri is None or validation.check_uri(uri)
-
-        if uri:
-            deprecation.warn('core.library.lookup:uri_arg')
-
-        if uri is not None:
-            uris = [uri]
+        validation.check_uris(uris)
 
         futures = {}
         results = {u: [] for u in uris}
@@ -232,8 +213,6 @@ class LibraryController(object):
                     # then remove this filtering of tracks without URIs.
                     results[u] = [r for r in result if r.uri]
 
-        if uri:
-            return results[uri]
         return results
 
     def refresh(self, uri=None):

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -475,7 +475,7 @@ class TracklistController(object):
         self._tl_tracks = new_tl_tracks
         self._increase_version()
 
-    def remove(self, criteria=None, **kwargs):
+    def remove(self, criteria):
         """
         Remove the matching tracks from the tracklist.
 
@@ -486,14 +486,8 @@ class TracklistController(object):
         :param criteria: on or more criteria to match by
         :type criteria: dict
         :rtype: list of :class:`mopidy.models.TlTrack` that was removed
-
-        .. deprecated:: 1.1
-            Providing the criteria  via ``kwargs``.
         """
-        if kwargs:
-            deprecation.warn('core.tracklist.remove:kwargs_criteria')
-
-        tl_tracks = self.filter(criteria or kwargs)
+        tl_tracks = self.filter(criteria)
         for tl_track in tl_tracks:
             position = self._tl_tracks.index(tl_track)
             del self._tl_tracks[position]

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -327,14 +327,11 @@ class TracklistController(object):
         # 1 - len(tracks) Thus 'position - 1' will always be within the list.
         return self._tl_tracks[position - 1]
 
-    def add(self, tracks=None, at_position=None, uri=None, uris=None):
+    def add(self, tracks=None, at_position=None, uris=None):
         """
         Add tracks to the tracklist.
 
-        If ``uri`` is given instead of ``tracks``, the URI is looked up in the
-        library and the resulting tracks are added to the tracklist.
-
-        If ``uris`` is given instead of ``uri`` or ``tracks``, the URIs are
+        If ``uris`` is given instead of ``tracks``, the URIs are
         looked up in the library and the resulting tracks are added to the
         tracklist.
 
@@ -348,8 +345,6 @@ class TracklistController(object):
         :type tracks: list of :class:`mopidy.models.Track` or :class:`None`
         :param at_position: position in tracklist to add tracks
         :type at_position: int or :class:`None`
-        :param uri: URI for tracks to add
-        :type uri: string or :class:`None`
         :param uris: list of URIs for tracks to add
         :type uris: list of string or :class:`None`
         :rtype: list of :class:`mopidy.models.TlTrack`
@@ -358,27 +353,20 @@ class TracklistController(object):
             The ``uris`` argument.
 
         .. deprecated:: 1.0
-            The ``tracks`` and ``uri`` arguments. Use ``uris``.
+            The ``tracks`` argument. Use ``uris``.
         """
-        if sum(o is not None for o in [tracks, uri, uris]) != 1:
+        if sum(o is not None for o in [tracks, uris]) != 1:
             raise ValueError(
-                'Exactly one of "tracks", "uri" or "uris" must be set')
+                'Exactly one of "tracks" or "uris" must be set')
 
         tracks is None or validation.check_instances(tracks, Track)
-        uri is None or validation.check_uri(uri)
         uris is None or validation.check_uris(uris)
         validation.check_integer(at_position or 0)
 
         if tracks:
             deprecation.warn('core.tracklist.add:tracks_arg')
 
-        if uri:
-            deprecation.warn('core.tracklist.add:uri_arg')
-
         if tracks is None:
-            if uri is not None:
-                uris = [uri]
-
             tracks = []
             track_map = self.core.library.lookup(uris=uris)
             for uri in uris:

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -403,7 +403,7 @@ class TracklistController(object):
         self._tl_tracks = []
         self._increase_version()
 
-    def filter(self, criteria=None, **kwargs):
+    def filter(self, criteria):
         """
         Filter the tracklist by the given criterias.
 
@@ -428,14 +428,7 @@ class TracklistController(object):
         :param criteria: on or more criteria to match by
         :type criteria: dict, of (string, list) pairs
         :rtype: list of :class:`mopidy.models.TlTrack`
-
-        .. deprecated:: 1.1
-            Providing the criteria via ``kwargs``.
         """
-        if kwargs:
-            deprecation.warn('core.tracklist.filter:kwargs_criteria')
-
-        criteria = criteria or kwargs
         tlids = criteria.pop('tlid', [])
         validation.check_query(criteria, validation.TRACKLIST_FIELDS)
         validation.check_instances(tlids, int)

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -16,10 +16,6 @@ _MESSAGES = {
     'mpd.protocol.current_playlist.playlist':
         'Do not use this, instead use playlistinfo',
 
-    # Deprecated features in core libary:
-    'core.library.search:kwargs_query':
-        'library.search() with "kwargs" as query is deprecated',
-
     # Deprecated features in core playback:
     'core.playback.play:tl_track_kwargs':
         'playback.play() with "tl_track" argument is pending deprecation use '
@@ -39,6 +35,7 @@ _MESSAGES = {
         'tracklist.previous_track() is pending deprecation, use '
         'tracklist.get_previous_tlid()',
 
+    # Deprecated features in the models
     'models.immutable.copy':
         'ImmutableObject.copy() is deprecated, use ImmutableObject.replace()',
 }

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -17,8 +17,6 @@ _MESSAGES = {
         'Do not use this, instead use playlistinfo',
 
     # Deprecated features in core libary:
-    'core.library.lookup:uri_arg':
-        'library.lookup() "uri" argument is deprecated',
     'core.library.search:kwargs_query':
         'library.search() with "kwargs" as query is deprecated',
     'core.library.search:empty_query':

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -32,8 +32,6 @@ _MESSAGES = {
     # Deprecated features in core tracklist:
     'core.tracklist.add:tracks_arg':
         'tracklist.add() "tracks" argument is deprecated',
-    'core.tracklist.remove:kwargs_criteria':
-        'tracklist.remove() with "kwargs" as criteria is deprecated',
 
     'core.tracklist.eot_track':
         'tracklist.eot_track() is pending deprecation, use '

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -32,8 +32,6 @@ _MESSAGES = {
     # Deprecated features in core tracklist:
     'core.tracklist.add:tracks_arg':
         'tracklist.add() "tracks" argument is deprecated',
-    'core.tracklist.filter:kwargs_criteria':
-        'tracklist.filter() with "kwargs" as criteria is deprecated',
     'core.tracklist.remove:kwargs_criteria':
         'tracklist.remove() with "kwargs" as criteria is deprecated',
 

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -32,8 +32,6 @@ _MESSAGES = {
     # Deprecated features in core tracklist:
     'core.tracklist.add:tracks_arg':
         'tracklist.add() "tracks" argument is deprecated',
-    'core.tracklist.add:uri_arg':
-        'tracklist.add() "uri" argument is deprecated',
     'core.tracklist.filter:kwargs_criteria':
         'tracklist.filter() with "kwargs" as criteria is deprecated',
     'core.tracklist.remove:kwargs_criteria':

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -19,8 +19,6 @@ _MESSAGES = {
     # Deprecated features in core libary:
     'core.library.search:kwargs_query':
         'library.search() with "kwargs" as query is deprecated',
-    'core.library.search:empty_query':
-        'library.search() with empty "query" argument deprecated',
 
     # Deprecated features in core playback:
     'core.playback.play:tl_track_kwargs':

--- a/mopidy/mpd/protocol/current_playlist.py
+++ b/mopidy/mpd/protocol/current_playlist.py
@@ -392,19 +392,10 @@ def swap(context, songpos1, songpos2):
 
         Swaps the positions of ``SONG1`` and ``SONG2``.
     """
-    tracks = context.core.tracklist.get_tracks().get()
-    song1 = tracks[songpos1]
-    song2 = tracks[songpos2]
-    del tracks[songpos1]
-    tracks.insert(songpos1, song2)
-    del tracks[songpos2]
-    tracks.insert(songpos2, song1)
-
-    # TODO: do we need a tracklist.replace()
-    context.core.tracklist.clear()
-
-    with deprecation.ignore('core.tracklist.add:tracks_arg'):
-        context.core.tracklist.add(tracks=tracks).get()
+    if songpos2 < songpos1:
+        songpos1, songpos2 = songpos2, songpos1
+    context.core.tracklist.move(songpos1, songpos1 + 1, songpos2)
+    context.core.tracklist.move(songpos2 - 1, songpos2, songpos1)
 
 
 @protocol.commands.add('swapid', tlid1=protocol.UINT, tlid2=protocol.UINT)

--- a/mopidy/mpd/protocol/music_db.py
+++ b/mopidy/mpd/protocol/music_db.py
@@ -141,8 +141,7 @@ def find(context, *args):
     except ValueError:
         return
 
-    with deprecation.ignore('core.library.search:empty_query'):
-        results = context.core.library.search(query=query, exact=True).get()
+    results = context.core.library.search(query=query, exact=True).get()
     result_tracks = []
     if ('artist' not in query and
             'albumartist' not in query and
@@ -439,8 +438,7 @@ def search(context, *args):
         query = _query_from_mpd_search_parameters(args, _SEARCH_MAPPING)
     except ValueError:
         return
-    with deprecation.ignore('core.library.search:empty_query'):
-        results = context.core.library.search(query).get()
+    results = context.core.library.search(query).get()
     artists = [_artist_as_track(a) for a in _get_artists(results)]
     albums = [_album_as_track(a) for a in _get_albums(results)]
     tracks = _get_tracks(results)

--- a/mopidy/mpd/protocol/music_db.py
+++ b/mopidy/mpd/protocol/music_db.py
@@ -3,7 +3,6 @@ from __future__ import absolute_import, unicode_literals
 import functools
 import itertools
 
-from mopidy.internal import deprecation
 from mopidy.models import Track
 from mopidy.mpd import exceptions, protocol, translator
 
@@ -171,10 +170,9 @@ def findadd(context, *args):
 
     results = context.core.library.search(query=query, exact=True).get()
 
-    with deprecation.ignore('core.tracklist.add:tracks_arg'):
-        # TODO: for now just use tracks as other wise we have to lookup the
-        # tracks we just got from the search.
-        context.core.tracklist.add(tracks=_get_tracks(results)).get()
+    context.core.tracklist.add(
+        uris=[track.uri for track in _get_tracks(results)]
+    ).get()
 
 
 @protocol.commands.add('list')
@@ -465,10 +463,9 @@ def searchadd(context, *args):
 
     results = context.core.library.search(query).get()
 
-    with deprecation.ignore('core.tracklist.add:tracks_arg'):
-        # TODO: for now just use tracks as other wise we have to lookup the
-        # tracks we just got from the search.
-        context.core.tracklist.add(_get_tracks(results)).get()
+    context.core.tracklist.add(
+        uris=[track.uri for track in _get_tracks(results)]
+    ).get()
 
 
 @protocol.commands.add('searchaddpl')

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -5,7 +5,6 @@ import unittest
 import mock
 
 from mopidy import backend, core
-from mopidy.internal import deprecation
 from mopidy.internal.models import TracklistState
 from mopidy.models import TlTrack, Track
 
@@ -44,8 +43,7 @@ class TracklistTest(unittest.TestCase):
         self.library.lookup.reset_mock()
         self.core.tracklist.clear()
 
-        with deprecation.ignore('core.tracklist.add:uri_arg'):
-            tl_tracks = self.core.tracklist.add(uris=['dummy1:a'])
+        tl_tracks = self.core.tracklist.add(uris=['dummy1:a'])
 
         self.library.lookup.assert_called_once_with('dummy1:a')
         self.assertEqual(1, len(tl_tracks))

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -645,7 +645,7 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
 
         self.assertIn('core.library.lookup', methods)
         self.assertEqual(
-            methods['core.library.lookup']['params'][0]['name'], 'uri')
+            methods['core.library.lookup']['params'][0]['name'], 'uris')
 
         self.assertIn('core.playback.next', methods)
         self.assertEqual(len(methods['core.playback.next']['params']), 0)

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -643,7 +643,7 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
         self.assertIn('core.get_uri_schemes', methods)
         self.assertEqual(len(methods['core.get_uri_schemes']['params']), 0)
 
-        self.assertIn('core.library.lookup', methods.keys())
+        self.assertIn('core.library.lookup', methods)
         self.assertEqual(
             methods['core.library.lookup']['params'][0]['name'], 'uri')
 
@@ -654,10 +654,6 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
         self.assertEqual(
             len(methods['core.playlists.as_list']['params']), 0)
 
-        self.assertIn('core.tracklist.filter', methods.keys())
+        self.assertIn('core.tracklist.filter', methods)
         self.assertEqual(
             methods['core.tracklist.filter']['params'][0]['name'], 'criteria')
-        self.assertEqual(
-            methods['core.tracklist.filter']['params'][1]['name'], 'kwargs')
-        self.assertEqual(
-            methods['core.tracklist.filter']['params'][1]['kwargs'], True)

--- a/tests/local/test_playback.py
+++ b/tests/local/test_playback.py
@@ -9,7 +9,6 @@ import pykka
 
 from mopidy import core
 from mopidy.core import PlaybackState
-from mopidy.internal import deprecation
 from mopidy.local import actor
 from mopidy.models import TlTrack, Track
 
@@ -48,10 +47,6 @@ class LocalPlaybackProviderTest(unittest.TestCase):
 
         callback = self.audio.get_about_to_finish_callback().get()
         callback()
-
-    def run(self, result=None):
-        with deprecation.ignore('core.tracklist.add:tracks_arg'):
-            return super(LocalPlaybackProviderTest, self).run(result)
 
     def setUp(self):  # noqa: N802
         self.audio = dummy_audio.create_proxy()

--- a/tests/local/test_tracklist.py
+++ b/tests/local/test_tracklist.py
@@ -7,7 +7,6 @@ import pykka
 
 from mopidy import core
 from mopidy.core import PlaybackState
-from mopidy.internal import deprecation
 from mopidy.local import actor
 from mopidy.models import Playlist, Track
 
@@ -29,10 +28,6 @@ class LocalTracklistProviderTest(unittest.TestCase):
     }
     tracks = [
         Track(uri=generate_song(i), length=4464) for i in range(1, 4)]
-
-    def run(self, result=None):
-        with deprecation.ignore('core.tracklist.add:tracks_arg'):
-            return super(LocalTracklistProviderTest, self).run(result)
 
     def setUp(self):  # noqa: N802
         self.audio = dummy_audio.create_proxy()

--- a/tests/mpd/protocol/test_current_playlist.py
+++ b/tests/mpd/protocol/test_current_playlist.py
@@ -445,6 +445,12 @@ class SwapCommandTest(BasePopulatedTracklistTestCase):
         self.assertEqual(result, ['a', 'e', 'c', 'd', 'b', 'f'])
         self.assertInResponse('OK')
 
+    def test_swap_highest_position_first(self):
+        self.send_request('swap "4" "1"')
+        result = [t.name for t in self.core.tracklist.get_tracks().get()]
+        self.assertEqual(result, ['a', 'e', 'c', 'd', 'b', 'f'])
+        self.assertInResponse('OK')
+
     def test_swapid(self):
         self.send_request('swapid "2" "5"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]

--- a/tests/mpd/protocol/test_music_db.py
+++ b/tests/mpd/protocol/test_music_db.py
@@ -92,8 +92,10 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         self.assertInResponse('OK')
 
     def test_findadd(self):
+        track = Track(uri='dummy:a', name='A')
+        self.backend.library.dummy_library = [track]
         self.backend.library.dummy_find_exact_result = SearchResult(
-            tracks=[Track(uri='dummy:a', name='A')])
+            tracks=[track])
         self.assertEqual(self.core.tracklist.get_length().get(), 0)
 
         self.send_request('findadd "title" "A"')
@@ -104,8 +106,10 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         self.assertInResponse('OK')
 
     def test_searchadd(self):
+        track = Track(uri='dummy:a', name='A')
+        self.backend.library.dummy_library = [track]
         self.backend.library.dummy_search_result = SearchResult(
-            tracks=[Track(uri='dummy:a', name='A')])
+            tracks=[track])
         self.assertEqual(self.core.tracklist.get_length().get(), 0)
 
         self.send_request('searchadd "title" "a"')


### PR DESCRIPTION
This removes all deprecated arguments in the Core API, with the exception of `tracklist.add(tracks=...)`. However, this PR includes a couple of improvements to make it easier to remove `tracklist.add(tracks=...)`.

This almost completes #1461.