### PR TITLE
Mopidy on Windows

### DIFF
--- a/docs/command.rst
+++ b/docs/command.rst
@@ -53,7 +53,7 @@ Options
 .. cmdoption:: --config <file|directory>
 
     Specify config files and directories to use. To use multiple config files
-    or directories, separate them with a colon. The later files override the
+    or directories, separate them with a semicolon. The later files override the
     earlier ones if there's a conflict. When specifying a directory, all files
     ending in .conf in the directory are used.
 

--- a/mopidy/__init__.py
+++ b/mopidy/__init__.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, print_function, unicode_literals
 import platform
 import sys
 import warnings
+import os, posixpath
 
 
 if not (2, 7) <= sys.version_info < (3,):
@@ -15,3 +16,10 @@ warnings.filterwarnings('ignore', 'could not open display')
 
 
 __version__ = '2.3.0'
+
+
+def posix_normpath(path):
+    """if path has win32 backslashes, convert to forward slashes"""
+    path = os.path.splitdrive(path)[1]
+    path_parts = path.split(os.path.sep)
+    return posixpath.sep.join(path_parts)

--- a/mopidy/__init__.py
+++ b/mopidy/__init__.py
@@ -21,7 +21,6 @@ __version__ = '2.3.0'
 
 def posix_normpath(*paths):
     """if path has win32 backslashes, convert to forward slashes"""
-    # drive, path = os.path.splitdrive(paths[0])
     res = paths[0].split(os.path.sep)
     for path in paths[1:]:
         path_parts = path.split(os.path.sep)

--- a/mopidy/__init__.py
+++ b/mopidy/__init__.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
+import os
 import platform
+import posixpath
 import sys
 import warnings
-import os, posixpath
 
 
 if not (2, 7) <= sys.version_info < (3,):

--- a/mopidy/__init__.py
+++ b/mopidy/__init__.py
@@ -18,8 +18,11 @@ warnings.filterwarnings('ignore', 'could not open display')
 __version__ = '2.3.0'
 
 
-def posix_normpath(path):
+def posix_normpath(*paths):
     """if path has win32 backslashes, convert to forward slashes"""
-    path = os.path.splitdrive(path)[1]
-    path_parts = path.split(os.path.sep)
-    return posixpath.sep.join(path_parts)
+    drive, path = os.path.splitdrive(paths[0])
+    res = path.split(os.path.sep)
+    for path in paths[1:]:
+        path_parts = path.split(os.path.sep)
+        res.extend(path_parts)
+    return posixpath.sep.join(res)

--- a/mopidy/__init__.py
+++ b/mopidy/__init__.py
@@ -20,8 +20,8 @@ __version__ = '2.3.0'
 
 def posix_normpath(*paths):
     """if path has win32 backslashes, convert to forward slashes"""
-    drive, path = os.path.splitdrive(paths[0])
-    res = path.split(os.path.sep)
+    # drive, path = os.path.splitdrive(paths[0])
+    res = paths[0].split(os.path.sep)
     for path in paths[1:]:
         path_parts = path.split(os.path.sep)
         res.extend(path_parts)

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -289,8 +289,11 @@ class RootCommand(Command):
             loop.quit()
 
         loop = GLib.MainLoop()
-        GLib.unix_signal_add(
-            GLib.PRIORITY_DEFAULT, signal.SIGTERM, on_sigterm, loop)
+        # unix_signal_add allows for terminating GStreamer on closing
+        #  not critical, and not supported by win32 lib
+        if sys.platform != 'win32':
+            GLib.unix_signal_add(
+                GLib.PRIORITY_DEFAULT, signal.SIGTERM, on_sigterm, loop)
 
         mixer_class = self.get_mixer_class(config, args.registry['mixer'])
         backend_classes = args.registry['backend']

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 _default_config = []
 for base in GLib.get_system_config_dirs() + [GLib.get_user_config_dir()]:
     _default_config.append(os.path.join(base, b'mopidy', b'mopidy.conf'))
-DEFAULT_CONFIG = b':'.join(_default_config)
+DEFAULT_CONFIG = b';'.join(_default_config)
 
 
 def config_files_type(value):

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -25,7 +25,7 @@ DEFAULT_CONFIG = b':'.join(_default_config)
 
 
 def config_files_type(value):
-    return value.split(b':')
+    return value.split(b';')  # win32 uses : for drive-name indicator
 
 
 def config_override_type(value):
@@ -276,7 +276,7 @@ class RootCommand(Command):
             '--config',
             action='store', dest='config_files', type=config_files_type,
             default=DEFAULT_CONFIG, metavar='FILES',
-            help='config files to use, colon seperated, later files override')
+            help='config files to use, semicolon separated, later files override')
         self.add_argument(
             '-o', '--option',
             action='append', dest='config_overrides',

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -276,7 +276,8 @@ class RootCommand(Command):
             '--config',
             action='store', dest='config_files', type=config_files_type,
             default=DEFAULT_CONFIG, metavar='FILES',
-            help='config files to use, semicolon separated, later files override')
+            help='config files to use, semicolon separated, '
+                 'later files override')
         self.add_argument(
             '-o', '--option',
             action='append', dest='config_overrides',

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -310,7 +310,7 @@ class Path(ConfigValue):
         validators.validate_required(expanded, self._required)
         if not value or expanded is None:
             return None
-        _, expanded = os.path.splitdrive(expanded)
+        # _, expanded = os.path.splitdrive(expanded)
         return ExpandedPath(value, expanded)
 
     def serialize(self, value, display=False):

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import os
 import logging
 import re
 import socket
@@ -309,6 +310,7 @@ class Path(ConfigValue):
         validators.validate_required(expanded, self._required)
         if not value or expanded is None:
             return None
+        _, expanded = os.path.splitdrive(expanded)
         return ExpandedPath(value, expanded)
 
     def serialize(self, value, display=False):

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import os
 import logging
 import re
 import socket

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -71,7 +71,7 @@ class Extension(object):
         """
         assert cls.ext_name is not None
         cache_dir_path = bytes(posixpath.join(config['core']['cache_dir'],
-                                            cls.ext_name))
+                                              cls.ext_name))
         path.get_or_create_dir(cache_dir_path)
         return cache_dir_path
 
@@ -84,7 +84,7 @@ class Extension(object):
         """
         assert cls.ext_name is not None
         config_dir_path = bytes(posixpath.join(config['core']['config_dir'],
-                                             cls.ext_name))
+                                               cls.ext_name))
         path.get_or_create_dir(config_dir_path)
         return config_dir_path
 
@@ -99,7 +99,7 @@ class Extension(object):
         """
         assert cls.ext_name is not None
         data_dir_path = bytes(posixpath.join(config['core']['data_dir'],
-                                           cls.ext_name))
+                                             cls.ext_name))
         path.get_or_create_dir(data_dir_path)
         return data_dir_path
 

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import collections
 import logging
-import os
+import posixpath
 
 import pkg_resources
 
@@ -70,7 +70,7 @@ class Extension(object):
         :return: string
         """
         assert cls.ext_name is not None
