### PR TITLE
Some fixes for non-ASCII chars in MPD uris

### DIFF
--- a/mopidy/mpd/protocol/stored_playlists.py
+++ b/mopidy/mpd/protocol/stored_playlists.py
@@ -41,7 +41,7 @@ def listplaylist(context, name):
         file: relative/path/to/file3.mp3
     """
     playlist = _get_playlist(context, name)
-    return ['file: %s' % t.uri for t in playlist.tracks]
+    return [translator.uri_to_mpd_format(t.uri) for t in playlist.tracks]
 
 
 @protocol.commands.add('listplaylistinfo')

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -43,7 +43,7 @@ def track_to_mpd_format(track, position=None, stream_title=None):
         return []
 
     result = [
-        ('file', track.uri),
+        ('file', track.uri.decode('utf-8')),
         ('Time', track.length and (track.length // 1000) or 0),
         ('Artist', concat_multi_values(track.artists, 'name')),
         ('Album', track.album and track.album.name or ''),

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -21,6 +21,10 @@ def normalize_path(path, relative=False):
     return '/'.join(parts)
 
 
+def uri_to_mpd_format(uri):
+    return ('file', uri.decode('utf-8'))
+
+
 def track_to_mpd_format(track, position=None, stream_title=None):
     """
     Format track for output to MPD client.
@@ -43,7 +47,7 @@ def track_to_mpd_format(track, position=None, stream_title=None):
         return []
 
     result = [
-        ('file', track.uri.decode('utf-8')),
+        uri_to_mpd_format(track.uri),
         ('Time', track.length and (track.length // 1000) or 0),
         ('Artist', concat_multi_values(track.artists, 'name')),
         ('Album', track.album and track.album.name or ''),

--- a/tests/dummy_backend.py
+++ b/tests/dummy_backend.py
@@ -124,6 +124,7 @@ class DummyPlaylistsProvider(backend.PlaylistsProvider):
             Ref.track(uri=t.uri, name=t.name) for t in playlist.tracks]
 
     def lookup(self, uri):
+        uri = Ref.playlist(uri=uri).uri
         for playlist in self._playlists:
             if playlist.uri == uri:
                 return playlist

--- a/tests/dummy_backend.py
+++ b/tests/dummy_backend.py
@@ -49,6 +49,7 @@ class DummyLibraryProvider(backend.LibraryProvider):
         return self.dummy_get_distinct_result.get(field, set())
 
     def lookup(self, uri):
+        uri = Ref.track(uri=uri).uri
         return [t for t in self.dummy_library if uri == t.uri]
 
     def refresh(self, uri=None):

--- a/tests/mpd/protocol/__init__.py
+++ b/tests/mpd/protocol/__init__.py
@@ -22,6 +22,7 @@ class MockConnection(mock.Mock):
         self.response = []
 
     def queue_send(self, data):
+        data = data.decode('utf-8')
         lines = (line for line in data.split('\n') if line)
         self.response.extend(lines)
 
@@ -68,7 +69,7 @@ class BaseTestCase(unittest.TestCase):
 
     def send_request(self, request):
         self.connection.response = []
-        request = '%s\n' % request.encode('utf-8')
+        request = ('%s\n' % request).encode('utf-8')
         self.session.on_receive({'received': request})
         return self.connection.response
 


### PR DESCRIPTION
Fixes #1759 

Most of this comes from Track `uris`s being `bytes` and but falling over when formatted with unicode  strings for output or logging. And then I went a bit mad sprinkling non-ASCII throughout the tests.