### PR TITLE
Py3: More deprecated inspect functions

### DIFF
--- a/mopidy/compat.py
+++ b/mopidy/compat.py
@@ -41,7 +41,7 @@ if PY2:
     def itervalues(dct, **kwargs):
         return iter(dct.itervalues(**kwargs))
 
-    from inspect import getargspec  # noqa
+    from inspect import getargspec, getcallargs  # noqa
     from itertools import izip_longest as zip_longest  # noqa
 
 else:
@@ -69,6 +69,11 @@ else:
         spec = inspect.getfullargspec(func)
         return inspect.ArgSpec(
             spec.args, spec.varargs, spec.varkw, spec.defaults)
+
+    def getcallargs(func, *args, **kwargs):
+        ba = inspect.signature(func).bind(*args, **kwargs)
+        ba.apply_defaults()
+        return ba.arguments
 
 
 def add_metaclass(metaclass):

--- a/mopidy/mpd/protocol/__init__.py
+++ b/mopidy/mpd/protocol/__init__.py
@@ -139,10 +139,7 @@ class Commands(object):
             if name in self.handlers:
                 raise ValueError('%s already registered' % name)
 
-            if compat.PY2:
-                spec = inspect.getargspec(func)
-            else:
-                spec = inspect.getfullargspec(func)
+            spec = compat.getargspec(func)
             defaults = dict(
                 zip(spec.args[-len(spec.defaults or []):], spec.defaults or [])
             )
@@ -157,12 +154,8 @@ class Commands(object):
             if not set(validators.keys()).issubset(spec.args):
                 raise TypeError('Validator for non-existent arg passed')
 
-            if compat.PY2:
-                if spec.keywords:
-                    raise TypeError('Keyword arguments are not permitted')
-            else:
-                if spec.varkw or spec.kwonlyargs:
-                    raise TypeError('Keyword arguments are not permitted')
+            if spec.keywords:
+                raise TypeError('Keyword arguments are not permitted')
 
             def validate(*args, **kwargs):
                 if spec.varargs:

--- a/mopidy/mpd/protocol/__init__.py
+++ b/mopidy/mpd/protocol/__init__.py
@@ -12,8 +12,6 @@ implement our own MPD server which is compatible with the numerous existing
 
 from __future__ import absolute_import, unicode_literals
 
-import inspect
-
 from mopidy import compat
 from mopidy.mpd import exceptions
 
@@ -162,7 +160,7 @@ class Commands(object):
                     return func(*args, **kwargs)
 
                 try:
-                    callargs = inspect.getcallargs(func, *args, **kwargs)
+                    callargs = compat.getcallargs(func, *args, **kwargs)
                 except TypeError:
                     raise exceptions.MpdArgError(
                         'wrong number of arguments for "%s"' % name)


### PR DESCRIPTION
Use `compat.getargspec` elsewhere [as suggested in #1813](https://github.com/mopidy/mopidy/pull/1813#discussion_r332295364). However, this does lose Python3's check for `kwonlyargs` so maybe this fix isn't as good as what we already had. 

Defined `compat.getcallargs` since that has also been deprecated in Py3. Note: the MPD tests currently don't work so this is untested. Happy to wait for those to be fixed before merging this. 