### PR TITLE
FileBackend using Track.replace() instead of Track.copy()

### DIFF
--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -93,7 +93,7 @@ class FileLibraryProvider(backend.LibraryProvider):
 
         try:
             result = self._scanner.scan(uri)
-            track = tags.convert_tags_to_track(result.tags).copy(
+            track = tags.convert_tags_to_track(result.tags).replace(
                 uri=uri, length=result.duration)
         except exceptions.ScannerError as e:
             logger.warning('Failed looking up %s: %s', uri, e)
@@ -102,7 +102,7 @@ class FileLibraryProvider(backend.LibraryProvider):
         if not track.name:
             filename = os.path.basename(local_path)
             name = urllib2.unquote(filename).decode(FS_ENCODING, 'replace')
-            track = track.copy(name=name)
+            track = track.replace(name=name)
 
         return [track]
 

--- a/tests/file/test_lookup.py
+++ b/tests/file/test_lookup.py
@@ -1,3 +1,46 @@
 from __future__ import unicode_literals
 
-# TODO Test lookup()
+import mock
+
+import pytest
+
+from mopidy.file import backend
+from mopidy.internal import path
+
+from tests import path_to_data_dir
+
+
+@pytest.fixture
+def config():
+    return {
+        'proxy': {},
+        'file': {
+            'show_dotfiles': False,
+            'media_dirs': [],
+            'excluded_file_extensions': [],
+            'follow_symlinks': False,
+            'metadata_timeout': 1000
+        },
+    }
+
+
+@pytest.fixture
+def audio():
+    return mock.Mock()
+
+
+@pytest.fixture
+def track_uri():
+    return path.path_to_uri(path_to_data_dir('song1.wav'))
+
+
+def test_lookup(config, audio, track_uri):
+    provider = backend.FileBackend(audio=audio, config=config).library
+
+    result = provider.lookup(track_uri)
+
+    assert len(result) == 1
+    track = result[0]
+    assert track.uri == track_uri
+    assert track.length == 4406
+    assert track.name == 'song1.wav'


### PR DESCRIPTION
The `copy` method of our models has been deprecated for some time and was finally removed as part of #1774

Also added a simple test.