### PR TITLE
py3: Convert mopidy.ext

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -186,7 +186,13 @@ Models
 Extension support
 -----------------
 
-- (no changes yet)
+- The following methods now return :class:`pathlib.Path` objects instead of strings:
+
+  - :meth:`mopidy.ext.Extension.get_cache_dir`
+  - :meth:`mopidy.ext.Extension.get_config_dir`
+  - :meth:`mopidy.ext.Extension.get_data_dir`
+
+  This makes it easier to support arbitrary encoding in file names.
 
 HTTP frontend
 -------------

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -2,7 +2,6 @@ from __future__ import absolute_import, unicode_literals
 
 import collections
 import logging
-import os
 
 import pkg_resources
 
@@ -67,11 +66,12 @@ class Extension(object):
         Use this directory to cache data that can safely be thrown away.
 
         :param config: the Mopidy config object
-        :return: string
+        :return: pathlib.Path
         """
         assert cls.ext_name is not None
-        cache_dir_path = bytes(os.path.join(config['core']['cache_dir'],
-                                            cls.ext_name))
+        cache_dir_path = (
+            path.expand_path(config['core']['cache_dir']) / cls.ext_name
+        )
         path.get_or_create_dir(cache_dir_path)
         return cache_dir_path
 
@@ -80,11 +80,12 @@ class Extension(object):
         """Get or create configuration directory for the extension.
 
         :param config: the Mopidy config object
-        :return: string
+        :return: pathlib.Path
         """
         assert cls.ext_name is not None
-        config_dir_path = bytes(os.path.join(config['core']['config_dir'],
-                                             cls.ext_name))
+        config_dir_path = (
+            path.expand_path(config['core']['config_dir']) / cls.ext_name
+        )
         path.get_or_create_dir(config_dir_path)
         return config_dir_path
 
@@ -95,11 +96,12 @@ class Extension(object):
         Use this directory to store data that should be persistent.
 
         :param config: the Mopidy config object
-        :returns: string
+        :returns: pathlib.Path
         """
         assert cls.ext_name is not None
-        data_dir_path = bytes(os.path.join(config['core']['data_dir'],
-                                           cls.ext_name))
+        data_dir_path = (
+            path.expand_path(config['core']['data_dir']) / cls.ext_name
+        )
         path.get_or_create_dir(data_dir_path)
         return data_dir_path
 

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,7 +1,5 @@
 from __future__ import absolute_import, unicode_literals
 
-import os
-
 import mock
 
 import pkg_resources
@@ -9,6 +7,7 @@ import pkg_resources
 import pytest
 
 from mopidy import config, exceptions, ext
+from mopidy.compat import pathlib
 
 from tests import IsA, any_unicode
 
@@ -247,7 +246,7 @@ class TestValidateExtensionData(object):
         with mock.patch.object(ext.path, 'get_or_create_dir'):
             cache_dir = extension.get_cache_dir(config)
 
-        expected = os.path.join(core_cache_dir, extension.ext_name)
+        expected = pathlib.Path(core_cache_dir) / extension.ext_name
         assert cache_dir == expected
 
     def test_get_config_dir(self, ext_data):
@@ -258,7 +257,7 @@ class TestValidateExtensionData(object):
         with mock.patch.object(ext.path, 'get_or_create_dir'):
             config_dir = extension.get_config_dir(config)
 
-        expected = os.path.join(core_config_dir, extension.ext_name)
+        expected = pathlib.Path(core_config_dir) / extension.ext_name
         assert config_dir == expected
 
     def test_get_data_dir(self, ext_data):
@@ -269,5 +268,5 @@ class TestValidateExtensionData(object):
         with mock.patch.object(ext.path, 'get_or_create_dir'):
             data_dir = extension.get_data_dir(config)
 
-        expected = os.path.join(core_data_dir, extension.ext_name)
+        expected = pathlib.Path(core_data_dir) / extension.ext_name
         assert data_dir == expected

--- a/tox.ini
+++ b/tox.ini
@@ -39,7 +39,6 @@ commands =
         --deselect=tests/mpd/protocol/test_playback.py \
         --deselect=tests/mpd/protocol/test_regression.py \
         --deselect=tests/mpd/protocol/test_stored_playlists.py \
-        --deselect=tests/test_ext.py \
         {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
I opted to change the external API towards the extensions for the better. I think spreading pathlib to them is more helpful than requiring them to discover all the subleties of path handling themselves.