### PR TITLE
Replace mock with unittest.mock (and isort)

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -7,6 +7,9 @@ sphinx
 # Format code
 black
 
+# Import sorting
+isort[pyproject]
+
 # Check code style, errors, etc
 flake8
 flake8-bugbear

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -16,8 +16,7 @@ flake8-bugbear
 flake8-import-order
 pep8-naming
 
-# Mock dependencies in tests
-mock
+# Mock HTTP requests in tests
 responses
 
 # Test runners

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -4,11 +4,13 @@
 import os
 import sys
 
-
-# -- Workarounds to have autodoc generate API docs ----------------------------
-
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + "/../"))
+
+from mopidy.internal.versioning import get_version  # isort:skip
+
+
+# -- Workarounds to have autodoc generate API docs ----------------------------
 
 
 class Mock:
@@ -76,7 +78,6 @@ master_doc = "index"
 project = "Mopidy"
 copyright = "2009-2019, Stein Magnus Jodal and contributors"
 
-from mopidy.internal.versioning import get_version
 
 release = get_version()
 version = ".".join(release.split(".")[:2])

--- a/mopidy/__init__.py
+++ b/mopidy/__init__.py
@@ -2,7 +2,6 @@ import platform
 import sys
 import warnings
 
-
 if not sys.version_info >= (3, 7):
     sys.exit(
         f"ERROR: Mopidy requires Python >= 3.7, "

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -4,7 +4,9 @@ import sys
 
 import pykka.debug
 
-from mopidy import commands, config as config_lib, ext
+from mopidy import commands
+from mopidy import config as config_lib
+from mopidy import ext
 from mopidy.internal import encoding, log, path, process, versioning
 from mopidy.internal.gi import Gst  # noqa: F401
 

--- a/mopidy/audio/__init__.py
+++ b/mopidy/audio/__init__.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 from .actor import Audio
-from .listener import AudioListener
 from .constants import PlaybackState
+from .listener import AudioListener
 from .utils import (
     calculate_duration,
     create_buffer,

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -5,12 +5,12 @@ import threading
 import pykka
 
 from mopidy import exceptions
-from mopidy.audio import tags as tags_lib, utils
+from mopidy.audio import tags as tags_lib
+from mopidy.audio import utils
 from mopidy.audio.constants import PlaybackState
 from mopidy.audio.listener import AudioListener
 from mopidy.internal import process
 from mopidy.internal.gi import GLib, GObject, Gst, GstPbutils
-
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -3,7 +3,8 @@ import logging
 import time
 
 from mopidy import exceptions
-from mopidy.audio import tags as tags_lib, utils
+from mopidy.audio import tags as tags_lib
+from mopidy.audio import utils
 from mopidy.internal import encoding, log
 from mopidy.internal.gi import Gst, GstPbutils
 

--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -7,7 +7,6 @@ from mopidy.internal import log
 from mopidy.internal.gi import GLib, Gst
 from mopidy.models import Album, Artist, Track
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -2,7 +2,6 @@ import logging
 
 from mopidy import listener
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -1,15 +1,16 @@
 import argparse
 import collections
 import contextlib
-import pathlib
 import logging
 import os
+import pathlib
 import signal
 import sys
 
 import pykka
 
-from mopidy import config as config_lib, exceptions
+from mopidy import config as config_lib
+from mopidy import exceptions
 from mopidy.audio import Audio
 from mopidy.core import Core
 from mopidy.internal import deps, process, timer, versioning

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -17,7 +17,6 @@ from mopidy.core.tracklist import TracklistController
 from mopidy.internal import path, storage, validation, versioning
 from mopidy.internal.models import CoreState
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -8,7 +8,6 @@ from collections.abc import Mapping
 from mopidy import exceptions, models
 from mopidy.internal import validation
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/core/mixer.py
+++ b/mopidy/core/mixer.py
@@ -5,7 +5,6 @@ from mopidy import exceptions
 from mopidy.internal import validation
 from mopidy.internal.models import MixerState
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -4,9 +4,9 @@ from collections.abc import Mapping
 
 import pkg_resources
 
-from mopidy import config as config_lib, exceptions
+from mopidy import config as config_lib
+from mopidy import exceptions
 from mopidy.internal import path
-
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/file/backend.py
+++ b/mopidy/file/backend.py
@@ -5,7 +5,6 @@ import pykka
 from mopidy import backend
 from mopidy.file import library
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -5,7 +5,6 @@ from mopidy import backend, exceptions, models
 from mopidy.audio import scan, tags
 from mopidy.internal import path
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -2,8 +2,8 @@ import logging
 import os
 
 import mopidy
-from mopidy import config as config_lib, exceptions, ext
-
+from mopidy import config as config_lib
+from mopidy import exceptions, ext
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -3,7 +3,6 @@ import logging
 import threading
 
 import pykka
-
 import tornado.httpserver
 import tornado.ioloop
 import tornado.netutil

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -12,7 +12,6 @@ import mopidy
 from mopidy import core, models
 from mopidy.internal import encoding, jsonrpc
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -2,7 +2,6 @@ import contextlib
 import re
 import warnings
 
-
 # Messages used in deprecation warnings are collected here so we can target
 # them easily when ignoring warnings.
 _MESSAGES = {

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -1,7 +1,6 @@
 import sys
 import textwrap
 
-
 try:
     import gi
 

--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -3,7 +3,6 @@ import logging.config
 import logging.handlers
 import platform
 
-
 LOG_LEVELS = {
     -1: dict(root=logging.ERROR, mopidy=logging.WARNING),
     0: dict(root=logging.ERROR, mopidy=logging.INFO),

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -11,7 +11,6 @@ import pykka
 from mopidy.internal import encoding, path, validation
 from mopidy.internal.gi import GLib
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -8,7 +8,6 @@ from mopidy.internal import xdg
 # Reexport in old location for Mopidy-Local's use
 from mopidy.internal.mtimes import find_mtimes  # noqa
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/internal/process.py
+++ b/mopidy/internal/process.py
@@ -1,9 +1,9 @@
 import logging
 import threading
-import _thread
 
 import pykka
 
+import _thread
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/internal/timer.py
+++ b/mopidy/internal/timer.py
@@ -4,7 +4,6 @@ import time
 
 from mopidy.internal import log
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/internal/validation.py
+++ b/mopidy/internal/validation.py
@@ -3,7 +3,6 @@ from collections.abc import Iterable, Mapping
 
 from mopidy import exceptions
 
-
 PLAYBACK_STATES = {"paused", "stopped", "playing"}
 
 SEARCH_FIELDS = {

--- a/mopidy/local.py
+++ b/mopidy/local.py
@@ -6,7 +6,6 @@ import warnings
 
 from mopidy_local import *  # noqa
 
-
 warnings.warn(
     "Mopidy-Local has been moved to its own project. "
     "Update any imports from `mopidy.local` to use `mopidy_local` instead.",

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -2,7 +2,6 @@ import logging
 
 from mopidy import listener
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/models/immutable.py
+++ b/mopidy/models/immutable.py
@@ -4,7 +4,6 @@ import weakref
 
 from mopidy.models.fields import Field
 
-
 # Registered models for automatic deserialization
 _models = {}
 

--- a/mopidy/mpd/tokenize.py
+++ b/mopidy/mpd/tokenize.py
@@ -2,7 +2,6 @@ import re
 
 from mopidy.mpd import exceptions
 
-
 WORD_RE = re.compile(
     r"""
     ^

--- a/mopidy/mpd/translator.py
+++ b/mopidy/mpd/translator.py
@@ -5,7 +5,6 @@ import re
 from mopidy.models import TlTrack
 from mopidy.mpd.protocol import tagtype_list
 
-
 logger = logging.getLogger(__name__)
 
 # TODO: special handling of local:// uri scheme

--- a/mopidy/softwaremixer/mixer.py
+++ b/mopidy/softwaremixer/mixer.py
@@ -4,7 +4,6 @@ import pykka
 
 from mopidy import mixer
 
-
 logger = logging.getLogger(__name__)
 
 

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -6,7 +6,8 @@ import urllib
 
 import pykka
 
-from mopidy import audio as audio_lib, backend, exceptions, stream
+from mopidy import audio as audio_lib
+from mopidy import backend, exceptions, stream
 from mopidy.audio import scan, tags
 from mopidy.internal import http, playlists
 from mopidy.models import Track

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,3 +5,13 @@ requires = ["setuptools", "wheel"]
 [tool.black]
 target-version = ["py37", "py38"]
 line-length = 80
+
+
+[tool.isort]
+multi_line_output = 3
+include_trailing_comma = true
+force_grid_wrap = 0
+use_parentheses = true
+line_length = 88
+known_tests = "tests"
+sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -2,7 +2,6 @@ import threading
 import unittest
 
 import mock
-
 import pykka
 
 from mopidy import audio

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -1,7 +1,7 @@
 import threading
 import unittest
+from unittest import mock
 
-import mock
 import pykka
 
 from mopidy import audio

--- a/tests/audio/test_listener.py
+++ b/tests/audio/test_listener.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import audio
 

--- a/tests/backend/test_listener.py
+++ b/tests/backend/test_listener.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import backend
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import config, ext
 

--- a/tests/config/test_schemas.py
+++ b/tests/config/test_schemas.py
@@ -1,7 +1,6 @@
 import logging
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy.config import schemas, types
 

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -1,7 +1,7 @@
 import logging
 import socket
+from unittest import mock
 
-import mock
 import pytest
 
 from mopidy.config import types

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -2,7 +2,6 @@ import logging
 import socket
 
 import mock
-
 import pytest
 
 from mopidy.config import types

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -4,7 +4,6 @@ import tempfile
 import unittest
 
 import mock
-
 import pykka
 
 import mopidy

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -2,8 +2,8 @@ import pathlib
 import shutil
 import tempfile
 import unittest
+from unittest import mock
 
-import mock
 import pykka
 
 import mopidy

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -1,7 +1,6 @@
 import unittest
 
 import mock
-
 import pykka
 
 from mopidy import core

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -1,6 +1,6 @@
 import unittest
+from unittest import mock
 
-import mock
 import pykka
 
 from mopidy import core

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import backend, core
 from mopidy.models import Image, Ref, SearchResult, Track

--- a/tests/core/test_listener.py
+++ b/tests/core/test_listener.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy.core import CoreListener, PlaybackState
 from mopidy.models import Playlist, TlTrack

--- a/tests/core/test_mixer.py
+++ b/tests/core/test_mixer.py
@@ -1,7 +1,6 @@
 import unittest
 
 import mock
-
 import pykka
 
 from mopidy import core, mixer

--- a/tests/core/test_mixer.py
+++ b/tests/core/test_mixer.py
@@ -1,6 +1,6 @@
 import unittest
+from unittest import mock
 
-import mock
 import pykka
 
 from mopidy import core, mixer

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -1,7 +1,5 @@
 import mock
-
 import pykka
-
 import pytest
 
 from mopidy import backend, core

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import pykka
 import pytest
 

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import backend, core
 from mopidy.models import Playlist, Ref, Track

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import backend, core
 from mopidy.internal.models import TracklistState

--- a/tests/file/test_lookup.py
+++ b/tests/file/test_lookup.py
@@ -1,5 +1,4 @@
 import mock
-
 import pytest
 
 from mopidy.file import backend

--- a/tests/file/test_lookup.py
+++ b/tests/file/test_lookup.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import pytest
 
 from mopidy.file import backend

--- a/tests/http/test_events.py
+++ b/tests/http/test_events.py
@@ -1,7 +1,6 @@
 import json
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy.http import actor
 

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -1,7 +1,7 @@
 import os
 import unittest
+from unittest import mock
 
-import mock
 import tornado.testing
 import tornado.web
 import tornado.websocket

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -2,7 +2,6 @@ import os
 import unittest
 
 import mock
-
 import tornado.testing
 import tornado.web
 import tornado.websocket

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -1,7 +1,6 @@
 import os
 
 import mock
-
 import tornado.testing
 import tornado.wsgi
 

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -1,6 +1,6 @@
 import os
+from unittest import mock
 
-import mock
 import tornado.testing
 import tornado.wsgi
 

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -2,9 +2,9 @@ import errno
 import logging
 import socket
 import unittest
+from unittest.mock import Mock, call, patch, sentinel
 
 import pykka
-from mock import Mock, call, patch, sentinel
 
 from mopidy.internal import network
 from mopidy.internal.gi import GLib

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -3,9 +3,8 @@ import logging
 import socket
 import unittest
 
-from mock import Mock, call, patch, sentinel
-
 import pykka
+from mock import Mock, call, patch, sentinel
 
 from mopidy.internal import network
 from mopidy.internal.gi import GLib

--- a/tests/internal/network/test_lineprotocol.py
+++ b/tests/internal/network/test_lineprotocol.py
@@ -1,7 +1,6 @@
 import re
 import unittest
-
-from mock import Mock, sentinel
+from unittest.mock import Mock, sentinel
 
 from mopidy.internal import network
 

--- a/tests/internal/network/test_server.py
+++ b/tests/internal/network/test_server.py
@@ -2,8 +2,7 @@ import errno
 import os
 import socket
 import unittest
-
-from mock import Mock, patch, sentinel
+from unittest.mock import Mock, patch, sentinel
 
 from mopidy import exceptions
 from mopidy.internal import network

--- a/tests/internal/network/test_utils.py
+++ b/tests/internal/network/test_utils.py
@@ -1,7 +1,6 @@
 import socket
 import unittest
-
-from mock import Mock, patch, sentinel
+from unittest.mock import Mock, patch, sentinel
 
 from mopidy.internal import network
 

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -1,8 +1,8 @@
 import platform
 import sys
 import unittest
+from unittest import mock
 
-import mock
 import pkg_resources
 
 from mopidy.internal import deps

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -3,7 +3,6 @@ import sys
 import unittest
 
 import mock
-
 import pkg_resources
 
 from mopidy.internal import deps

--- a/tests/internal/test_encoding.py
+++ b/tests/internal/test_encoding.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy.internal import encoding
 

--- a/tests/internal/test_http.py
+++ b/tests/internal/test_http.py
@@ -1,13 +1,9 @@
 import mock
-
 import pytest
-
 import requests
-
 import responses
 
 from mopidy.internal import http
-
 
 TIMEOUT = 1000
 URI = "http://example.com/foo.txt"

--- a/tests/internal/test_http.py
+++ b/tests/internal/test_http.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import pytest
 import requests
 import responses

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -1,7 +1,7 @@
 import json
 import unittest
+from unittest import mock
 
-import mock
 import pykka
 
 from mopidy import core, models

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -2,7 +2,6 @@ import json
 import unittest
 
 import mock
-
 import pykka
 
 from mopidy import core, models

--- a/tests/internal/test_playlists.py
+++ b/tests/internal/test_playlists.py
@@ -2,7 +2,6 @@ import pytest
 
 from mopidy.internal import playlists
 
-
 BAD = b"foobarbaz"
 
 EXTM3U = b"""#EXTM3U

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -1,7 +1,7 @@
 import os
 import pathlib
+from unittest import mock
 
-import mock
 import pytest
 
 from mopidy.internal import xdg

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -2,7 +2,6 @@ import os
 import pathlib
 
 import mock
-
 import pytest
 
 from mopidy.internal import xdg

--- a/tests/mpd/protocol/__init__.py
+++ b/tests/mpd/protocol/__init__.py
@@ -1,7 +1,6 @@
 import unittest
 
 import mock
-
 import pykka
 
 from mopidy import core

--- a/tests/mpd/protocol/__init__.py
+++ b/tests/mpd/protocol/__init__.py
@@ -1,6 +1,6 @@
 import unittest
+from unittest import mock
 
-import mock
 import pykka
 
 from mopidy import core

--- a/tests/mpd/protocol/test_connection.py
+++ b/tests/mpd/protocol/test_connection.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from tests.mpd import protocol
 

--- a/tests/mpd/protocol/test_idle.py
+++ b/tests/mpd/protocol/test_idle.py
@@ -1,4 +1,4 @@
-from mock import patch
+from unittest.mock import patch
 
 from mopidy.mpd.protocol.status import SUBSYSTEMS
 

--- a/tests/mpd/protocol/test_music_db.py
+++ b/tests/mpd/protocol/test_music_db.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy.models import Album, Artist, Playlist, Ref, SearchResult, Track
 from mopidy.mpd.protocol import music_db, stored_playlists

--- a/tests/mpd/protocol/test_playback.py
+++ b/tests/mpd/protocol/test_playback.py
@@ -6,7 +6,6 @@ from mopidy.models import Track
 
 from tests.mpd import protocol
 
-
 PAUSED = PlaybackState.PAUSED
 PLAYING = PlaybackState.PLAYING
 STOPPED = PlaybackState.STOPPED

--- a/tests/mpd/protocol/test_regression.py
+++ b/tests/mpd/protocol/test_regression.py
@@ -1,6 +1,5 @@
 import random
-
-import mock
+from unittest import mock
 
 from mopidy.models import Playlist, Ref, Track
 from mopidy.mpd.protocol import stored_playlists

--- a/tests/mpd/protocol/test_stored_playlists.py
+++ b/tests/mpd/protocol/test_stored_playlists.py
@@ -1,4 +1,4 @@
-import mock
+from unittest import mock
 
 from mopidy.models import Playlist, Track
 from mopidy.mpd.protocol import stored_playlists

--- a/tests/mpd/test_actor.py
+++ b/tests/mpd/test_actor.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import pytest
 
 from mopidy.mpd import actor

--- a/tests/mpd/test_actor.py
+++ b/tests/mpd/test_actor.py
@@ -1,5 +1,4 @@
 import mock
-
 import pytest
 
 from mopidy.mpd import actor

--- a/tests/mpd/test_session.py
+++ b/tests/mpd/test_session.py
@@ -1,6 +1,5 @@
 import logging
-
-from mock import Mock, sentinel
+from unittest.mock import Mock, sentinel
 
 from mopidy.internal import network
 from mopidy.mpd import dispatcher, session

--- a/tests/mpd/test_status.py
+++ b/tests/mpd/test_status.py
@@ -11,7 +11,6 @@ from mopidy.mpd.protocol import status
 
 from tests import dummy_audio, dummy_backend, dummy_mixer
 
-
 PAUSED = PlaybackState.PAUSED
 PLAYING = PlaybackState.PLAYING
 STOPPED = PlaybackState.STOPPED

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -1,5 +1,4 @@
 import mock
-
 import pytest
 
 from mopidy.internal import path

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -1,4 +1,5 @@
-import mock
+from unittest import mock
+
 import pytest
 
 from mopidy.internal import path

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -1,7 +1,7 @@
 import logging
 import os
+from unittest import mock
 
-import mock
 import pytest
 import requests.exceptions
 import responses

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -2,17 +2,13 @@ import logging
 import os
 
 import mock
-
 import pytest
-
 import requests.exceptions
-
 import responses
 
 from mopidy import exceptions
 from mopidy.audio import scan
 from mopidy.stream import actor
-
 
 TIMEOUT = 1000
 PLAYLIST_URI = "http://example.com/listen.m3u"

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -1,7 +1,6 @@
 import argparse
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import commands
 

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -2,7 +2,6 @@ import pathlib
 from unittest import mock
 
 import pkg_resources
-
 import pytest
 
 from mopidy import config, exceptions, ext

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -1,6 +1,5 @@
 import unittest
-
-import mock
+from unittest import mock
 
 from mopidy import mixer
 


### PR DESCRIPTION
This PR replaces the `mock` library from PyPI with `unittest.mock` from the standard library, as we now only support Python versions where `unittest.mock` is available.

It also sets up isort as it was used to quickly regroup the imports after some search and replace. As isort and black isn't perfect friends (three files are handled differently), I'm just leaving the isort config as a tool without adding isort to tox/CI.