### PR TITLE
state_changed should use getter/setter for accessing playback state.

### DIFF
--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -94,8 +94,8 @@ class Core(
         # We ignore cases when target state is set as this is buffering
         # updates (at least for now) and we need to get #234 fixed...
         if (new_state == PlaybackState.PAUSED and not target_state and
-                self.playback.state != PlaybackState.PAUSED):
-            self.playback.state = new_state
+                self.playback.get_state() != PlaybackState.PAUSED):
+            self.playback.set_state(new_state)
             self.playback._trigger_track_playback_paused()
 
     def playlists_loaded(self):

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -10,7 +10,8 @@ import mock
 import pykka
 
 import mopidy
-from mopidy.core import Core
+from mopidy.audio import PlaybackState
+from mopidy.core import Core, CoreListener
 from mopidy.internal import models, storage, versioning
 from mopidy.models import Track
 
@@ -50,6 +51,17 @@ class CoreActorTest(unittest.TestCase):
 
     def test_version(self):
         self.assertEqual(self.core.get_version(), versioning.get_version())
+
+    @mock.patch(
+        'mopidy.core.playback.listener.CoreListener', spec=CoreListener)
+    def test_state_changed(self, listener_mock):
+        self.core.state_changed(None, PlaybackState.PAUSED, None)
+
+        assert listener_mock.send.mock_calls == [
+            mock.call(
+                'playback_state_changed',
+                old_state='stopped', new_state='paused'),
+        ]
 
 
 class CoreActorSaveLoadStateTest(unittest.TestCase):


### PR DESCRIPTION
This was missed during #1768. Partly because it has no test coverage, so I added something simple.