### PR TITLE
Py3: Convert remaining parts of mopidy.mpd.protocol

### DIFF
--- a/mopidy/mpd/protocol/music_db.py
+++ b/mopidy/mpd/protocol/music_db.py
@@ -103,9 +103,10 @@ def count(context, *args):
         raise exceptions.MpdArgError('incorrect arguments')
     results = context.core.library.search(query=query, exact=True).get()
     result_tracks = _get_tracks(results)
+    total_length = sum(t.length for t in result_tracks if t.length)
     return [
         ('songs', len(result_tracks)),
-        ('playtime', sum(t.length for t in result_tracks if t.length) / 1000),
+        ('playtime', int(total_length / 1000)),
     ]
 
 

--- a/tests/mpd/protocol/test_current_playlist.py
+++ b/tests/mpd/protocol/test_current_playlist.py
@@ -2,6 +2,7 @@
 
 from __future__ import absolute_import, unicode_literals
 
+from mopidy import compat
 from mopidy.internal import deprecation
 from mopidy.models import Ref, Track
 
@@ -35,7 +36,10 @@ class AddCommandsTest(protocol.BaseTestCase):
 
     def test_add_unicode(self):
         for track in [self.tracks[0], self.tracks[1], self.tracks[2]]:
-            self.send_request('add "%s"' % track.uri.decode('utf-8'))
+            if compat.PY2:
+                self.send_request('add "%s"' % track.uri.decode('utf-8'))
+            else:
+                self.send_request('add "%s"' % track.uri)
 
         self.assertEqual(len(self.core.tracklist.get_tracks().get()), 3)
         self.assertEqual(

--- a/tests/mpd/protocol/test_playback.py
+++ b/tests/mpd/protocol/test_playback.py
@@ -342,7 +342,8 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         current_track = self.core.playback.get_current_track().get()
         self.assertEqual(current_track, self.tracks[0])
-        self.assertGreaterEqual(self.core.playback.get_time_position(), 30000)
+        self.assertGreaterEqual(
+            self.core.playback.get_time_position().get(), 30000)
         self.assertInResponse('OK')
 
     def test_seek_in_another_track(self):

--- a/tests/mpd/protocol/test_regression.py
+++ b/tests/mpd/protocol/test_regression.py
@@ -10,6 +10,10 @@ from mopidy.mpd.protocol import stored_playlists
 from tests.mpd import protocol
 
 
+def mock_shuffle(foo):
+    foo[:] = [foo[1], foo[2], foo[5], foo[3], foo[4], foo[0]]
+
+
 class IssueGH17RegressionTest(protocol.BaseTestCase):
 
     """
@@ -22,6 +26,8 @@ class IssueGH17RegressionTest(protocol.BaseTestCase):
     - Press next until you get to the unplayable track
     """
 
+    @mock.patch.object(
+        protocol.core.tracklist.random, 'shuffle', mock_shuffle)
     def test(self):
         tracks = [
             Track(uri='dummy:a'),
@@ -35,7 +41,7 @@ class IssueGH17RegressionTest(protocol.BaseTestCase):
         self.backend.library.dummy_library = tracks
         self.core.tracklist.add(uris=[t.uri for t in tracks]).get()
 
-        random.seed(1)  # Playlist order: abcfde
+        # Playlist order: abcfde
 
         self.send_request('play')
         self.assertEqual(

--- a/tests/mpd/protocol/test_stored_playlists.py
+++ b/tests/mpd/protocol/test_stored_playlists.py
@@ -4,6 +4,7 @@ from __future__ import absolute_import, unicode_literals
 
 import mock
 
+from mopidy import compat
 from mopidy.models import Playlist, Track
 from mopidy.mpd.protocol import stored_playlists
 
@@ -206,7 +207,10 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.assertEqual('dummy:b', tracks[1].uri)
         self.assertEqual('dummy:c', tracks[2].uri)
         self.assertEqual('dummy:d', tracks[3].uri)
-        self.assertEqual('dummy:ǫ', tracks[4].uri.decode('utf-8'))
+        if compat.PY2:
+            self.assertEqual('dummy:ǫ', tracks[4].uri.decode('utf-8'))
+        else:
+            self.assertEqual('dummy:ǫ', tracks[4].uri)
         self.assertInResponse('OK')
 
     def test_load_with_range_loads_part_of_playlist(self):

--- a/tox.ini
+++ b/tox.ini
@@ -34,11 +34,6 @@ commands =
         --deselect=tests/core/test_playback.py \
         --deselect=tests/file/test_lookup.py \
         --deselect=tests/m3u/test_playlists.py \
-        --deselect=tests/mpd/protocol/test_current_playlist.py \
-        --deselect=tests/mpd/protocol/test_music_db.py \
-        --deselect=tests/mpd/protocol/test_playback.py \
-        --deselect=tests/mpd/protocol/test_regression.py \
-        --deselect=tests/mpd/protocol/test_stored_playlists.py \
         {posargs}
 
 [testenv:docs]


### PR DESCRIPTION
Continue returning integer playtime value.

Fix test to handle different random number generation between versions.

Broken test was comparing 'ThreadingFuture' and 'int'.