### PR TITLE
More fixes for non-ASCII chars in MPD uris

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -42,6 +42,9 @@ version of Tornado, we're doing a minor version bump of Mopidy.
 - MPD: Add support for seeking to time positions with float point precision.
   (Fixes: :issue:`1756`, PR: :issue:`1801`)
 
+- MPD: Handle URIs containing non-ASCII characters. (Fixes: :issue:`1759`,
+  PR: :issue:`1805`, :issue:`1808`)
+
 
 v2.2.3 (2019-06-20)
 ===================

--- a/mopidy/mpd/protocol/stored_playlists.py
+++ b/mopidy/mpd/protocol/stored_playlists.py
@@ -41,7 +41,8 @@ def listplaylist(context, name):
         file: relative/path/to/file3.mp3
     """
     playlist = _get_playlist(context, name)
-    return [translator.uri_to_mpd_format(t.uri) for t in playlist.tracks]
+    uris = [translator.uri_to_mpd_format(t.uri) for t in playlist.tracks]
+    return ['file: %s' % u for u in uris]
 
 
 @protocol.commands.add('listplaylistinfo')

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -22,7 +22,7 @@ def normalize_path(path, relative=False):
 
 
 def uri_to_mpd_format(uri):
-    return ('file', uri.decode('utf-8'))
+    return uri.decode('utf-8')
 
 
 def track_to_mpd_format(track, position=None, stream_title=None):
@@ -47,7 +47,7 @@ def track_to_mpd_format(track, position=None, stream_title=None):
         return []
 
     result = [
-        uri_to_mpd_format(track.uri),
+        ('file', uri_to_mpd_format(track.uri)),
         ('Time', track.length and (track.length // 1000) or 0),
         ('Artist', concat_multi_values(track.artists, 'name')),
         ('Album', track.album and track.album.name or ''),
@@ -110,7 +110,7 @@ def track_to_mpd_format(track, position=None, stream_title=None):
         result.append(('MUSICBRAINZ_TRACKID', track.musicbrainz_id))
 
     if track.album and track.album.uri:
-        result.append(('X-AlbumUri', track.album.uri))
+        result.append(('X-AlbumUri', uri_to_mpd_format(track.album.uri)))
     if track.album and track.album.images:
         images = ';'.join(i for i in track.album.images if i != '')
         result.append(('X-AlbumImage', images))

--- a/tests/mpd/protocol/test_status.py
+++ b/tests/mpd/protocol/test_status.py
@@ -1,6 +1,9 @@
+# encoding: utf-8
+
+
 from __future__ import absolute_import, unicode_literals
 
-from mopidy.models import Track
+from mopidy.models import Album, Track
 
 from tests.mpd import protocol
 
@@ -28,6 +31,21 @@ class StatusHandlerTest(protocol.BaseTestCase):
         self.assertInResponse('Pos: 0')
         self.assertInResponse('Id: 1')
         self.assertInResponse('OK')
+
+    def test_currentsong_unicode(self):
+        track = Track(
+            uri='dummy:/à',
+            name='a nàme',
+            album=Album(uri='something:àlbum:12345')
+        )
+        self.backend.library.dummy_library = [track]
+        self.core.tracklist.add(uris=[track.uri]).get()
+
+        self.core.playback.play().get()
+        self.send_request('currentsong')
+        self.assertInResponse('file: dummy:/à')
+        self.assertInResponse('Title: a nàme')
+        self.assertInResponse('X-AlbumUri: something:àlbum:12345')
 
     def test_currentsong_without_song(self):
         self.send_request('currentsong')

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 from __future__ import absolute_import, unicode_literals
 
 import unittest
@@ -9,13 +11,13 @@ from mopidy.mpd import translator
 
 class TrackMpdFormatTest(unittest.TestCase):
     track = Track(
-        uri='a uri',
+        uri='à uri',
         artists=[Artist(name='an artist')],
-        name='a name',
+        name='a nàme',
         album=Album(
             name='an album', num_tracks=13,
             artists=[Artist(name='an other artist')],
-            uri='urischeme:album:12345', images=['image1']),
+            uri='urischeme:àlbum:12345', images=['image1']),
         track_no=7,
         composers=[Artist(name='a composer')],
         performers=[Artist(name='a performer')],
@@ -63,10 +65,10 @@ class TrackMpdFormatTest(unittest.TestCase):
     def test_track_to_mpd_format_for_nonempty_track(self):
         result = translator.track_to_mpd_format(
             TlTrack(122, self.track), position=9)
-        self.assertIn(('file', 'a uri'), result)
+        self.assertIn(('file', 'à uri'), result)
         self.assertIn(('Time', 137), result)
         self.assertIn(('Artist', 'an artist'), result)
-        self.assertIn(('Title', 'a name'), result)
+        self.assertIn(('Title', 'a nàme'), result)
         self.assertIn(('Album', 'an album'), result)
         self.assertIn(('AlbumArtist', 'an other artist'), result)
         self.assertIn(('Composer', 'a composer'), result)
@@ -77,7 +79,7 @@ class TrackMpdFormatTest(unittest.TestCase):
         self.assertIn(('Disc', 1), result)
         self.assertIn(('Pos', 9), result)
         self.assertIn(('Id', 122), result)
-        self.assertIn(('X-AlbumUri', 'urischeme:album:12345'), result)
+        self.assertIn(('X-AlbumUri', 'urischeme:àlbum:12345'), result)
         self.assertIn(('X-AlbumImage', 'image1'), result)
         self.assertNotIn(('Comment', 'a comment'), result)
         self.assertEqual(len(result), 16)
@@ -134,12 +136,12 @@ class TrackMpdFormatTest(unittest.TestCase):
 
     def test_track_to_mpd_format_with_stream_title(self):
         result = translator.track_to_mpd_format(self.track, stream_title='foo')
-        self.assertIn(('Name', 'a name'), result)
+        self.assertIn(('Name', 'a nàme'), result)
         self.assertIn(('Title', 'foo'), result)
 
     def test_track_to_mpd_format_with_empty_stream_title(self):
         result = translator.track_to_mpd_format(self.track, stream_title='')
-        self.assertIn(('Name', 'a name'), result)
+        self.assertIn(('Name', 'a nàme'), result)
         self.assertNotIn(('Title', ''), result)
 
     def test_track_to_mpd_format_with_stream_and_no_track_name(self):
@@ -154,7 +156,7 @@ class PlaylistMpdFormatTest(unittest.TestCase):
     def test_mpd_format(self):
         playlist = Playlist(tracks=[
             Track(uri='foo', track_no=1),
-            Track(uri='bar', track_no=2),
+            Track(uri='bàr', track_no=2),
             Track(uri='baz', track_no=3)])
         result = translator.playlist_to_mpd_format(playlist)
         self.assertEqual(len(result), 3)
@@ -162,7 +164,7 @@ class PlaylistMpdFormatTest(unittest.TestCase):
     def test_mpd_format_with_range(self):
         playlist = Playlist(tracks=[
             Track(uri='foo', track_no=1),
-            Track(uri='bar', track_no=2),
+            Track(uri='bàr', track_no=2),
             Track(uri='baz', track_no=3)])
         result = translator.playlist_to_mpd_format(playlist, 1, 2)
         self.assertEqual(len(result), 1)


### PR DESCRIPTION
I missed Album URIs in #1805. And a changelog entry.