### PR TITLE
handle stream playlists containing relative URIs

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,9 @@ Bug fix release.
   on recieving a ``title`` audio tag that differs from the current track's
   :attr:`mopidy.models.Track.name`. (Fixes: :issue:`1746`, PR: :issue:`1751`)
 
+- Stream: Support playlists containing relative URIs. (Fixes: :issue:`1785`,
+  PR: :issue:`1802`)
+
 
 v2.2.3 (2019-06-20)
 ===================

--- a/mopidy/compat.py
+++ b/mopidy/compat.py
@@ -21,6 +21,7 @@ if PY2:
         urllib.parse.quote = py2_urllib.quote
         urllib.parse.unquote = py2_urllib.unquote
 
+        urllib.parse.urljoin = py2_urlparse.urljoin
         urllib.parse.urlparse = py2_urlparse.urlparse
         urllib.parse.urlsplit = py2_urlparse.urlsplit
         urllib.parse.urlunsplit = py2_urlparse.urlunsplit

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -160,4 +160,4 @@ def _unwrap_stream(uri, timeout, scanner, requests_session):
         # TODO Test streams and return first that seems to be playable
         logger.debug(
             'Parsed playlist (%s) and found new URI: %s', uri, uris[0])
-        uri = uris[0]
+        uri = urllib.parse.urljoin(uri, uris[0])


### PR DESCRIPTION
This doesn't actually fix the example given in #1785 since it's a HLS stream and our stream backend will only play the first segment. We should fix HLS support separately. 