### PR TITLE
fix websocket broadcasts in Tornado 5.x

### DIFF
--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -75,14 +75,14 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
         self.server.stop()
 
     def on_event(self, name, **data):
-        on_event(name, **data)
+        on_event(name, self.server.io_loop, **data)
 
 
-def on_event(name, **data):
+def on_event(name, ioloop, **data):
     event = data
     event['event'] = name
     message = json.dumps(event, cls=models.ModelJSONEncoder)
-    handlers.WebSocketHandler.broadcast(message)
+    handlers.WebSocketHandler.broadcast(ioloop, message)
 
 
 class HttpServer(threading.Thread):

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -98,9 +98,7 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
     clients = set()
 
     @classmethod
-    def broadcast(cls, msg):
-        loop = tornado.ioloop.IOLoop.current()
-
+    def broadcast(cls, loop, msg):
         # This can be called from outside the Tornado ioloop, so we need to
         # safely cross the thread boundary by adding a callback to the loop.
         for client in cls.clients:

--- a/tests/http/test_events.py
+++ b/tests/http/test_events.py
@@ -11,20 +11,23 @@ from mopidy.http import actor
 @mock.patch('mopidy.http.handlers.WebSocketHandler.broadcast')
 class HttpEventsTest(unittest.TestCase):
 
+    def setUp(self):
+        self.loop = mock.Mock()
+
     def test_track_playback_paused_is_broadcasted(self, broadcast):
-        actor.on_event('track_playback_paused', foo='bar')
+        actor.on_event('track_playback_paused', self.loop, foo='bar')
 
         self.assertDictEqual(
-            json.loads(str(broadcast.call_args[0][0])), {
+            json.loads(str(broadcast.call_args[0][1])), {
                 'event': 'track_playback_paused',
                 'foo': 'bar',
             })
 
     def test_track_playback_resumed_is_broadcasted(self, broadcast):
-        actor.on_event('track_playback_resumed', foo='bar')
+        actor.on_event('track_playback_resumed', self.loop, foo='bar')
 
         self.assertDictEqual(
-            json.loads(str(broadcast.call_args[0][0])), {
+            json.loads(str(broadcast.call_args[0][1])), {
                 'event': 'track_playback_resumed',
                 'foo': 'bar',
             })

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -55,7 +55,7 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
 
     def connection(self):
         url = self.get_url('/ws').replace('http', 'ws')
-        return tornado.websocket.websocket_connect(url, self.io_loop)
+        return tornado.websocket.websocket_connect(url)
 
     @tornado.testing.gen_test
     def test_invalid_json_rpc_request_doesnt_crash_handler(self):
@@ -69,7 +69,7 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
     @tornado.testing.gen_test
     def test_broadcast_makes_it_to_client(self):
         conn = yield self.connection()
-        handlers.WebSocketHandler.broadcast('message')
+        handlers.WebSocketHandler.broadcast(self.io_loop, 'message')
         message = yield conn.read_message()
         self.assertEqual(message, 'message')
 
@@ -77,7 +77,7 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def test_broadcast_to_client_that_just_closed_connection(self):
         conn = yield self.connection()
         conn.stream.close()
-        handlers.WebSocketHandler.broadcast('message')
+        handlers.WebSocketHandler.broadcast(self.io_loop, 'message')
 
     @tornado.testing.gen_test
     def test_broadcast_to_client_without_ws_connection_present(self):
@@ -87,7 +87,7 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
         # this has happened but we have not yet been removed from clients.
         for client in handlers.WebSocketHandler.clients:
             client.ws_connection = None
-        handlers.WebSocketHandler.broadcast('message')
+        handlers.WebSocketHandler.broadcast(self.io_loop, 'message')
 
 
 class CheckOriginTests(unittest.TestCase):


### PR DESCRIPTION
In Tornado 4.x and earlier, `IOLoop.current()` would return the global IOLoop
if there was no IOLoop already running in the calling thread. This was the
case when calling our websocket handler's `broadcast` method from the `HttpFrontend` thread
and so callbacks were correctly scheduled on the `HttpServer` thread's IOLoop.
However, in Tornado 5.0+, the idea of a global IOLoop is gone and calling
`IOLoop.current()` will simply create a new IOLoop if there isn't one already
running in the calling thread.
This incorrectly resulted in callbacks being scheduled on that new IOLoop
which is never actually started and so the broadcasts were never sent.

To fix this we explicitly provide `broadcast` with the correct IOLoop to use (`HttpServer`'s).

Also, `tornado.websocket.websocket_connect` removed the io_loop parameter, which we don't seem to need. I gave up trying to get the tests to fail under Tornado 5.x.

This is related to #1716.