### PR TITLE
Decode uri before logging unplayable uri

### DIFF
--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -547,7 +547,8 @@ class TracklistController(object):
 
     def _mark_unplayable(self, tl_track):
         """Internal method for :class:`mopidy.core.PlaybackController`."""
-        logger.warning('Track is not playable: %s', tl_track.track.uri)
+        logger.warning(
+            'Track is not playable: %s', tl_track.track.uri.decode('utf-8'))
         if self.get_consume() and tl_track is not None:
             self.remove({'tlid': [tl_track.tlid]})
         if self.get_random() and tl_track in self._shuffled:


### PR DESCRIPTION
After adding some non-ASCII URIs to the tests, I still had to run pytest with `--capture=no` to make these `UnicodeDecodeError`s come out. I don't understand why this is.