-        cache_dir_path = bytes(os.path.join(config['core']['cache_dir'],
+        cache_dir_path = bytes(posixpath.join(config['core']['cache_dir'],
                                             cls.ext_name))
         path.get_or_create_dir(cache_dir_path)
         return cache_dir_path
@@ -83,7 +83,7 @@ class Extension(object):
         :return: string
         """
         assert cls.ext_name is not None
-        config_dir_path = bytes(os.path.join(config['core']['config_dir'],
+        config_dir_path = bytes(posixpath.join(config['core']['config_dir'],
                                              cls.ext_name))
         path.get_or_create_dir(config_dir_path)
         return config_dir_path
@@ -98,7 +98,7 @@ class Extension(object):
         :returns: string
         """
         assert cls.ext_name is not None
-        data_dir_path = bytes(os.path.join(config['core']['data_dir'],
+        data_dir_path = bytes(posixpath.join(config['core']['data_dir'],
                                            cls.ext_name))
         path.get_or_create_dir(data_dir_path)
         return data_dir_path

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -288,12 +288,13 @@ class Connection(object):
     def enable_recv(self):
         if self.recv_id is not None:
             return
-        if sys.platform == 'win32':
-            chan = self._sock
-        else:
-            chan = self._sock.fileno()
 
-        try:
+	try:
+            if sys.platform == 'win32':
+                chan = self._sock
+	    else:
+                chan = self._sock.fileno()
+
             self.recv_id = GObject.io_add_watch(
                 chan,
                 1,  # priority?

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -107,7 +107,7 @@ class Server(object):
         self.server_socket = self.create_server_socket(host, port)
         self.address = get_socket_address(host, port)
 
-        self.watcher = self.register_server_socket(self.server_socket.fileno())
+        self.watcher = self.register_server_socket(self.server_socket)
 
     def create_server_socket(self, host, port):
         socket_path = path.get_unix_socket_path(host)

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -147,7 +147,7 @@ class Server(object):
         return GObject.io_add_watch(
             chan,
             1,  # priority?
-            GObject.IO_IN,
+            GLib.IO_IN,
             self.handle_connection)
 
     def handle_connection(self, fd, flags):
@@ -297,7 +297,7 @@ class Connection(object):
             self.recv_id = GObject.io_add_watch(
                 chan,
                 1,  # priority?
-                GObject.IO_IN | GObject.IO_ERR | GObject.IO_HUP,
+                GLib.IO_IN | GLib.IO_ERR | GLib.IO_HUP,
                 self.recv_callback)
         except socket.error as e:
             self.stop('Problem with connection: %s' % e)
@@ -315,7 +315,7 @@ class Connection(object):
         try:
             self.send_id = GObject.io_add_watch(
                 self._sock.fileno(),
-                GObject.IO_OUT | GObject.IO_ERR | GObject.IO_HUP,
+                GLib.IO_OUT | GLib.IO_ERR | GLib.IO_HUP,
                 self.send_callback)
         except socket.error as e:
             self.stop('Problem with connection: %s' % e)
@@ -328,7 +328,7 @@ class Connection(object):
         self.send_id = None
 
     def recv_callback(self, fd, flags):
-        if flags & (GObject.IO_ERR | GObject.IO_HUP):
+        if flags & (GLib.IO_ERR | GLib.IO_HUP):
             self.stop('Bad client flags: %s' % flags)
             return True
 
@@ -352,7 +352,7 @@ class Connection(object):
         return True
 
     def send_callback(self, fd, flags):
-        if flags & (GObject.IO_ERR | GObject.IO_HUP):
+        if flags & (GLib.IO_ERR | GLib.IO_HUP):
             self.stop('Bad client flags: %s' % flags)
             return True
 

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -147,7 +147,7 @@ class Server(object):
         return GObject.io_add_watch(
             chan,
             1,  # priority?
-            GLib.IO_IN,
+            GObject.IO_IN,
             self.handle_connection)
 
     def handle_connection(self, fd, flags):
@@ -297,7 +297,7 @@ class Connection(object):
             self.recv_id = GObject.io_add_watch(
                 chan,
                 1,  # priority?
-                GLib.IO_IN | GLib.IO_ERR | GLib.IO_HUP,
+                GObject.IO_IN | GObject.IO_ERR | GObject.IO_HUP,
                 self.recv_callback)
         except socket.error as e:
             self.stop('Problem with connection: %s' % e)
@@ -315,7 +315,7 @@ class Connection(object):
         try:
             self.send_id = GObject.io_add_watch(
                 self._sock.fileno(),
-                GLib.IO_OUT | GLib.IO_ERR | GLib.IO_HUP,
+                GObject.IO_OUT | GObject.IO_ERR | GObject.IO_HUP,
                 self.send_callback)
         except socket.error as e:
             self.stop('Problem with connection: %s' % e)
@@ -328,7 +328,7 @@ class Connection(object):
         self.send_id = None
 
     def recv_callback(self, fd, flags):
-        if flags & (GLib.IO_ERR | GLib.IO_HUP):
+        if flags & (GObject.IO_ERR | GObject.IO_HUP):
             self.stop('Bad client flags: %s' % flags)
             return True
 
@@ -352,7 +352,7 @@ class Connection(object):
         return True
 
     def send_callback(self, fd, flags):
-        if flags & (GLib.IO_ERR | GLib.IO_HUP):
+        if flags & (GObject.IO_ERR | GObject.IO_HUP):
             self.stop('Bad client flags: %s' % flags)
             return True
 

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -289,10 +289,10 @@ class Connection(object):
         if self.recv_id is not None:
             return
 
-	try:
+        try:
             if sys.platform == 'win32':
                 chan = self._sock
-	    else:
+            else:
                 chan = self._sock.fileno()
 
             self.recv_id = GObject.io_add_watch(

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -71,7 +71,7 @@ def path_to_uri(path):
     drive, path = os.path.splitdrive(path)
     path = urllib.parse.quote(path)
     if drive:
-        path = posixpath.sep.join([b'', drive])+path
+        path = posixpath.sep.join([b'', drive]) + path
     return urllib.parse.urlunsplit((b'file', b'', path, b'', b''))
 
 
@@ -144,13 +144,14 @@ def _find_worker(relative, follow, done, work, results, errors):
 
             # st_dev and st_ino are always 0 on win32
             signature = (st.st_dev, st.st_ino)
-            if signature != (0,0) and signature in parents:
+            if signature != (0, 0) and signature in parents:
                 errors[path] = exceptions.FindError('Sym/hardlink loop found.')
                 continue
 
             # backstop to prevent infinite recursion
             if len(parents) > MAX_RECURSE:
-                errors[path] = exceptions.FindError('Overly deep dir recursion found.')
+                errors[path] = exceptions.FindError('Overly deep dir '
+                                                    'recursion found.')
                 continue
 
             parents = parents + [signature]

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -14,7 +14,7 @@ from mopidy.internal import encoding, xdg
 
 logger = logging.getLogger(__name__)
 
-MAX_RECURSE = 100
+MAX_RECURSE = 25
 
 XDG_DIRS = xdg.get_dirs()
 
@@ -23,7 +23,6 @@ def get_or_create_dir(dir_path):
     if not isinstance(dir_path, bytes):
         raise ValueError('Path is not a bytestring.')
     dir_path = expand_path(dir_path)
-    print('dir_path 1 {}'.format(dir_path))
     if os.path.isfile(dir_path):
         raise OSError(
             'A file with the same name as the desired dir, '

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -7,7 +7,7 @@ import stat
 import string
 import threading
 
-from mopidy import compat, exceptions
+from mopidy import compat, exceptions, posix_normpath
 from mopidy.compat import queue, urllib
 from mopidy.internal import encoding, xdg
 
@@ -67,6 +67,7 @@ def path_to_uri(path):
     """
     if isinstance(path, compat.text_type):
         path = path.encode('utf-8')
+    path = posix_normpath(path)
     path = urllib.parse.quote(path)
     return urllib.parse.urlunsplit((b'file', b'', path, b'', b''))
 

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -11,7 +11,6 @@ from mopidy import compat, exceptions, posix_normpath
 from mopidy.compat import queue, urllib
 from mopidy.internal import encoding, xdg
 
-
 logger = logging.getLogger(__name__)
 
 MAX_RECURSE = 25
@@ -68,7 +67,7 @@ def path_to_uri(path):
     """
     if isinstance(path, compat.text_type):
         path = path.encode('utf-8')
-    path = posix_normpath(path)
+    path = posix_normpath(os.path.splitdrive(path)[1])
     path = urllib.parse.quote(path)
     return urllib.parse.urlunsplit((b'file', b'', path, b'', b''))
 
@@ -205,8 +204,8 @@ def _find(root, thread_count=10, relative=False, follow=False):
     return results, errors
 
 
-def find_mtimes(root, follow=False):
-    results, errors = _find(root, relative=False, follow=follow)
+def find_mtimes(root, follow=False, relative=False):
+    results, errors = _find(root, relative=relative, follow=follow)
     # return the mtimes as integer milliseconds
     mtimes = {f: int(st.st_mtime * 1000) for f, st in results.items()}
     return mtimes, errors

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -14,6 +14,7 @@ from mopidy.internal import encoding, xdg
 
 logger = logging.getLogger(__name__)
 
+MAX_RECURSE = 100
 
 XDG_DIRS = xdg.get_dirs()
 
@@ -146,7 +147,8 @@ def _find_worker(relative, follow, done, work, results, errors):
                 errors[path] = exceptions.FindError('Sym/hardlink loop found.')
                 continue
 
-            if len(parents) > 100:
+            # backstop to prevent infinite recursion
+            if len(parents) > MAX_RECURSE:
                 errors[path] = exceptions.FindError('Overly deep dir recursion found.')
                 continue
 

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -22,6 +22,7 @@ def get_or_create_dir(dir_path):
     if not isinstance(dir_path, bytes):
         raise ValueError('Path is not a bytestring.')
     dir_path = expand_path(dir_path)
+    print('dir_path 1 {}'.format(dir_path))
     if os.path.isfile(dir_path):
         raise OSError(
             'A file with the same name as the desired dir, '
@@ -129,9 +130,9 @@ def _find_worker(relative, follow, done, work, results, errors):
             continue
 
         if relative:
-            path = os.path.relpath(entry, relative)
+            path = posix_normpath(os.path.relpath(entry, relative))
         else:
-            path = entry
+            path = posix_normpath(entry)
 
         try:
             if follow:

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -109,7 +109,7 @@ def expand_path(path):
         return None
     path = os.path.expanduser(path)
     path = os.path.abspath(path)
-    return path
+    return posix_normpath(path)
 
 
 def _find_worker(relative, follow, done, work, results, errors):

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import, unicode_literals
 
 import logging
 import os
+import posixpath
 import re
 import stat
 import string
@@ -67,8 +68,10 @@ def path_to_uri(path):
     """
     if isinstance(path, compat.text_type):
         path = path.encode('utf-8')
-    path = posix_normpath(os.path.splitdrive(path)[1])
+    drive, path = os.path.splitdrive(path)
     path = urllib.parse.quote(path)
+    if drive:
+        path = posixpath.sep.join([b'', drive])+path
     return urllib.parse.urlunsplit((b'file', b'', path, b'', b''))
 
 

--- a/mopidy/internal/storage.py
+++ b/mopidy/internal/storage.py
@@ -53,7 +53,6 @@ def dump(path, data):
             with gzip.GzipFile(fileobj=tmp, mode='wb', filename=basename[:-3]) as fp:
                 json.dump(data, fp, cls=models.ModelJSONEncoder,
                           indent=2, separators=(',', ': '))
-        print('save path {}  basename {}'.format(path, basename))
         if os.path.exists(path):
             os.remove(path)
         os.rename(tmp.name, path)

--- a/mopidy/internal/storage.py
+++ b/mopidy/internal/storage.py
@@ -50,7 +50,8 @@ def dump(path, data):
     try:
         with tempfile.NamedTemporaryFile(
                 prefix=basename + '.', dir=directory, delete=False) as tmp:
-            with gzip.GzipFile(fileobj=tmp, mode='wb', filename=basename[:-3]) as fp:
+            with gzip.GzipFile(fileobj=tmp, mode='wb',
+                               filename=basename[:-3]) as fp:
                 json.dump(data, fp, cls=models.ModelJSONEncoder,
                           indent=2, separators=(',', ': '))
         if os.path.exists(path):

--- a/mopidy/internal/storage.py
+++ b/mopidy/internal/storage.py
@@ -47,13 +47,15 @@ def dump(path, data):
     directory, basename = os.path.split(path)
 
     # TODO: cleanup directory/basename.* files.
-    tmp = tempfile.NamedTemporaryFile(
-        prefix=basename + '.', dir=directory, delete=False)
-
     try:
-        with gzip.GzipFile(fileobj=tmp, mode='wb') as fp:
-            json.dump(data, fp, cls=models.ModelJSONEncoder,
-                      indent=2, separators=(',', ': '))
+        with tempfile.NamedTemporaryFile(
+                prefix=basename + '.', dir=directory, delete=False) as tmp:
+            with gzip.GzipFile(fileobj=tmp, mode='wb', filename=basename[:-3]) as fp:
+                json.dump(data, fp, cls=models.ModelJSONEncoder,
+                          indent=2, separators=(',', ': '))
+        print('save path {}  basename {}'.format(path, basename))
+        if os.path.exists(path):
+            os.remove(path)
         os.rename(tmp.name, path)
     finally:
         if os.path.exists(tmp.name):

--- a/mopidy/internal/xdg.py
+++ b/mopidy/internal/xdg.py
@@ -2,7 +2,9 @@ from __future__ import absolute_import, unicode_literals
 
 import io
 import os
+import posixpath
 
+from mopidy import posix_normpath
 from mopidy.compat import configparser
 
 
@@ -22,13 +24,13 @@ def get_dirs():
     dirs = {
         'XDG_CACHE_DIR': (
             os.environ.get('XDG_CACHE_HOME') or
-            os.path.expanduser(b'~/.cache')),
+            posix_normpath(os.path.expanduser(b'~/.cache'))),
         'XDG_CONFIG_DIR': (
             os.environ.get('XDG_CONFIG_HOME') or
-            os.path.expanduser(b'~/.config')),
+            posix_normpath(os.path.expanduser(b'~/.config'))),
         'XDG_DATA_DIR': (
             os.environ.get('XDG_DATA_HOME') or
-            os.path.expanduser(b'~/.local/share')),
+            posix_normpath(os.path.expanduser(b'~/.local/share'))),
     }
 
     dirs.update(_get_user_dirs(dirs['XDG_CONFIG_DIR']))
@@ -63,6 +65,6 @@ def _get_user_dirs(xdg_config_dir):
     config.readfp(io.BytesIO(data))
 
     return {
-        k.upper().decode('utf-8'): os.path.abspath(v)
+        k.upper().decode('utf-8'): posixpath.abspath(v)
         for k, v in config.items('XDG_USER_DIRS') if v is not None
     }

--- a/mopidy/local/translator.py
+++ b/mopidy/local/translator.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import logging
-import os
+import posixpath
 import urllib
 
 from mopidy import compat
@@ -23,7 +23,7 @@ def local_uri_to_path(uri, media_dir):
             not uri.startswith('local:track:')):
         raise ValueError('Invalid URI.')
     file_path = path.uri_to_path(uri).split(b':', 1)[1]
-    return os.path.join(media_dir, file_path)
+    return posixpath.join(media_dir, file_path)
 
 
 def local_track_uri_to_path(uri, media_dir):

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -26,40 +26,32 @@ def log_environment_error(message, error):
 
 @contextlib.contextmanager
 def replace(path, mode='w+b', encoding=None, errors=None):
-    print('>>>replace 0 --> {}'.format(path))
     try:
         (fd, tempname) = tempfile.mkstemp(dir=os.path.dirname(path))
     except TypeError:
         # Python 3 requires dir to be of type str until v3.5
         import sys
         path = path.decode(sys.getfilesystemencoding())
-        print('>>>replace 1 --> {}'.format(path))
         (fd, tempname) = tempfile.mkstemp(dir=os.path.dirname(path))
     try:
-        print('>>>replace 2 --> {}  {}'.format(path, tempname))
         fp = io.open(fd, mode, encoding=encoding, errors=errors)
     except Exception:
         os.remove(tempname)
         os.close(fd)
         raise
     try:
-        print('>>>replace 3 --> {}  {}'.format(path, tempname))
         yield fp
         fp.flush()
-        print('>>>replace 3.1 --> {}  {}'.format(path, tempname))
         os.fsync(fd)
-        print('>>>replace 3.2 --> {}  {}'.format(path, tempname))
         fp.close()  # win32 needs files closed before renaming or removing
         # win32 will not overwrite with os.rename, so delete first
         if os.path.isfile(path):
             os.remove(path)
         os.rename(tempname, path)
     except Exception:
-        print('>>>replace 3e --> {}  {}'.format(path, tempname))
         os.remove(tempname)
         raise
     finally:
-        print('>>>replace F --> {}  {}'.format(path, tempname))
         fp.close()
 
 
@@ -145,20 +137,17 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
 
     def save(self, playlist):
         path = translator.uri_to_path(playlist.uri)
-        print("path from uri {}  {}".format(path, playlist.uri))
         if not self._is_in_basedir(path):
             logger.debug(
                 'Ignoring path outside playlist dir: %s', playlist.uri)
             return None
         name = translator.name_from_path(path)
         try:
-            print("save _open {}".format(path))
             with self._open(path, 'w') as fp:
                 translator.dump_items(playlist.tracks, fp)
             if playlist.name and playlist.name != name:
                 opath, ext = os.path.splitext(path)
                 path = translator.path_from_name(playlist.name.strip()) + ext
-                print("path {} > opath {} > ext {}".format(path, opath, ext))
                 # win32 wont overwrite, so delete first
                 if os.path.isfile(self._abspath(path)):
                     os.remove(self._abspath(path))
@@ -188,7 +177,6 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             raise Exception(
                 'Path (%s) is not inside playlist_dir (%s)'
                 % (path, self._playlists_dir))
-        print("_open {}".format(path))
         if 'w' in mode:
             return replace(path, mode, encoding=encoding, errors='replace')
         else:

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -6,6 +6,7 @@ import locale
 import logging
 import operator
 import os
+import posixpath
 import tempfile
 
 from mopidy import backend
@@ -159,11 +160,11 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             return translator.playlist(path, playlist.tracks, mtime)
 
     def _abspath(self, path):
-        return os.path.join(self._playlists_dir, path)
+        return posixpath.join(self._playlists_dir, path)
 
     def _is_in_basedir(self, local_path):
         if not os.path.isabs(local_path):
-            local_path = os.path.join(self._playlists_dir, local_path)
+            local_path = posixpath.join(self._playlists_dir, local_path)
         return path.is_path_inside_base_dir(local_path, self._playlists_dir)
 
     def _open(self, path, mode='r'):
@@ -172,7 +173,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         else:
             encoding = self._default_encoding
         if not os.path.isabs(path):
-            path = os.path.join(self._playlists_dir, path)
+            path = posixpath.join(self._playlists_dir, path)
         if not self._is_in_basedir(path):
             raise Exception(
                 'Path (%s) is not inside playlist_dir (%s)'

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -89,7 +89,8 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
                 pass
             mtime = os.path.getmtime(self._abspath(path))
         except EnvironmentError as e:
-            log_environment_error('Error creating playlist %s > %s' % (self._playlists_dir, self._abspath(path)), e)
+            log_environment_error('Error creating playlist %s > %s' % (
+                self._playlists_dir, self._abspath(path)), e)
         else:
             return translator.playlist(path, [], mtime)
 

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -43,8 +43,11 @@ except ImportError:
 def path_to_uri(path, scheme=Extension.ext_name):
     """Convert file path to URI."""
     assert isinstance(path, bytes), 'Mopidy paths should be bytes'
+    drive, path = os.path.splitdrive(path)
     path = os.path.normpath(path)
     uripath = quote_from_bytes(posix_normpath(path))
+    if drive:
+        uripath = posixpath.sep.join([b'', drive])+uripath
     return urlunsplit((scheme, None, uripath, None, None))
 
 

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -97,7 +97,7 @@ def load_items(fp, basedir):
                 name = line.partition(',')[2]
             continue
         elif not urlsplit(line).scheme:
-            path = posix_normpath(os.path.join(basedir, fsencode(line)))
+            path = posixpath.join(basedir, fsencode(line))
             if not name:
                 name = name_from_path(path)
             uri = path_to_uri(path, scheme='file')

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-import os, posixpath
+import os
+import posixpath
 
 from mopidy import models, posix_normpath
 
@@ -47,7 +48,7 @@ def path_to_uri(path, scheme=Extension.ext_name):
     path = os.path.normpath(path)
     uripath = quote_from_bytes(posix_normpath(path))
     if drive:
-        uripath = posixpath.sep.join([b'', drive])+uripath
+        uripath = posixpath.sep.join([b'', drive]) + uripath
     return urlunsplit((scheme, None, uripath, None, None))
 
 
@@ -68,8 +69,8 @@ def name_from_path(path):
 
 def sanitize_name(name):
     """remove bad char choices from name"""
-    excluded = '\\/:*?"<>|'+''.join([chr(i) for i in range(32)]) \
-        if sys.platform == 'win32' else '/'+chr(0)
+    excluded = '\\/:*?"<>|' + ''.join([chr(i) for i in range(32)]) \
+        if sys.platform == 'win32' else '/' + chr(0)
     name = "".join(i for i in name if i not in excluded)
     return name
 

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -1,8 +1,8 @@
 from __future__ import absolute_import, print_function, unicode_literals
 
-import os
+import os, posixpath
 
-from mopidy import models
+from mopidy import models, posix_normpath
 
 from . import Extension
 
@@ -43,7 +43,8 @@ except ImportError:
 def path_to_uri(path, scheme=Extension.ext_name):
     """Convert file path to URI."""
     assert isinstance(path, bytes), 'Mopidy paths should be bytes'
-    uripath = quote_from_bytes(os.path.normpath(path))
+    path = os.path.normpath(path)
+    uripath = quote_from_bytes(posix_normpath(path))
     return urlunsplit((scheme, None, uripath, None, None))
 
 
@@ -65,9 +66,9 @@ def name_from_path(path):
 def path_from_name(name, ext=None, sep='|'):
     """Convert name with optional extension to file path."""
     if ext:
-        return fsencode(name.replace(os.sep, sep) + ext)
+        return fsencode(name.replace(posixpath.sep, sep) + ext)
     else:
-        return fsencode(name.replace(os.sep, sep))
+        return fsencode(name.replace(posixpath.sep, sep))
 
 
 def path_to_ref(path):
@@ -86,7 +87,7 @@ def load_items(fp, basedir):
                 name = line.partition(',')[2]
             continue
         elif not urlsplit(line).scheme:
-            path = os.path.join(basedir, fsencode(line))
+            path = posix_normpath(os.path.join(basedir, fsencode(line)))
             if not name:
                 name = name_from_path(path)
             uri = path_to_uri(path, scheme='file')

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -63,10 +63,20 @@ def name_from_path(path):
         return None
 
 
+def sanitize_name(name):
+    """remove bad char choices from name"""
+    excluded = '\\/:*?"<>|'+''.join([chr(i) for i in range(32)]) \
+        if sys.platform == 'win32' else '/'+chr(0)
+    name = "".join(i for i in name if i not in excluded)
+    return name
+
+
 def path_from_name(name, ext=None, sep='|'):
     """Convert name with optional extension to file path."""
+    name = sanitize_name(name.replace(posixpath.sep, sep))
     if ext:
-        return fsencode(name.replace(posixpath.sep, sep) + ext)
+        ext = sanitize_name(ext)
+        return fsencode(name + ext)
     else:
         return fsencode(name.replace(posixpath.sep, sep))
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -2,16 +2,18 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 
-from mopidy import compat
+from mopidy import compat, posix_normpath
 
 
 def path_to_data_dir(name):
+
+    name = os.path.normpath(name) # sets slashes to platform norm
     if not isinstance(name, bytes):
         name = name.encode('utf-8')
     path = os.path.dirname(__file__)
-    path = os.path.join(path, b'data')
-    path = os.path.abspath(path)
-    return os.path.join(path, name)
+    path = os.path.join(path, b'data', name)
+
+    return posix_normpath(path)  # sets slashes to posix norm, strips drive
 
 
 class IsA(object):

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,13 +5,16 @@ import os
 from mopidy import compat, posix_normpath
 
 
-def path_to_data_dir(name):
+def path_to_data_dir(name=None):
 
-    name = os.path.normpath(name) # sets slashes to platform norm
-    if not isinstance(name, bytes):
-        name = name.encode('utf-8')
     path = os.path.dirname(__file__)
-    path = os.path.join(path, b'data', name)
+    if name is None:
+        path = os.path.join(path, b'data')
+    else:
+        name = os.path.normpath(name) # sets slashes to platform norm
+        if not isinstance(name, bytes):
+            name = name.encode('utf-8')
+        path = os.path.join(path, b'data', name)
 
     return posix_normpath(path)  # sets slashes to posix norm, strips drive
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,7 @@ def path_to_data_dir(name):
     path = os.path.dirname(__file__)
     path = os.path.join(path, b'data')
     path = os.path.abspath(path)
-    _, path = os.path.splitdrive(path)
+    # _, path = os.path.splitdrive(path)
     return posix_normpath(path, name)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -16,6 +16,8 @@ def path_to_data_dir(name=None):
             name = name.encode('utf-8')
         path = os.path.join(path, b'data', name)
 
+    # maybe needs abspath() call?
+
     return posix_normpath(path)  # sets slashes to posix norm, strips drive
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -11,7 +11,6 @@ def path_to_data_dir(name):
     path = os.path.dirname(__file__)
     path = os.path.join(path, b'data')
     path = os.path.abspath(path)
-    # _, path = os.path.splitdrive(path)
     return posix_normpath(path, name)
 
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -5,20 +5,14 @@ import os
 from mopidy import compat, posix_normpath
 
 
-def path_to_data_dir(name=None):
-
+def path_to_data_dir(name):
+    if not isinstance(name, bytes):
+        name = name.encode('utf-8')
     path = os.path.dirname(__file__)
-    if name is None:
-        path = os.path.join(path, b'data')
-    else:
-        name = os.path.normpath(name) # sets slashes to platform norm
-        if not isinstance(name, bytes):
-            name = name.encode('utf-8')
-        path = os.path.join(path, b'data', name)
-
-    # maybe needs abspath() call?
-
-    return posix_normpath(path)  # sets slashes to posix norm, strips drive
+    path = os.path.join(path, b'data')
+    path = os.path.abspath(path)
+    _, path = os.path.splitdrive(path)
+    return posix_normpath(path, name)
 
 
 class IsA(object):

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -34,7 +34,9 @@ class ScannerTest(unittest.TestCase):
 
     def check(self, name, key, value):
         name = path_to_data_dir(name)
-        self.assertEqual(self.result[name].tags[key], value)
+        uri = path_lib.path_to_uri(name)
+        uri_key = uri[len('file://'):]
+        self.assertEqual(self.result[uri_key].tags[key], value)
 
     def check_if_missing_plugin(self):
         for path, result in self.result.items():

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -16,11 +16,11 @@ class ScannerTest(unittest.TestCase):
         self.errors = {}
         self.result = {}
 
-    def find(self, path):
+    def find(self, path, relative=False):
         media_dir = path_to_data_dir(path)
-        result, errors = path_lib.find_mtimes(media_dir)
+        result, errors = path_lib.find_mtimes(media_dir, relative=relative)
         for path in result:
-            yield os.path.join(media_dir, path)
+            yield path  # os.path.join(media_dir, path)
 
     def scan(self, paths):
         scanner = scan.Scanner()
@@ -34,9 +34,7 @@ class ScannerTest(unittest.TestCase):
 
     def check(self, name, key, value):
         name = path_to_data_dir(name)
-        uri = path_lib.path_to_uri(name)
-        uri_key = uri[len('file://'):]
-        self.assertEqual(self.result[uri_key].tags[key], value)
+        self.assertEqual(self.result[name].tags[key], value)
 
     def check_if_missing_plugin(self):
         for path, result in self.result.items():

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import os
 import unittest
 
 from mopidy import exceptions
@@ -34,7 +33,8 @@ class ScannerTest(unittest.TestCase):
         print(self.errors)
 
     def _normalize_key(self, name):
-        return path_lib.uri_to_path(path_lib.path_to_uri(path_to_data_dir(name)))
+        return path_lib.uri_to_path(
+            path_lib.path_to_uri(path_to_data_dir(name)))
 
     def check(self, name, key, value):
         name = self._normalize_key(name)
@@ -121,7 +121,8 @@ class ScannerTest(unittest.TestCase):
         name = 'scanner/playlist.m3u'
         path = path_to_data_dir(name)
         self.scan([path])
-        self.assertEqual(self.result[self._normalize_key(name)].mime, 'text/uri-list')
+        self.assertEqual(self.result[self._normalize_key(name)].mime,
+                         'text/uri-list')
 
     def test_text_plain(self):
         # GStreamer decode bin hardcodes bad handling of text plain :/

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -27,8 +27,8 @@ class TestConvertTaglist(object):
             elif isinstance(value, int):
                 gobject_value.init(GObject.TYPE_UINT)
                 gobject_value.set_uint(value)
-                gobject_value.init(GObject.TYPE_VALUE)
-                gobject_value.set_value(value)
+                # gobject_value.init(GObject.TYPE_VALUE)  # warning from GLib?
+                # gobject_value.set_value(value)
             else:
                 raise TypeError
             taglist.add_value(Gst.TagMergeMode.APPEND, tag, gobject_value)

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
+import os
 import logging
 import socket
 import unittest
@@ -391,7 +392,7 @@ class PathTest(unittest.TestCase):
 
     def test_deserialize_conversion_success(self):
         result = types.Path().deserialize(b'/foo')
-        self.assertEqual('/foo', result)
+        self.assertEqual('/foo', os.path.splitdrive(result)[1])
         self.assertIsInstance(result, types.ExpandedPath)
         self.assertIsInstance(result, bytes)
 

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -2,8 +2,8 @@
 
 from __future__ import absolute_import, unicode_literals
 
-import os
 import logging
+import os
 import socket
 import unittest
 

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import, unicode_literals
 
+import sys
 import errno
 import logging
 import socket
@@ -170,7 +171,8 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.enable_recv(self.mock)
         GObject.io_add_watch.assert_called_once_with(
-            sentinel.fileno,
+            self.mock._sock if sys.platform == 'win32' else sentinel.fileno,
+            1,
             GObject.IO_IN | GObject.IO_ERR | GObject.IO_HUP,
             self.mock.recv_callback)
         self.assertEqual(sentinel.tag, self.mock.recv_id)

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -1,9 +1,9 @@
 from __future__ import absolute_import, unicode_literals
 
-import sys
 import errno
 import logging
 import socket
+import sys
 import unittest
 
 from mock import Mock, call, patch, sentinel

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -173,7 +173,7 @@ class ConnectionTest(unittest.TestCase):
         GObject.io_add_watch.assert_called_once_with(
             self.mock._sock if sys.platform == 'win32' else sentinel.fileno,
             1,
-            GLib.IO_IN | GLib.IO_ERR | GLib.IO_HUP,
+            GObject.IO_IN | GObject.IO_ERR | GObject.IO_HUP,
             self.mock.recv_callback)
         self.assertEqual(sentinel.tag, self.mock.recv_id)
 
@@ -227,7 +227,7 @@ class ConnectionTest(unittest.TestCase):
         network.Connection.enable_send(self.mock)
         GObject.io_add_watch.assert_called_once_with(
             sentinel.fileno,
-            GLib.IO_OUT | GLib.IO_ERR | GLib.IO_HUP,
+            GObject.IO_OUT | GObject.IO_ERR | GObject.IO_HUP,
             self.mock.send_callback)
         self.assertEqual(sentinel.tag, self.mock.send_id)
 
@@ -373,7 +373,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_ERR))
+            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_respects_io_hup(self):
@@ -381,7 +381,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP))
+            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_HUP))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_respects_io_hup_and_io_err(self):
@@ -390,7 +390,7 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertTrue(network.Connection.recv_callback(
             self.mock, sentinel.fd,
-            GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR))
+            GObject.IO_IN | GObject.IO_HUP | GObject.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_sends_data_to_actor(self):
@@ -399,7 +399,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.mock.actor_ref.tell.assert_called_once_with(
             {'received': 'data'})
 
@@ -410,7 +410,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref.tell.side_effect = pykka.ActorDeadError()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_gets_no_data(self):
@@ -419,7 +419,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.assertEqual(self.mock.mock_calls, [
             call._sock.recv(any_int),
             call.disable_recv(),
@@ -432,7 +432,7 @@ class ConnectionTest(unittest.TestCase):
         for error in (errno.EWOULDBLOCK, errno.EINTR):
             self.mock._sock.recv.side_effect = socket.error(error, '')
             self.assertTrue(network.Connection.recv_callback(
-                self.mock, sentinel.fd, GLib.IO_IN))
+                self.mock, sentinel.fd, GObject.IO_IN))
             self.assertEqual(0, self.mock.stop.call_count)
 
     def test_recv_callback_unrecoverable_error(self):
@@ -440,7 +440,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.recv.side_effect = socket.error
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_respects_io_err(self):
@@ -451,7 +451,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send_buffer = ''
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_ERR))
+            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_respects_io_hup(self):
@@ -462,7 +462,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send_buffer = ''
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP))
+            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_HUP))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_respects_io_hup_and_io_err(self):
@@ -474,7 +474,7 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertTrue(network.Connection.send_callback(
             self.mock, sentinel.fd,
-            GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR))
+            GObject.IO_IN | GObject.IO_HUP | GObject.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_acquires_and_releases_lock(self):
@@ -485,7 +485,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.send.return_value = 0
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.mock.send_lock.acquire.assert_called_once_with(False)
         self.mock.send_lock.release.assert_called_once_with()
 
@@ -497,7 +497,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.send.return_value = 0
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.mock.send_lock.acquire.assert_called_once_with(False)
         self.assertEqual(0, self.mock._sock.send.call_count)
 
@@ -508,7 +508,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send.return_value = ''
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.mock.disable_send.assert_called_once_with()
         self.mock.send.assert_called_once_with('data')
         self.assertEqual('', self.mock.send_buffer)
@@ -520,7 +520,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send.return_value = 'ta'
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GLib.IO_IN))
+            self.mock, sentinel.fd, GObject.IO_IN))
         self.mock.send.assert_called_once_with('data')
         self.assertEqual('ta', self.mock.send_buffer)
 

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -173,7 +173,7 @@ class ConnectionTest(unittest.TestCase):
         GObject.io_add_watch.assert_called_once_with(
             self.mock._sock if sys.platform == 'win32' else sentinel.fileno,
             1,
-            GObject.IO_IN | GObject.IO_ERR | GObject.IO_HUP,
+            GLib.IO_IN | GLib.IO_ERR | GLib.IO_HUP,
             self.mock.recv_callback)
         self.assertEqual(sentinel.tag, self.mock.recv_id)
 
@@ -227,7 +227,7 @@ class ConnectionTest(unittest.TestCase):
         network.Connection.enable_send(self.mock)
         GObject.io_add_watch.assert_called_once_with(
             sentinel.fileno,
-            GObject.IO_OUT | GObject.IO_ERR | GObject.IO_HUP,
+            GLib.IO_OUT | GLib.IO_ERR | GLib.IO_HUP,
             self.mock.send_callback)
         self.assertEqual(sentinel.tag, self.mock.send_id)
 
@@ -373,7 +373,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_ERR))
+            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_respects_io_hup(self):
@@ -381,7 +381,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_HUP))
+            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_respects_io_hup_and_io_err(self):
@@ -390,7 +390,7 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertTrue(network.Connection.recv_callback(
             self.mock, sentinel.fd,
-            GObject.IO_IN | GObject.IO_HUP | GObject.IO_ERR))
+            GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_sends_data_to_actor(self):
@@ -399,7 +399,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.mock.actor_ref.tell.assert_called_once_with(
             {'received': 'data'})
 
@@ -410,7 +410,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref.tell.side_effect = pykka.ActorDeadError()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_recv_callback_gets_no_data(self):
@@ -419,7 +419,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.assertEqual(self.mock.mock_calls, [
             call._sock.recv(any_int),
             call.disable_recv(),
@@ -432,7 +432,7 @@ class ConnectionTest(unittest.TestCase):
         for error in (errno.EWOULDBLOCK, errno.EINTR):
             self.mock._sock.recv.side_effect = socket.error(error, '')
             self.assertTrue(network.Connection.recv_callback(
-                self.mock, sentinel.fd, GObject.IO_IN))
+                self.mock, sentinel.fd, GLib.IO_IN))
             self.assertEqual(0, self.mock.stop.call_count)
 
     def test_recv_callback_unrecoverable_error(self):
@@ -440,7 +440,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.recv.side_effect = socket.error
 
         self.assertTrue(network.Connection.recv_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_respects_io_err(self):
@@ -451,7 +451,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send_buffer = ''
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_ERR))
+            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_respects_io_hup(self):
@@ -462,7 +462,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send_buffer = ''
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GObject.IO_IN | GObject.IO_HUP))
+            self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_respects_io_hup_and_io_err(self):
@@ -474,7 +474,7 @@ class ConnectionTest(unittest.TestCase):
 
         self.assertTrue(network.Connection.send_callback(
             self.mock, sentinel.fd,
-            GObject.IO_IN | GObject.IO_HUP | GObject.IO_ERR))
+            GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR))
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_send_callback_acquires_and_releases_lock(self):
@@ -485,7 +485,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.send.return_value = 0
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.mock.send_lock.acquire.assert_called_once_with(False)
         self.mock.send_lock.release.assert_called_once_with()
 
@@ -497,7 +497,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.send.return_value = 0
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.mock.send_lock.acquire.assert_called_once_with(False)
         self.assertEqual(0, self.mock._sock.send.call_count)
 
@@ -508,7 +508,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send.return_value = ''
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.mock.disable_send.assert_called_once_with()
         self.mock.send.assert_called_once_with('data')
         self.assertEqual('', self.mock.send_buffer)
@@ -520,7 +520,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send.return_value = 'ta'
 
         self.assertTrue(network.Connection.send_callback(
-            self.mock, sentinel.fd, GObject.IO_IN))
+            self.mock, sentinel.fd, GLib.IO_IN))
         self.mock.send.assert_called_once_with('data')
         self.assertEqual('ta', self.mock.send_buffer)
 

--- a/tests/internal/network/test_server.py
+++ b/tests/internal/network/test_server.py
@@ -177,7 +177,7 @@ class ServerTest(unittest.TestCase):
         self.mock.server_socket = sock
         network.Server.register_server_socket(self.mock, self.mock.server_socket)
         GObject.io_add_watch.assert_called_once_with(
-            self.mock.server_socket, 1, GObject.IO_IN, self.mock.handle_connection)
+            self.mock.server_socket, 1, GLib.IO_IN, self.mock.handle_connection)
 
     def test_handle_connection(self):
         self.mock.accept_connection.return_value = (
@@ -185,7 +185,7 @@ class ServerTest(unittest.TestCase):
         self.mock.maximum_connections_exceeded.return_value = False
 
         self.assertTrue(network.Server.handle_connection(
-            self.mock, sentinel.fileno, GObject.IO_IN))
+            self.mock, sentinel.fileno, GLib.IO_IN))
         self.mock.accept_connection.assert_called_once_with()
         self.mock.maximum_connections_exceeded.assert_called_once_with()
         self.mock.init_connection.assert_called_once_with(
@@ -198,7 +198,7 @@ class ServerTest(unittest.TestCase):
         self.mock.maximum_connections_exceeded.return_value = True
 
         self.assertTrue(network.Server.handle_connection(
-            self.mock, sentinel.fileno, GObject.IO_IN))
+            self.mock, sentinel.fileno, GLib.IO_IN))
         self.mock.accept_connection.assert_called_once_with()
         self.mock.maximum_connections_exceeded.assert_called_once_with()
         self.mock.reject_connection.assert_called_once_with(

--- a/tests/internal/network/test_server.py
+++ b/tests/internal/network/test_server.py
@@ -46,10 +46,9 @@ class ServerTest(unittest.TestCase):
 
         network.Server.__init__(
             self.mock, sentinel.host, sentinel.port, sentinel.protocol)
-        res = sock if sys.platform == 'win32' else sentinel.fileno
-        self.mock.register_server_socket.assert_called_once_with(res)
+        self.mock.register_server_socket.assert_called_once_with(sock)
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="fileno not used with win32")
+    @pytest.mark.skip(reason="fileno not callde by Server.__init__")
     @patch.object(network, 'get_socket_address', new=Mock())
     def test_init_fails_on_fileno_call(self):
         sock = Mock(spec=socket.SocketType)
@@ -176,8 +175,9 @@ class ServerTest(unittest.TestCase):
         # sock.family = socket.AF_UNIX
         self.mock.server_socket = sock
         network.Server.register_server_socket(self.mock, self.mock.server_socket)
+        res = self.mock.server_socket if sys.platform == 'win32' else self.mock.server_socket.fileno()
         GObject.io_add_watch.assert_called_once_with(
-            self.mock.server_socket, 1, GObject.IO_IN, self.mock.handle_connection)
+            res, 1, GObject.IO_IN, self.mock.handle_connection)
 
     def test_handle_connection(self):
         self.mock.accept_connection.return_value = (

--- a/tests/internal/network/test_server.py
+++ b/tests/internal/network/test_server.py
@@ -177,7 +177,7 @@ class ServerTest(unittest.TestCase):
         self.mock.server_socket = sock
         network.Server.register_server_socket(self.mock, self.mock.server_socket)
         GObject.io_add_watch.assert_called_once_with(
-            self.mock.server_socket, 1, GLib.IO_IN, self.mock.handle_connection)
+            self.mock.server_socket, 1, GObject.IO_IN, self.mock.handle_connection)
 
     def test_handle_connection(self):
         self.mock.accept_connection.return_value = (
@@ -185,7 +185,7 @@ class ServerTest(unittest.TestCase):
         self.mock.maximum_connections_exceeded.return_value = False
 
         self.assertTrue(network.Server.handle_connection(
-            self.mock, sentinel.fileno, GLib.IO_IN))
+            self.mock, sentinel.fileno, GObject.IO_IN))
         self.mock.accept_connection.assert_called_once_with()
         self.mock.maximum_connections_exceeded.assert_called_once_with()
         self.mock.init_connection.assert_called_once_with(
@@ -198,7 +198,7 @@ class ServerTest(unittest.TestCase):
         self.mock.maximum_connections_exceeded.return_value = True
 
         self.assertTrue(network.Server.handle_connection(
-            self.mock, sentinel.fileno, GLib.IO_IN))
+            self.mock, sentinel.fileno, GObject.IO_IN))
         self.mock.accept_connection.assert_called_once_with()
         self.mock.maximum_connections_exceeded.assert_called_once_with()
         self.mock.reject_connection.assert_called_once_with(

--- a/tests/internal/network/test_server.py
+++ b/tests/internal/network/test_server.py
@@ -1,13 +1,14 @@
 from __future__ import absolute_import, unicode_literals
 
-import sys
 import errno
 import os
 import socket
+import sys
 import unittest
-import pytest
 
 from mock import Mock, patch, sentinel
+
+import pytest
 
 from mopidy import exceptions
 from mopidy.internal import network
@@ -174,8 +175,10 @@ class ServerTest(unittest.TestCase):
         sock = Mock()
         # sock.family = socket.AF_UNIX
         self.mock.server_socket = sock
-        network.Server.register_server_socket(self.mock, self.mock.server_socket)
-        res = self.mock.server_socket if sys.platform == 'win32' else self.mock.server_socket.fileno()
+        network.Server.register_server_socket(self.mock,
+                                              self.mock.server_socket)
+        res = self.mock.server_socket if sys.platform == 'win32' \
+            else self.mock.server_socket.fileno()
         GObject.io_add_watch.assert_called_once_with(
             res, 1, GObject.IO_IN, self.mock.handle_connection)
 

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -74,7 +74,6 @@ class GetOrCreateFileTest(unittest.TestCase):
 
     def setUp(self):  # noqa: N802
         self.parent = posix_normpath(tempfile.mkdtemp())
-        print("parent {}  dir {}".format(self.parent, 1))
 
     def tearDown(self):  # noqa: N802
         if os.path.isdir(self.parent):

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -4,8 +4,8 @@ from __future__ import absolute_import, unicode_literals
 
 import os
 import posixpath
-import sys
 import shutil
+import sys
 import tempfile
 import unittest
 
@@ -216,30 +216,39 @@ class ExpandPathTest(unittest.TestCase):
     # TODO: test via mocks?
 
     def test_empty_path(self):
-        self.assertEqual(posix_normpath(os.path.abspath(b'.')), path.expand_path(b''))
+        self.assertEqual(posix_normpath(os.path.abspath(b'.')),
+                         path.expand_path(b''))
 
-    @unittest.skipIf(sys.platform == 'win32', 'win32 absolute paths include drive')
+    @unittest.skipIf(sys.platform == 'win32',
+                     'win32 absolute paths include drive')
     def test_absolute_path(self):
         self.assertEqual(b'/tmp/foo', path.expand_path(b'/tmp/foo'))
 
-    @unittest.skipUnless(sys.platform == 'win32', 'win32 absolute paths include drive')
+    @unittest.skipUnless(sys.platform == 'win32',
+                         'win32 absolute paths include drive')
     def test_absolute_path_win32(self):
         self.assertEqual(b'k:/tmp/foo', path.expand_path(b'k:/tmp/foo'))
 
     def test_home_dir_expansion(self):
         self.assertEqual(
-            posix_normpath(os.path.expanduser(b'~/foo')), path.expand_path(b'~/foo'))
+            posix_normpath(os.path.expanduser(b'~/foo')),
+            path.expand_path(b'~/foo'))
 
     def test_abspath(self):
-        self.assertEqual(posix_normpath(os.path.abspath(b'./foo')), path.expand_path(b'./foo'))
+        self.assertEqual(posix_normpath(os.path.abspath(b'./foo')),
+                         path.expand_path(b'./foo'))
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="don't understand this yet")
-    def test_xdg_subsititution(self):
+    @unittest.skipIf(sys.platform == 'win32',
+                     reason="don't understand this yet")
+#   in win32, get_user_data_dir provides '~/HOME/AppData/Local/foo'
+#       and XDG_DATA_DIR expansion provided '~/HOME/.local/share/foo'
+#   which is correct?
+    def test_xdg_substitution(self):
         self.assertEqual(
             posix_normpath(GLib.get_user_data_dir()) + b'/foo',
             path.expand_path(b'$XDG_DATA_DIR/foo'))
 
-    def test_xdg_subsititution_unknown(self):
+    def test_xdg_substitution_unknown(self):
         self.assertIsNone(
             path.expand_path(b'/tmp/$XDG_INVALID_DIR/foo'))
 
@@ -255,12 +264,12 @@ class FindMTimesTest(unittest.TestCase):
         shutil.rmtree(self.tmpdir, ignore_errors=True)
 
     def mkdir(self, *args):
-        name = posix_normpath(os.path.join(self.tmpdir, *[bytes(a) for a in args]))
+        name = posix_normpath(self.tmpdir, *[bytes(a) for a in args])
         os.mkdir(name)
         return name
 
     def touch(self, *args):
-        name = posix_normpath(os.path.join(self.tmpdir, *[bytes(a) for a in args]))
+        name = posix_normpath(self.tmpdir, *[bytes(a) for a in args])
         open(name, 'w').close()
         return name
 
@@ -321,7 +330,8 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({target: tests.any_int}, result)
         self.assertEqual({}, errors)
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="chmod on win32 only sets read-permission")
+    @pytest.mark.skipif(sys.platform == 'win32',
+                        reason="chmod on win32 only sets read-permission")
     def test_missing_permission_to_directory(self):
         """Missing permissions to a directory is an error"""
         directory = self.mkdir('no-permission')
@@ -331,7 +341,8 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({}, result)
         self.assertEqual({directory: tests.IsA(exceptions.FindError)}, errors)
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
+    @pytest.mark.skipif(sys.platform == 'win32',
+                        reason="symlinks not supported by 2.7 os module")
     def test_symlinks_are_ignored(self):
         """By default symlinks should be treated as an error"""
         target = self.touch('target')
@@ -342,7 +353,8 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual(result, {target: tests.any_int})
         self.assertEqual(errors, {link: tests.IsA(exceptions.FindError)})
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
+    @pytest.mark.skipif(sys.platform == 'win32',
+                        reason="symlinks not supported by 2.7 os module")
     def test_symlink_to_file_as_root_is_followed(self):
         """Passing a symlink as the root should be followed when follow=True"""
         target = self.touch('target')
@@ -356,7 +368,8 @@ class FindMTimesTest(unittest.TestCase):
     def test_symlink_to_directory_is_followed(self):
         pass
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
+    @unittest.skipIf(sys.platform == 'win32',
+                     reason="symlinks not supported by 2.7 os module")
     def test_symlink_pointing_at_itself_fails(self):
         """Symlink pointing at itself should give as an OS error"""
         link = posixpath.join(self.tmpdir, 'link')
@@ -366,7 +379,8 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({}, result)
         self.assertEqual({link: tests.IsA(exceptions.FindError)}, errors)
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
+    @unittest.skipIf(sys.platform == 'win32',
+                     reason="symlinks not supported by 2.7 os module")
     def test_symlink_pointing_at_parent_fails(self):
         """We should detect a loop via the parent and give up on the branch"""
         os.symlink(self.tmpdir, posixpath.join(self.tmpdir, 'link'))
@@ -376,7 +390,8 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual(1, len(errors))
         self.assertEqual(tests.IsA(Exception), errors.values()[0])
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
+    @unittest.skipIf(sys.platform == 'win32',
+                     reason="symlinks not supported by 2.7 os module")
     def test_indirect_symlink_loop(self):
         """More indirect loops should also be detected"""
         # Setup tmpdir/directory/loop where loop points to tmpdir
@@ -390,7 +405,8 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({}, result)
         self.assertEqual({loop: tests.IsA(Exception)}, errors)
 
-    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
+    @unittest.skipIf(sys.platform == 'win32',
+                     reason="symlinks not supported by 2.7 os module")
     def test_symlink_branches_are_not_excluded(self):
         """Using symlinks to make a file show up multiple times should work"""
         self.mkdir('directory')

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -247,7 +247,6 @@ class FindMTimesTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
         data_dir = tests.path_to_data_dir('temp')
         self.tmpdir = posix_normpath(tempfile.mkdtemp(b'.mopidy-tests', dir=data_dir))
-        print('tmpdir {}'.format(self.tmpdir))
         # self.tmpdir = tempfile.mkdtemp(b'.mopidy-tests')
 
     def tearDown(self):  # noqa: N802
@@ -288,7 +287,6 @@ class FindMTimesTest(unittest.TestCase):
         """Specifying a file as the root should just return the file"""
         single = self.touch('single')
 
-        print('single {}'.format(single))
         result, errors = path.find_mtimes(single)
         self.assertEqual(result, {single: tests.any_int})
         self.assertEqual(errors, {})
@@ -328,8 +326,6 @@ class FindMTimesTest(unittest.TestCase):
         os.chmod(directory, 0)
 
         result, errors = path.find_mtimes(self.tmpdir)
-        print(result)
-        print(errors)
         self.assertEqual({}, result)
         self.assertEqual({directory: tests.IsA(exceptions.FindError)}, errors)
 

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -3,6 +3,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import posixpath
 import sys
 import shutil
 import tempfile
@@ -20,15 +21,14 @@ import tests
 class GetOrCreateDirTest(unittest.TestCase):
 
     def setUp(self):  # noqa: N802
-        data_dir = tests.path_to_data_dir('temp')
-        self.parent = posix_normpath(tempfile.mkdtemp(dir=data_dir))
+        self.parent = posix_normpath(tempfile.mkdtemp())
 
     def tearDown(self):  # noqa: N802
         if os.path.isdir(self.parent):
             shutil.rmtree(self.parent)
 
     def test_creating_dir(self):
-        dir_path = posix_normpath(os.path.join(self.parent, b'test'))
+        dir_path = posixpath.join(self.parent, b'test')
         self.assert_(not os.path.exists(dir_path))
         created = path.get_or_create_dir(dir_path)
         self.assert_(os.path.exists(dir_path))
@@ -36,8 +36,8 @@ class GetOrCreateDirTest(unittest.TestCase):
         self.assertEqual(created, dir_path)
 
     def test_creating_nested_dirs(self):
-        level2_dir = posix_normpath(os.path.join(self.parent, b'test'))
-        level3_dir = posix_normpath(os.path.join(self.parent, b'test', b'test'))
+        level2_dir = posixpath.join(self.parent, b'test')
+        level3_dir = posixpath.join(self.parent, b'test', b'test')
         self.assert_(not os.path.exists(level2_dir))
         self.assert_(not os.path.exists(level3_dir))
         created = path.get_or_create_dir(level3_dir)
@@ -54,15 +54,15 @@ class GetOrCreateDirTest(unittest.TestCase):
         self.assertEqual(created, self.parent)
 
     def test_create_dir_with_name_of_existing_file_throws_oserror(self):
-        conflicting_file = posix_normpath(os.path.join(self.parent, b'test'))
+        conflicting_file = posixpath.join(self.parent, b'test')
         open(conflicting_file, 'w').close()
-        dir_path = posix_normpath(os.path.join(self.parent, b'test'))
+        dir_path = posixpath.join(self.parent, b'test')
         with self.assertRaises(OSError):
             path.get_or_create_dir(dir_path)
 
     def test_create_dir_with_unicode(self):
         with self.assertRaises(ValueError):
-            dir_path = compat.text_type(posix_normpath(os.path.join(self.parent, b'test')))
+            dir_path = compat.text_type(posixpath.join(self.parent, b'test'))
             path.get_or_create_dir(dir_path)
 
     def test_create_dir_with_none(self):
@@ -73,16 +73,15 @@ class GetOrCreateDirTest(unittest.TestCase):
 class GetOrCreateFileTest(unittest.TestCase):
 
     def setUp(self):  # noqa: N802
-        data_dir = tests.path_to_data_dir('temp')
-        self.parent = posix_normpath(tempfile.mkdtemp(dir=data_dir))
-        # self.parent = tempfile.mkdtemp()
+        self.parent = posix_normpath(tempfile.mkdtemp())
+        print("parent {}  dir {}".format(self.parent, 1))
 
     def tearDown(self):  # noqa: N802
         if os.path.isdir(self.parent):
             shutil.rmtree(self.parent)
 
     def test_creating_file(self):
-        file_path = posix_normpath(os.path.join(self.parent, b'test'))
+        file_path = posixpath.join(self.parent, b'test')
         self.assert_(not os.path.exists(file_path))
         created = path.get_or_create_file(file_path)
         self.assert_(os.path.exists(file_path))
@@ -90,8 +89,8 @@ class GetOrCreateFileTest(unittest.TestCase):
         self.assertEqual(created, file_path)
 
     def test_creating_nested_file(self):
-        level2_dir = posix_normpath(os.path.join(self.parent, b'test'))
-        file_path = posix_normpath(os.path.join(self.parent, b'test', b'test'))
+        level2_dir = posixpath.join(self.parent, b'test')
+        file_path = posixpath.join(self.parent, b'test', b'test')
         self.assert_(not os.path.exists(level2_dir))
         self.assert_(not os.path.exists(file_path))
         created = path.get_or_create_file(file_path)
@@ -102,7 +101,7 @@ class GetOrCreateFileTest(unittest.TestCase):
         self.assertEqual(created, file_path)
 
     def test_creating_existing_file(self):
-        file_path = posix_normpath(os.path.join(self.parent, b'test'))
+        file_path = posixpath.join(self.parent, b'test')
         path.get_or_create_file(file_path)
         created = path.get_or_create_file(file_path)
         self.assert_(os.path.exists(file_path))
@@ -110,13 +109,13 @@ class GetOrCreateFileTest(unittest.TestCase):
         self.assertEqual(created, file_path)
 
     def test_create_file_with_name_of_existing_dir_throws_ioerror(self):
-        conflicting_dir = posix_normpath(os.path.join(self.parent))
+        conflicting_dir = posixpath.join(self.parent)
         with self.assertRaises(IOError):
             path.get_or_create_file(conflicting_dir)
 
     def test_create_dir_with_unicode_filename_throws_value_error(self):
         with self.assertRaises(ValueError):
-            file_path = compat.text_type(posix_normpath(os.path.join(self.parent, b'test')))
+            file_path = compat.text_type(posixpath.join(self.parent, b'test'))
             path.get_or_create_file(file_path)
 
     def test_create_file_with_none_filename_throws_value_error(self):
@@ -124,18 +123,18 @@ class GetOrCreateFileTest(unittest.TestCase):
             path.get_or_create_file(None)
 
     def test_create_dir_without_mkdir(self):
-        file_path = posix_normpath(os.path.join(self.parent, b'foo', b'bar'))
+        file_path = posixpath.join(self.parent, b'foo', b'bar')
         with self.assertRaises(IOError):
             path.get_or_create_file(file_path, mkdir=False)
 
     def test_create_dir_with_bytes_content(self):
-        file_path = posix_normpath(os.path.join(self.parent, b'test'))
+        file_path = posixpath.join(self.parent, b'test')
         created = path.get_or_create_file(file_path, content=b'foobar')
         with open(created) as fh:
             self.assertEqual(fh.read(), b'foobar')
 
     def test_create_dir_with_unicode_content(self):
-        file_path = posix_normpath(os.path.join(self.parent, b'test'))
+        file_path = posixpath.join(self.parent, b'test')
         created = path.get_or_create_file(file_path, content='foobaræøå')
         with open(created) as fh:
             self.assertEqual(fh.read(), b'foobar\xc3\xa6\xc3\xb8\xc3\xa5')
@@ -220,8 +219,13 @@ class ExpandPathTest(unittest.TestCase):
     def test_empty_path(self):
         self.assertEqual(posix_normpath(os.path.abspath(b'.')), path.expand_path(b''))
 
+    @unittest.skipIf(sys.platform == 'win32', 'win32 absolute paths include drive')
     def test_absolute_path(self):
         self.assertEqual(b'/tmp/foo', path.expand_path(b'/tmp/foo'))
+
+    @unittest.skipUnless(sys.platform == 'win32', 'win32 absolute paths include drive')
+    def test_absolute_path_win32(self):
+        self.assertEqual(b'k:/tmp/foo', path.expand_path(b'k:/tmp/foo'))
 
     def test_home_dir_expansion(self):
         self.assertEqual(
@@ -245,8 +249,7 @@ class FindMTimesTest(unittest.TestCase):
     maxDiff = None  # noqa: N815
 
     def setUp(self):  # noqa: N802
-        data_dir = tests.path_to_data_dir('temp')
-        self.tmpdir = posix_normpath(tempfile.mkdtemp(b'.mopidy-tests', dir=data_dir))
+        self.tmpdir = posix_normpath(tempfile.mkdtemp(b'.mopidy-tests'))
         # self.tmpdir = tempfile.mkdtemp(b'.mopidy-tests')
 
     def tearDown(self):  # noqa: N802
@@ -270,7 +273,7 @@ class FindMTimesTest(unittest.TestCase):
 
     def test_nonexistent_dir(self):
         """Non existent search roots are an error"""
-        missing = posix_normpath(os.path.join(self.tmpdir, 'does-not-exist'))
+        missing = posixpath.join(self.tmpdir, 'does-not-exist')
         result, errors = path.find_mtimes(missing)
         self.assertEqual(result, {})
         self.assertEqual(errors, {missing: tests.IsA(exceptions.FindError)})
@@ -333,7 +336,7 @@ class FindMTimesTest(unittest.TestCase):
     def test_symlinks_are_ignored(self):
         """By default symlinks should be treated as an error"""
         target = self.touch('target')
-        link = posix_normpath(os.path.join(self.tmpdir, 'link'))
+        link = posixpath.join(self.tmpdir, 'link')
         os.symlink(target, link)
 
         result, errors = path.find_mtimes(self.tmpdir)
@@ -344,7 +347,7 @@ class FindMTimesTest(unittest.TestCase):
     def test_symlink_to_file_as_root_is_followed(self):
         """Passing a symlink as the root should be followed when follow=True"""
         target = self.touch('target')
-        link = posix_normpath(os.path.join(self.tmpdir, 'link'))
+        link = posixpath.join(self.tmpdir, 'link')
         os.symlink(target, link)
 
         result, errors = path.find_mtimes(link, follow=True)
@@ -357,7 +360,7 @@ class FindMTimesTest(unittest.TestCase):
     @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_symlink_pointing_at_itself_fails(self):
         """Symlink pointing at itself should give as an OS error"""
-        link = posix_normpath(os.path.join(self.tmpdir, 'link'))
+        link = posixpath.join(self.tmpdir, 'link')
         os.symlink(link, link)
 
         result, errors = path.find_mtimes(link, follow=True)
@@ -367,7 +370,7 @@ class FindMTimesTest(unittest.TestCase):
     @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_symlink_pointing_at_parent_fails(self):
         """We should detect a loop via the parent and give up on the branch"""
-        os.symlink(self.tmpdir, posix_normpath(os.path.join(self.tmpdir, 'link')))
+        os.symlink(self.tmpdir, posixpath.join(self.tmpdir, 'link'))
 
         result, errors = path.find_mtimes(self.tmpdir, follow=True)
         self.assertEqual({}, result)
@@ -378,8 +381,8 @@ class FindMTimesTest(unittest.TestCase):
     def test_indirect_symlink_loop(self):
         """More indirect loops should also be detected"""
         # Setup tmpdir/directory/loop where loop points to tmpdir
-        directory = posix_normpath(os.path.join(self.tmpdir, b'directory'))
-        loop = posix_normpath(os.path.join(directory, b'loop'))
+        directory = posixpath.join(self.tmpdir, b'directory')
+        loop = posixpath.join(directory, b'loop')
 
         os.mkdir(directory)
         os.symlink(self.tmpdir, loop)
@@ -393,8 +396,8 @@ class FindMTimesTest(unittest.TestCase):
         """Using symlinks to make a file show up multiple times should work"""
         self.mkdir('directory')
         target = self.touch('directory', 'target')
-        link1 = posix_normpath(os.path.join(self.tmpdir, b'link1'))
-        link2 = posix_normpath(os.path.join(self.tmpdir, b'link2'))
+        link1 = posixpath.join(self.tmpdir, b'link1')
+        link2 = posixpath.join(self.tmpdir, b'link2')
 
         os.symlink(target, link1)
         os.symlink(target, link2)

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -325,12 +325,14 @@ class FindMTimesTest(unittest.TestCase):
     def test_missing_permission_to_directory(self):
         """Missing permissions to a directory is an error"""
         if sys.platform == 'win32':
-            pytest.skip("chmod not supported by 2.7 os module")
+            pytest.skip("chmod on win32 only sets read-permission")
 
         directory = self.mkdir('no-permission')
         os.chmod(directory, 0)
 
         result, errors = path.find_mtimes(self.tmpdir)
+        print(result)
+        print(errors)
         self.assertEqual({}, result)
         self.assertEqual({directory: tests.IsA(exceptions.FindError)}, errors)
 

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -230,9 +230,8 @@ class ExpandPathTest(unittest.TestCase):
     def test_abspath(self):
         self.assertEqual(posix_normpath(os.path.abspath(b'./foo')), path.expand_path(b'./foo'))
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="don't understand this yet")
     def test_xdg_subsititution(self):
-        if sys.platform == 'win32':
-            pytest.skip("don't understand this yet")
         self.assertEqual(
             posix_normpath(GLib.get_user_data_dir()) + b'/foo',
             path.expand_path(b'$XDG_DATA_DIR/foo'))
@@ -322,11 +321,9 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({target: tests.any_int}, result)
         self.assertEqual({}, errors)
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="chmod on win32 only sets read-permission")
     def test_missing_permission_to_directory(self):
         """Missing permissions to a directory is an error"""
-        if sys.platform == 'win32':
-            pytest.skip("chmod on win32 only sets read-permission")
-
         directory = self.mkdir('no-permission')
         os.chmod(directory, 0)
 
@@ -336,11 +333,9 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({}, result)
         self.assertEqual({directory: tests.IsA(exceptions.FindError)}, errors)
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_symlinks_are_ignored(self):
         """By default symlinks should be treated as an error"""
-        if sys.platform == 'win32':
-            pytest.skip("symlinks not supported by 2.7 os module")
-
         target = self.touch('target')
         link = posix_normpath(os.path.join(self.tmpdir, 'link'))
         os.symlink(target, link)
@@ -349,11 +344,9 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual(result, {target: tests.any_int})
         self.assertEqual(errors, {link: tests.IsA(exceptions.FindError)})
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_symlink_to_file_as_root_is_followed(self):
         """Passing a symlink as the root should be followed when follow=True"""
-        if sys.platform == 'win32':
-            pytest.skip("symlinks not supported by 2.7 os module")
-
         target = self.touch('target')
         link = posix_normpath(os.path.join(self.tmpdir, 'link'))
         os.symlink(target, link)
@@ -365,11 +358,9 @@ class FindMTimesTest(unittest.TestCase):
     def test_symlink_to_directory_is_followed(self):
         pass
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_symlink_pointing_at_itself_fails(self):
         """Symlink pointing at itself should give as an OS error"""
-        if sys.platform == 'win32':
-            pytest.skip("symlinks not supported by 2.7 os module")
-
         link = posix_normpath(os.path.join(self.tmpdir, 'link'))
         os.symlink(link, link)
 
@@ -377,11 +368,9 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({}, result)
         self.assertEqual({link: tests.IsA(exceptions.FindError)}, errors)
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_symlink_pointing_at_parent_fails(self):
         """We should detect a loop via the parent and give up on the branch"""
-        if sys.platform == 'win32':
-            pytest.skip("symlinks not supported by 2.7 os module")
-
         os.symlink(self.tmpdir, posix_normpath(os.path.join(self.tmpdir, 'link')))
 
         result, errors = path.find_mtimes(self.tmpdir, follow=True)
@@ -389,11 +378,9 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual(1, len(errors))
         self.assertEqual(tests.IsA(Exception), errors.values()[0])
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_indirect_symlink_loop(self):
         """More indirect loops should also be detected"""
-        if sys.platform == 'win32':
-            pytest.skip("symlinks not supported by 2.7 os module")
-
         # Setup tmpdir/directory/loop where loop points to tmpdir
         directory = posix_normpath(os.path.join(self.tmpdir, b'directory'))
         loop = posix_normpath(os.path.join(directory, b'loop'))
@@ -405,11 +392,9 @@ class FindMTimesTest(unittest.TestCase):
         self.assertEqual({}, result)
         self.assertEqual({loop: tests.IsA(Exception)}, errors)
 
+    @pytest.mark.skipif(sys.platform == 'win32', reason="symlinks not supported by 2.7 os module")
     def test_symlink_branches_are_not_excluded(self):
         """Using symlinks to make a file show up multiple times should work"""
-        if sys.platform == 'win32':
-            pytest.skip("symlinks not supported by 2.7 os module")
-
         self.mkdir('directory')
         target = self.touch('directory', 'target')
         link1 = posix_normpath(os.path.join(self.tmpdir, b'link1'))

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -1,7 +1,8 @@
 from __future__ import unicode_literals
 
-import sys
 import os
+import sys
+import unittest
 
 import mock
 
@@ -14,8 +15,8 @@ from mopidy.internal import xdg
 @pytest.yield_fixture
 def environ():
     patcher = mock.patch.dict(os.environ,
-                              { 'HOMEDRIVE': 'J:',  # necessary for win32
-                                'HOMEPATH': "\\Users\\Bugsbunny" },
+                              {'HOMEDRIVE': 'J:',  # necessary for win32
+                               'HOMEPATH': "\\Users\\Bugsbunny"},
                               clear=True)
     yield patcher.start()
     patcher.stop()
@@ -47,7 +48,7 @@ def test_config_dir_from_env(environ):
 
 def test_data_dir_default(environ):
     assert xdg.get_dirs()['XDG_DATA_DIR'] == posix_normpath(
-           os.path.expanduser(b'~/.local/share'))
+        os.path.expanduser(b'~/.local/share'))
 
 
 def test_data_dir_from_env(environ):
@@ -57,7 +58,8 @@ def test_data_dir_from_env(environ):
     assert type(xdg.get_dirs()['XDG_DATA_DIR']) == bytes
 
 
-@pytest.mark.skipif(sys.platform == 'win32', reason="needs different test for win32")
+@unittest.skipIf(sys.platform == 'win32',
+                 reason="needs different test for win32")
 def test_user_dirs(environ, tmpdir):
     os.environ['XDG_CONFIG_HOME'] = str(tmpdir)
 

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -12,13 +12,17 @@ from mopidy.internal import xdg
 
 @pytest.yield_fixture
 def environ():
-    patcher = mock.patch.dict(os.environ, clear=True)
+    patcher = mock.patch.dict(os.environ,
+                              { 'HOMEDRIVE': 'J:',  # necessary for win32
+                                'HOMEPATH': "\\Users\\Bugsbunny" },
+                              clear=True)
     yield patcher.start()
     patcher.stop()
 
 
 def test_cache_dir_default(environ):
-    assert xdg.get_dirs()['XDG_CACHE_DIR'] == os.path.expanduser(b'~/.cache')
+    assert xdg.get_dirs()['XDG_CACHE_DIR'] == os.path.expanduser(
+        os.path.normpath('~/.cache'))
 
 
 def test_cache_dir_from_env(environ):
@@ -29,7 +33,8 @@ def test_cache_dir_from_env(environ):
 
 
 def test_config_dir_default(environ):
-    assert xdg.get_dirs()['XDG_CONFIG_DIR'] == os.path.expanduser(b'~/.config')
+    assert xdg.get_dirs()['XDG_CONFIG_DIR'] == os.path.expanduser(
+        os.path.normpath('~/.config'))
 
 
 def test_config_dir_from_env(environ):

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -1,5 +1,6 @@
 from __future__ import unicode_literals
 
+import sys
 import os
 
 import mock
@@ -50,6 +51,7 @@ def test_data_dir_from_env(environ):
     assert type(xdg.get_dirs()['XDG_DATA_DIR']) == bytes
 
 
+@pytest.mark.skipif(sys.platform == 'win32', reason="needs different test for win32")
 def test_user_dirs(environ, tmpdir):
     os.environ['XDG_CONFIG_HOME'] = str(tmpdir)
 

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -7,6 +7,7 @@ import mock
 
 import pytest
 
+from mopidy import posix_normpath
 from mopidy.internal import xdg
 
 
@@ -21,8 +22,8 @@ def environ():
 
 
 def test_cache_dir_default(environ):
-    assert xdg.get_dirs()['XDG_CACHE_DIR'] == os.path.expanduser(
-        os.path.normpath('~/.cache'))
+    assert xdg.get_dirs()['XDG_CACHE_DIR'] == posix_normpath(
+        os.path.expanduser(os.path.normpath('~/.cache')))
 
 
 def test_cache_dir_from_env(environ):
@@ -33,8 +34,8 @@ def test_cache_dir_from_env(environ):
 
 
 def test_config_dir_default(environ):
-    assert xdg.get_dirs()['XDG_CONFIG_DIR'] == os.path.expanduser(
-        os.path.normpath('~/.config'))
+    assert xdg.get_dirs()['XDG_CONFIG_DIR'] == posix_normpath(
+        os.path.expanduser('~/.config'))
 
 
 def test_config_dir_from_env(environ):
@@ -45,8 +46,8 @@ def test_config_dir_from_env(environ):
 
 
 def test_data_dir_default(environ):
-    assert xdg.get_dirs()['XDG_DATA_DIR'] == os.path.expanduser(
-        b'~/.local/share')
+    assert xdg.get_dirs()['XDG_DATA_DIR'] == posix_normpath(
+           os.path.expanduser(b'~/.local/share'))
 
 
 def test_data_dir_from_env(environ):

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -4,11 +4,11 @@ from __future__ import absolute_import, unicode_literals
 
 import sys
 import os
+import posixpath
 import platform
 import shutil
 import tempfile
 import unittest
-import pytest
 
 import pykka
 
@@ -53,7 +53,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
     def test_created_playlist_is_persisted(self):
         uri = 'm3u:test.m3u'
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
         self.assertFalse(os.path.exists(path))
 
         playlist = self.core.playlists.create('test')
@@ -75,8 +75,8 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         uri1 = 'm3u:test1.m3u'
         uri2 = 'm3u:test2.m3u'
 
-        path1 = os.path.join(self.playlists_dir, b'test1.m3u')
-        path2 = os.path.join(self.playlists_dir, b'test2.m3u')
+        path1 = posixpath.join(self.playlists_dir, b'test1.m3u')
+        path2 = posixpath.join(self.playlists_dir, b'test2.m3u')
 
         playlist = self.core.playlists.create('test1')
         self.assertEqual('test1', playlist.name)
@@ -92,7 +92,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
     def test_deleted_playlist_is_removed(self):
         uri = 'm3u:test.m3u'
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
 
         self.assertFalse(os.path.exists(path))
 
@@ -114,7 +114,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         track = Track(uri=generate_song(1))
         playlist = self.core.playlists.create('test')
         playlist = self.core.playlists.save(playlist.replace(tracks=[track]))
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
 
         with open(path) as f:
             contents = f.read()
@@ -125,7 +125,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         track = Track(uri=generate_song(1), name='Test', length=60000)
         playlist = self.core.playlists.create('test')
         playlist = self.core.playlists.save(playlist.replace(tracks=[track]))
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
 
         with open(path) as f:
             m3u = f.read().splitlines()
@@ -136,7 +136,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         track = Track(uri=generate_song(1), name='Test\x9f', length=60000)
         playlist = self.core.playlists.create('test')
         playlist = self.core.playlists.save(playlist.replace(tracks=[track]))
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
 
         with open(path, 'rb') as f:
             m3u = f.read().splitlines()
@@ -146,7 +146,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         track = Track(uri=generate_song(1), name='Test\u07b4', length=60000)
         playlist = self.core.playlists.create('test')
         playlist = self.core.playlists.save(playlist.replace(tracks=[track]))
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
 
         with open(path, 'rb') as f:
             m3u = f.read().splitlines()
@@ -169,7 +169,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         'macOS 10.13 raises IOError "Illegal byte sequence" on open. '
         'Unicode is ok in win32.')
     def test_load_playlist_with_nonfilesystem_encoding_of_filename(self):
-        path = os.path.join(self.playlists_dir, 'øæå.m3u'.encode('latin-1'))
+        path = posixpath.join(self.playlists_dir, 'øæå.m3u'.encode('latin-1'))
         with open(path, 'wb+') as f:
             f.write(b'#EXTM3U\n')
 
@@ -214,7 +214,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         playlist = self.core.playlists.create('test')
         self.assertEqual(playlist, self.core.playlists.lookup(playlist.uri))
 
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
         self.assertTrue(os.path.exists(path))
 
         os.remove(path)
@@ -267,7 +267,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
     def test_save_playlist_with_new_uri(self):
         uri = 'm3u:test.m3u'
         self.core.playlists.save(Playlist(uri=uri))
-        path = os.path.join(self.playlists_dir, b'test.m3u')
+        path = posixpath.join(self.playlists_dir, b'test.m3u')
         self.assertTrue(os.path.exists(path))
 
     def test_save_on_path_outside_playlist_dir_returns_none(self):
@@ -301,7 +301,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
     def test_playlist_with_relative_path(self):
         track = Track(uri='test.mp3')
-        filepath = os.path.join(self.base_dir, b'test.mp3')
+        filepath = posixpath.join(self.base_dir, b'test.mp3')
         playlist = self.core.playlists.create('test')
         playlist = playlist.replace(tracks=[track])
         playlist = self.core.playlists.save(playlist)

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -16,6 +16,7 @@ from mopidy import core, posix_normpath
 from mopidy.internal import deprecation
 from mopidy.m3u.backend import M3UBackend
 from mopidy.models import Playlist, Track
+from mopidy.internal import path as path_lib
 
 from tests import dummy_audio, path_to_data_dir
 from tests.m3u import generate_song
@@ -310,7 +311,8 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         result = self.core.playlists.lookup('m3u:test.m3u')
         self.assertEqual('m3u:test.m3u', result.uri)
         self.assertEqual(playlist.name, result.name)
-        self.assertEqual('file://' + filepath, result.tracks[0].uri)
+        filepath = path_lib.path_to_uri(filepath)
+        self.assertEqual(filepath, result.tracks[0].uri)
 
     def test_playlist_sort_order(self):
         def check_order(playlists, names):

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -60,25 +60,18 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.assertEqual(uri, playlist.uri)
         self.assertTrue(os.path.exists(path))
 
-    @unittest.skipIf(sys.platform == 'win32',
-                     reason="| not valid filename char in win32")
     def test_create_sanitizes_playlist_name(self):
         test_name = '  ../../test FOO baR '
         playlist = self.core.playlists.create(test_name)
-        self.assertEqual('..|..|test FOO baR', playlist.name)
-        path = posix_normpath(self.playlists_dir,
-            (test_name.strip() + '.m3u').replace('/', '|').encode('utf-8'))
-        self.assertEqual(self.playlists_dir, os.path.dirname(path))
-        self.assertTrue(os.path.exists(path))
 
-    @unittest.skipUnless(sys.platform == 'win32',
-                         reason="| not valid filename char in win32")
-    def test_create_sanitizes_playlist_name_win32(self):
-        test_name = '  ../../test FOO baR '
-        playlist = self.core.playlists.create(test_name)
-        self.assertEqual('....test FOO baR', playlist.name)
-        path = posix_normpath(self.playlists_dir,
-            (test_name.strip() + '.m3u').replace('/', '').encode('utf-8'))
+        ref_sep = '' if sys.platform == 'win32' else '|'
+        ref_plname = test_name.strip().replace('/', ref_sep)
+        self.assertEqual(ref_plname, playlist.name)
+
+        ref_filename = (test_name.strip() + '.m3u')\
+            .replace('/', ref_sep).encode('utf-8')
+
+        path = posix_normpath(self.playlists_dir, ref_filename)
         self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))
 

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -71,8 +71,8 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))
 
-    @unittest.skipIf(sys.platform != 'win32',
-                     reason="| not valid filename char in win32")
+    @unittest.skipUnless(sys.platform == 'win32',
+                         reason="| not valid filename char in win32")
     def test_create_sanitizes_playlist_name_win32(self):
         test_name = '  ../../test FOO baR '
         playlist = self.core.playlists.create(test_name)

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -35,8 +35,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
     }
 
     def setUp(self):  # noqa: N802
-        # data_dir = path_to_data_dir('temp')
-        tmpdir = posix_normpath(tempfile.mkdtemp())  # dir=data_dir))
+        tmpdir = posix_normpath(tempfile.mkdtemp())
         self.config['m3u']['playlists_dir'] = tmpdir
         self.playlists_dir = self.config['m3u']['playlists_dir']
         self.base_dir = self.config['m3u']['base_dir'] or self.playlists_dir
@@ -62,6 +61,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.assertEqual(uri, playlist.uri)
         self.assertTrue(os.path.exists(path))
 
+    @unittest.skipIf(sys.platform == 'win32', reason="| not valid filename char in win32")
     def test_create_sanitizes_playlist_name(self):
         test_name = '  ../../test FOO baR '
         playlist = self.core.playlists.create(test_name)
@@ -69,7 +69,17 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         # self.assertEqual('....test FOO baR', playlist.name)
         path = posix_normpath(os.path.join(self.playlists_dir,
                 (test_name.strip()+'.m3u').replace('/','|').encode('utf-8')))
-	print('path is {}'.format(path))
+        self.assertEqual(self.playlists_dir, os.path.dirname(path))
+        self.assertTrue(os.path.exists(path))
+
+    @unittest.skipIf(sys.platform != 'win32', reason="| not valid filename char in win32")
+    def test_create_sanitizes_playlist_name_win32(self):
+        test_name = '  ../../test FOO baR '
+        playlist = self.core.playlists.create(test_name)
+        # self.assertEqual('..|..|test FOO baR', playlist.name)
+        self.assertEqual('....test FOO baR', playlist.name)
+        path = posix_normpath(os.path.join(self.playlists_dir,
+                (test_name.strip()+'.m3u').replace('/','').encode('utf-8')))
         self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))
 
@@ -365,8 +375,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 class M3UPlaylistsProviderBaseDirectoryTest(M3UPlaylistsProviderTest):
 
     def setUp(self):  # noqa: N802
-        # data_dir = path_to_data_dir('temp')
-        tmpdir = posix_normpath(tempfile.mkdtemp())  # dir=data_dir))
+        tmpdir = posix_normpath(tempfile.mkdtemp())
         self.config['m3u']['base_dir'] = posix_normpath(tmpdir)
         # self.config['m3u']['base_dir'] = tempfile.mkdtemp()
         super(M3UPlaylistsProviderBaseDirectoryTest, self).setUp()

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -2,21 +2,20 @@
 
 from __future__ import absolute_import, unicode_literals
 
-import sys
 import os
-import posixpath
 import platform
+import posixpath
 import shutil
+import sys
 import tempfile
 import unittest
 
 import pykka
 
 from mopidy import core, posix_normpath
-from mopidy.internal import deprecation
+from mopidy.internal import deprecation, path as path_lib
 from mopidy.m3u.backend import M3UBackend
 from mopidy.models import Playlist, Track
-from mopidy.internal import path as path_lib
 
 from tests import dummy_audio, path_to_data_dir
 from tests.m3u import generate_song
@@ -61,25 +60,25 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         self.assertEqual(uri, playlist.uri)
         self.assertTrue(os.path.exists(path))
 
-    @unittest.skipIf(sys.platform == 'win32', reason="| not valid filename char in win32")
+    @unittest.skipIf(sys.platform == 'win32',
+                     reason="| not valid filename char in win32")
     def test_create_sanitizes_playlist_name(self):
         test_name = '  ../../test FOO baR '
         playlist = self.core.playlists.create(test_name)
         self.assertEqual('..|..|test FOO baR', playlist.name)
-        # self.assertEqual('....test FOO baR', playlist.name)
-        path = posix_normpath(os.path.join(self.playlists_dir,
-                (test_name.strip()+'.m3u').replace('/','|').encode('utf-8')))
+        path = posix_normpath(self.playlists_dir,
+            (test_name.strip() + '.m3u').replace('/', '|').encode('utf-8'))
         self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))
 
-    @unittest.skipIf(sys.platform != 'win32', reason="| not valid filename char in win32")
+    @unittest.skipIf(sys.platform != 'win32',
+                     reason="| not valid filename char in win32")
     def test_create_sanitizes_playlist_name_win32(self):
         test_name = '  ../../test FOO baR '
         playlist = self.core.playlists.create(test_name)
-        # self.assertEqual('..|..|test FOO baR', playlist.name)
         self.assertEqual('....test FOO baR', playlist.name)
-        path = posix_normpath(os.path.join(self.playlists_dir,
-                (test_name.strip()+'.m3u').replace('/','').encode('utf-8')))
+        path = posix_normpath(self.playlists_dir,
+            (test_name.strip() + '.m3u').replace('/', '').encode('utf-8'))
         self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))
 

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -35,8 +35,8 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
     }
 
     def setUp(self):  # noqa: N802
-        data_dir = path_to_data_dir('temp')
-        tmpdir = posix_normpath(tempfile.mkdtemp(dir=data_dir))
+        # data_dir = path_to_data_dir('temp')
+        tmpdir = posix_normpath(tempfile.mkdtemp())  # dir=data_dir))
         self.config['m3u']['playlists_dir'] = tmpdir
         self.playlists_dir = self.config['m3u']['playlists_dir']
         self.base_dir = self.config['m3u']['base_dir'] or self.playlists_dir
@@ -65,10 +65,11 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
     def test_create_sanitizes_playlist_name(self):
         test_name = '  ../../test FOO baR '
         playlist = self.core.playlists.create(test_name)
-        # self.assertEqual('..|..|test FOO baR', playlist.name)
-        self.assertEqual('....test FOO baR', playlist.name)
+        self.assertEqual('..|..|test FOO baR', playlist.name)
+        # self.assertEqual('....test FOO baR', playlist.name)
         path = posix_normpath(os.path.join(self.playlists_dir,
-                (test_name.strip()+'.m3u').replace('/','').encode('utf-8')))
+                (test_name.strip()+'.m3u').replace('/','|').encode('utf-8')))
+	print('path is {}'.format(path))
         self.assertEqual(self.playlists_dir, os.path.dirname(path))
         self.assertTrue(os.path.exists(path))
 
@@ -364,8 +365,8 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 class M3UPlaylistsProviderBaseDirectoryTest(M3UPlaylistsProviderTest):
 
     def setUp(self):  # noqa: N802
-        data_dir = path_to_data_dir('temp')
-        tmpdir = posix_normpath(tempfile.mkdtemp(dir=data_dir))
+        # data_dir = path_to_data_dir('temp')
+        tmpdir = posix_normpath(tempfile.mkdtemp())  # dir=data_dir))
         self.config['m3u']['base_dir'] = posix_normpath(tmpdir)
         # self.config['m3u']['base_dir'] = tempfile.mkdtemp()
         super(M3UPlaylistsProviderBaseDirectoryTest, self).setUp()

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -49,7 +49,7 @@ def test_lookup_respects_blacklist(audio, config, track_uri):
 
 
 def test_lookup_respects_blacklist_globbing(audio, config, track_uri):
-    blacklist_glob = path.path_to_uri(path_to_data_dir()) + '*'
+    blacklist_glob = path.path_to_uri(path_to_data_dir('')) + '*'
     config['stream']['metadata_blacklist'].append(blacklist_glob)
     backend = actor.StreamBackend(audio=audio, config=config)
 

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -49,7 +49,7 @@ def test_lookup_respects_blacklist(audio, config, track_uri):
 
 
 def test_lookup_respects_blacklist_globbing(audio, config, track_uri):
-    blacklist_glob = path.path_to_uri(path_to_data_dir('')) + '*'
+    blacklist_glob = path.path_to_uri(path_to_data_dir()) + '*'
     config['stream']['metadata_blacklist'].append(blacklist_glob)
     backend = actor.StreamBackend(audio=audio, config=config)
 

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import, unicode_literals
 
 import os
+import posixpath
 
 import mock
 
@@ -247,7 +248,7 @@ class TestValidateExtensionData(object):
         with mock.patch.object(ext.path, 'get_or_create_dir'):
             cache_dir = extension.get_cache_dir(config)
 
-        expected = os.path.join(core_cache_dir, extension.ext_name)
+        expected = posixpath.join(core_cache_dir, extension.ext_name)
         assert cache_dir == expected
 
     def test_get_config_dir(self, ext_data):
@@ -258,7 +259,7 @@ class TestValidateExtensionData(object):
         with mock.patch.object(ext.path, 'get_or_create_dir'):
             config_dir = extension.get_config_dir(config)
 
-        expected = os.path.join(core_config_dir, extension.ext_name)
+        expected = posixpath.join(core_config_dir, extension.ext_name)
         assert config_dir == expected
 
     def test_get_data_dir(self, ext_data):
@@ -269,5 +270,5 @@ class TestValidateExtensionData(object):
         with mock.patch.object(ext.path, 'get_or_create_dir'):
             data_dir = extension.get_data_dir(config)
 
-        expected = os.path.join(core_data_dir, extension.ext_name)
+        expected = posixpath.join(core_data_dir, extension.ext_name)
         assert data_dir == expected

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,6 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import os
 import posixpath
 
 import mock

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -13,12 +13,25 @@ class HelpTest(unittest.TestCase):
     def test_help_has_mopidy_options(self):
         mopidy_dir = os.path.dirname(mopidy.__file__)
         args = [sys.executable, mopidy_dir, '--help']
+
+        # win32 requires env elements to be strings
+        if sys.platform == 'win32':
+            temp_env = {
+                str('PYTHONPATH'): str(':'.join([
+                    os.path.join(mopidy_dir, '..'),
+                    os.environ.get('PYTHONPATH', '')])),
+                str('SystemRoot'): str(os.environ.get('SystemRoot'))
+            }
+        else:
+            temp_env = {
+                'PYTHONPATH': ':'.join([
+                    os.path.join(mopidy_dir, '..'),
+                    os.environ.get('PYTHONPATH', '')])
+            }
+
         process = subprocess.Popen(
             args,
-            env={'PYTHONPATH': ':'.join([
-                os.path.join(mopidy_dir, '..'),
-                os.environ.get('PYTHONPATH', '')
-            ])},
+            env = temp_env,
             stdout=subprocess.PIPE)
         output = process.communicate()[0]
         self.assertIn('--version', output)

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -15,6 +15,7 @@ class HelpTest(unittest.TestCase):
         args = [sys.executable, mopidy_dir, '--help']
 
         # win32 requires env elements to be strings
+        #  SystemRoot variable is needed by urandom on win32
         if sys.platform == 'win32':
             temp_env = {
                 str('PYTHONPATH'): str(':'.join([

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -32,7 +32,7 @@ class HelpTest(unittest.TestCase):
 
         process = subprocess.Popen(
             args,
-            env = temp_env,
+            env=temp_env,
             stdout=subprocess.PIPE)
         output = process.communicate()[0]
         self.assertIn('--version', output)


### PR DESCRIPTION
This mopidy fork works on the Microsoft Windows platform.

Path handling is Posix (forward slashes).  Modern versions of Windows seem to handle Posix paths ok, so paths are converted to Posix early and maintained as Posix.  Many calls to os.path.* are now posixpath.*.  A new function, mopidy.posix_normpath, will convert any path to a Posix-style path possibly with drive (c:, d:) included.

All unittests pass, with maybe a dozen conditionally skipped.  Tests pass under Lubuntu 19.04 and Windows 8.1.

This is a fork of the 2.3 release branch.   The 3.0 develop branch does not seem to have a functioning web-client.

Todos:
1) Find a zeroconf binary, and verify functionality in mopidy.
2) Write an installation guide, covering Gstreamer and Zeroconf.
3) Create an installer, or a python wheel, for easy Windows install.

