### PR TITLE
fix: PkgResourcesDeprecationWarning from mopidy/ext.py

### DIFF
--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -199,7 +199,7 @@ def load_extensions():
     for entry_point in pkg_resources.iter_entry_points('mopidy.ext'):
         logger.debug('Loading entry point: %s', entry_point)
         try:
-            extension_class = entry_point.load(require=False)
+            extension_class = entry_point.resolve()
         except Exception as e:
             logger.exception("Failed to load extension %s: %s" % (
                 entry_point.name, e))

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -87,7 +87,7 @@ class TestLoadExtensions(object):
 
     def test_load_extensions(self, iter_entry_points_mock):
         mock_entry_point = mock.Mock()
-        mock_entry_point.load.return_value = DummyExtension
+        mock_entry_point.resolve.return_value = DummyExtension
 
         iter_entry_points_mock.return_value = [mock_entry_point]
 
@@ -103,7 +103,7 @@ class TestLoadExtensions(object):
             pass
 
         mock_entry_point = mock.Mock()
-        mock_entry_point.load.return_value = WrongClass
+        mock_entry_point.resolve.return_value = WrongClass
 
         iter_entry_points_mock.return_value = [mock_entry_point]
 
@@ -111,7 +111,7 @@ class TestLoadExtensions(object):
 
     def test_gets_instance(self, iter_entry_points_mock):
         mock_entry_point = mock.Mock()
-        mock_entry_point.load.return_value = DummyExtension()
+        mock_entry_point.resolve.return_value = DummyExtension()
 
         iter_entry_points_mock.return_value = [mock_entry_point]
 
@@ -122,7 +122,7 @@ class TestLoadExtensions(object):
         mock_extension.side_effect = Exception
 
         mock_entry_point = mock.Mock()
-        mock_entry_point.load.return_value = mock_extension
+        mock_entry_point.resolve.return_value = mock_extension
 
         iter_entry_points_mock.return_value = [mock_entry_point]
 
@@ -130,7 +130,7 @@ class TestLoadExtensions(object):
 
     def test_get_config_schema_fails(self, iter_entry_points_mock):
         mock_entry_point = mock.Mock()
-        mock_entry_point.load.return_value = DummyExtension
+        mock_entry_point.resolve.return_value = DummyExtension
 
         iter_entry_points_mock.return_value = [mock_entry_point]
 
@@ -142,7 +142,7 @@ class TestLoadExtensions(object):
 
     def test_get_default_config_fails(self, iter_entry_points_mock):
         mock_entry_point = mock.Mock()
-        mock_entry_point.load.return_value = DummyExtension
+        mock_entry_point.resolve.return_value = DummyExtension
 
         iter_entry_points_mock.return_value = [mock_entry_point]
 
@@ -154,7 +154,7 @@ class TestLoadExtensions(object):
 
     def test_get_command_fails(self, iter_entry_points_mock):
         mock_entry_point = mock.Mock()
-        mock_entry_point.load.return_value = DummyExtension
+        mock_entry_point.resolve.return_value = DummyExtension
 
         iter_entry_points_mock.return_value = [mock_entry_point]
 


### PR DESCRIPTION
sry for creating a new PR. I'm only a little server admin and rebasing was too scary :wink:.

I changed the base branch to `release-2.2` and started again. 

> Lovely to find a PR with a fix just hours after I created the issue! :-)
> 
> A couple of comments:
> 
> According to this [setuptools commit](https://github.com/pypa/setuptools/commit/92a553d3adeb431cdf92b136ac9ccc3f2ef98bf1) the new methods where added in setuptools 11.3 about five years ago. According to [packages.debian.org](https://packages.debian.org/search?keywords=python-setuptools), Debian oldstable (stretch) ships setuptools 33. In other words, we can safely remove the `if hasattr(...)` and instead assume the "new" API to be present.
> 
> Second, some tests in `tests/test_ext.py` are failing. It seems you simply need to update a mock definition ~3 places:
> 
> ```diff
> -mock_entry_point.load.return_value = DummyExtension
> +mock_entry_point.resolve.return_value = DummyExtension
> ```
> 
> Lastly, please rebase the fix on top of the `release-2.2` branch and make that branch the basis for the PR. That way we can ship the fix in the next 2.2 bugfix release. The `develop` branch will not be shipped until Mopidy 3.0 is ready.