### PR TITLE
py3: Stream backend

### DIFF
--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -98,5 +98,5 @@ class Signals(object):
 
     def clear(self):
         """Clear all registered signal handlers."""
-        for element, event in self._ids.keys():
+        for element, event in list(self._ids):
             element.disconnect(self._ids.pop((element, event)))

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -160,6 +160,7 @@ def _unwrap_stream(uri, timeout, scanner, requests_session):
             return uri, None
 
         # TODO Test streams and return first that seems to be playable
+        new_uri = uris[0].decode('utf-8')
         logger.debug(
-            'Parsed playlist (%s) and found new URI: %s', uri, uris[0])
-        uri = urllib.parse.urljoin(uri, uris[0])
+            'Parsed playlist (%s) and found new URI: %s', uri, new_uri)
+        uri = urllib.parse.urljoin(uri, new_uri)

--- a/tox.ini
+++ b/tox.ini
@@ -41,7 +41,6 @@ commands =
         --deselect=tests/m3u \
         --deselect=tests/models \
         --deselect=tests/mpd \
-        --deselect=tests/stream \
         --deselect=tests/test_exceptions.py \
         --deselect=tests/test_ext.py \
         --deselect=tests/test_help.py \


### PR DESCRIPTION
I'm not sure I did the right thing here.

`http.download()` gives us bytes, which is what `playlists.parse()` wants and also returns to us. And I've decoded that assuming utf-8 to match what `uris` is. But surely it's much better for `http.download()` to decode the bytes using the actual server encoding and then if `playlists.parse()` really wants to do deal in bytes (must it?) then we encode/decode around that. 

