### PR TITLE
network: log client address not server address. (Fixes #1788)

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,6 +20,10 @@ Bug fix release.
 - Network: Close connection following an exception in the protocol handler.
   (Fixes: :issue:`1762`, PR: :issue:`1765`)
 
+- Network: Log client's connection details instead of server's. This fixed a
+  regression introduced as part of PR: :issue:`1629`. (Fixes: :issue:`1788`,
+  PR: :issue:`1792`)
+
 
 v2.2.3 (2019-06-20)
 ===================

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -24,6 +24,14 @@ def is_unix_socket(sock):
     return False
 
 
+def get_socket_address(host, port):
+    unix_socket_path = path.get_unix_socket_path(host)
+    if unix_socket_path is not None:
+        return (unix_socket_path, None)
+    else:
+        return (host, port)
+
+
 class ShouldRetrySocketCall(Exception):
 
     """Indicate that attempted socket call should be retried"""
@@ -70,12 +78,13 @@ def create_unix_socket():
     return socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
 
 
-def format_socket_name(sock):
-    """Format the connection string for the given socket"""
-    if is_unix_socket(sock):
-        return '%s' % sock.getsockname()
+def format_address(address):
+    """Format socket address for display."""
+    host, port = address[:2]
+    if port is not None:
+        return '[%s]:%s' % (host, port)
     else:
-        return '[%s]:%s' % sock.getsockname()[:2]
+        return '[%s]' % host
 
 
 def format_hostname(hostname):
@@ -96,6 +105,7 @@ class Server(object):
         self.max_connections = max_connections
         self.timeout = timeout
         self.server_socket = self.create_server_socket(host, port)
+        self.address = get_socket_address(host, port)
 
         self.watcher = self.register_server_socket(self.server_socket.fileno())
 
@@ -166,9 +176,7 @@ class Server(object):
 
     def reject_connection(self, sock, addr):
         # FIXME provide more context in logging?
-        logger.warning(
-            'Rejected connection from %s',
-            format_socket_name(sock))
+        logger.warning('Rejected connection from %s', format_address(addr))
         try:
             sock.close()
         except socket.error:
@@ -356,7 +364,7 @@ class Connection(object):
         return False
 
     def __str__(self):
-        return format_socket_name(self._sock)
+        return format_address((self.host, self.port))
 
 
 class LineProtocol(pykka.ThreadingActor):

--- a/mopidy/mpd/actor.py
+++ b/mopidy/mpd/actor.py
@@ -61,8 +61,7 @@ class MpdFrontend(pykka.ThreadingActor, CoreListener):
                 encoding.locale_decode(error))
 
         logger.info(
-            'MPD server running at %s',
-            network.format_socket_name(server.server_socket))
+            'MPD server running at %s', network.format_address(server.address))
 
         return server
 

--- a/mopidy/mpd/session.py
+++ b/mopidy/mpd/session.py
@@ -29,14 +29,14 @@ class MpdSession(network.LineProtocol):
         self.send_lines(['OK MPD %s' % protocol.VERSION])
 
     def on_line_received(self, line):
-        logger.debug('Request from [%s]: %s', self.connection, line)
+        logger.debug('Request from %s: %s', self.connection, line)
 
         response = self.dispatcher.handle_request(line)
         if not response:
             return
 
         logger.debug(
-            'Response to [%s]: %s',
+            'Response to %s: %s',
             self.connection,
             formatting.indent(self.terminator.join(response)))
 

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -557,3 +557,15 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertFalse(network.Connection.timeout_callback(self.mock))
         self.mock.stop.assert_called_once_with(any_unicode)
+
+    def test_str(self):
+        self.mock.host = 'foo'
+        self.mock.port = 999
+
+        self.assertEqual('[foo]:999', network.Connection.__str__(self.mock))
+
+    def test_str_without_port(self):
+        self.mock.host = 'foo'
+        self.mock.port = None
+
+        self.assertEqual('[foo]', network.Connection.__str__(self.mock))

--- a/tests/internal/network/test_utils.py
+++ b/tests/internal/network/test_utils.py
@@ -22,23 +22,40 @@ class FormatHostnameTest(unittest.TestCase):
         self.assertEqual(network.format_hostname('0.0.0.0'), '0.0.0.0')
 
 
-class FormatSocketConnectionTest(unittest.TestCase):
+class FormatAddressTest(unittest.TestCase):
 
-    def test_format_socket_name(self):
-        sock = Mock(spec=socket.SocketType)
-        sock.family = socket.AF_INET
-        sock.getsockname.return_value = (sentinel.ip, sentinel.port)
+    def test_format_address_ipv4(self):
+        address = (sentinel.host, sentinel.port)
         self.assertEqual(
-            network.format_socket_name(sock),
-            '[%s]:%s' % (sentinel.ip, sentinel.port))
+            network.format_address(address),
+            '[%s]:%s' % (sentinel.host, sentinel.port))
 
-    def test_format_socket_name_unix(self):
-        sock = Mock(spec=socket.SocketType)
-        sock.family = socket.AF_UNIX
-        sock.getsockname.return_value = sentinel.sockname
+    def test_format_address_ipv6(self):
+        address = (sentinel.host, sentinel.port, sentinel.flow, sentinel.scope)
         self.assertEqual(
-            network.format_socket_name(sock),
-            str(sentinel.sockname))
+            network.format_address(address),
+            '[%s]:%s' % (sentinel.host, sentinel.port))
+
+    def test_format_address_unix(self):
+        address = (sentinel.path, None)
+        self.assertEqual(
+            network.format_address(address),
+            '[%s]' % (sentinel.path))
+
+
+class GetSocketAddress(unittest.TestCase):
+
+    def test_get_socket_address(self):
+        host = str(sentinel.host)
+        port = sentinel.port
+        self.assertEqual(
+            network.get_socket_address(host, port), (host, port))
+
+    def test_get_socket_address_unix(self):
+        host = str(sentinel.host)
+        port = sentinel.port
+        self.assertEqual(
+            network.get_socket_address('unix:' + host, port), (host, None))
 
 
 class TryIPv6SocketTest(unittest.TestCase):

--- a/tests/mpd/test_session.py
+++ b/tests/mpd/test_session.py
@@ -1,0 +1,30 @@
+from __future__ import unicode_literals
+
+import logging
+
+from mock import Mock, sentinel
+
+from mopidy.internal import network
+from mopidy.mpd import dispatcher, session
+
+
+def test_on_start_logged(caplog):
+    caplog.set_level(logging.INFO)
+    connection = Mock(spec=network.Connection)
+
+    session.MpdSession(connection).on_start()
+
+    assert 'New MPD connection from %s' % connection in caplog.text
+
+
+def test_on_line_received_logged(caplog):
+    caplog.set_level(logging.DEBUG)
+    connection = Mock(spec=network.Connection)
+    mpd_session = session.MpdSession(connection)
+    mpd_session.dispatcher = Mock(spec=dispatcher.MpdDispatcher)
+    mpd_session.dispatcher.handle_request.return_value = [str(sentinel.resp)]
+
+    mpd_session.on_line_received(sentinel.line)
+
+    assert 'Request from %s: %s' % (connection, sentinel.line) in caplog.text
+    assert 'Response to %s:' % (connection,) in caplog.text


### PR DESCRIPTION
This, along with some formatting, was broken in #1629.

Also added some mpd.session tests for the log messages.