### PR TITLE
Use Debian stretch packages for Ubuntu 18.04

### DIFF
--- a/docs/installation/debian.rst
+++ b/docs/installation/debian.rst
@@ -16,8 +16,11 @@ from scratch, we have a guide for installing Debian/Raspbian and Mopidy. See
 
 The packages are built for:
 
+- Debian stretch (oldstable), which also works for Raspbian stretch and Ubuntu
+  18.04 LTS.
+
 - Debian buster (stable), which also works for Raspbian buster and Ubuntu
-  18.04 LTS and newer.
+  19.10 and newer.
 
 The packages are available for multiple CPU architectures: i386, amd64, armel,
 and armhf (compatible with all Raspberry Pi models).
@@ -36,6 +39,10 @@ and armhf (compatible with all Raspberry Pi models).
 #. Add the APT repo to your package sources::
 
        sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/buster.list
+
+   Or, if you run an older Debian/Ubuntu distro (including Ubuntu 18.04 LTS)::
+
+       sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/stretch.list
 
 #. Install Mopidy and all dependencies::
 


### PR DESCRIPTION
I've pretty much restored what we used to have when supporting both jessie and stretch.