### PR TITLE
fix: PkgResourcesDeprecationWarning from mopidy/ext.py

### DIFF
--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -199,7 +199,10 @@ def load_extensions():
     for entry_point in pkg_resources.iter_entry_points('mopidy.ext'):
         logger.debug('Loading entry point: %s', entry_point)
         try:
-            extension_class = entry_point.load(require=False)
+            if hasattr(entry_point, 'resolve'):
+                extension_class = entry_point.resolve()
+            else:
+                extension_class = entry_point.load(require=False)
         except Exception as e:
             logger.exception("Failed to load extension {}: {}".format(
                 entry_point.name, e))


### PR DESCRIPTION
fixes #1778 