### PR TITLE
Switch to pytest assertions everywhere

### DIFF
--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -75,26 +75,26 @@ class AudioTest(BaseTest):
     def test_start_playback_existing_file(self):
         self.audio.prepare_change()
         self.audio.set_uri(self.uris[0])
-        self.assertTrue(self.audio.start_playback().get())
+        assert self.audio.start_playback().get()
 
     def test_start_playback_non_existing_file(self):
         self.possibly_trigger_fake_playback_error(self.uris[0] + "bogus")
 
         self.audio.prepare_change()
         self.audio.set_uri(self.uris[0] + "bogus")
-        self.assertFalse(self.audio.start_playback().get())
+        assert not self.audio.start_playback().get()
 
     def test_pause_playback_while_playing(self):
         self.audio.prepare_change()
         self.audio.set_uri(self.uris[0])
         self.audio.start_playback()
-        self.assertTrue(self.audio.pause_playback().get())
+        assert self.audio.pause_playback().get()
 
     def test_stop_playback_while_playing(self):
         self.audio.prepare_change()
         self.audio.set_uri(self.uris[0])
         self.audio.start_playback()
-        self.assertTrue(self.audio.stop_playback().get())
+        assert self.audio.stop_playback().get()
 
     @unittest.SkipTest
     def test_deliver_data(self):
@@ -157,10 +157,10 @@ class AudioEventTest(BaseTest):
         super().tearDown()
 
     def assertEvent(self, event, **kwargs):  # noqa: N802
-        self.assertIn((event, kwargs), self.listener.get_events().get())
+        assert (event, kwargs) in self.listener.get_events().get()
 
     def assertNotEvent(self, event, **kwargs):  # noqa: N802
-        self.assertNotIn((event, kwargs), self.listener.get_events().get())
+        assert (event, kwargs) not in self.listener.get_events().get()
 
     # TODO: test without uri set, with bad uri and gapless...
     # TODO: playing->playing triggered by seek should be removed
@@ -418,7 +418,7 @@ class AudioEventTest(BaseTest):
         if not event.wait(timeout=1.0):
             self.fail("End of stream not reached within deadline")
 
-        self.assertFalse(self.audio.get_current_tags().get())
+        assert not self.audio.get_current_tags().get()
 
     def test_gapless(self):
         uris = self.uris[1:]
@@ -448,16 +448,16 @@ class AudioEventTest(BaseTest):
 
         # Check that events counts check out.
         keys = [k for k, v in self.listener.get_events().get()]
-        self.assertEqual(2, keys.count("stream_changed"))
-        self.assertEqual(2, keys.count("position_changed"))
-        self.assertEqual(1, keys.count("state_changed"))
-        self.assertEqual(1, keys.count("reached_end_of_stream"))
+        assert 2 == keys.count('stream_changed')
+        assert 2 == keys.count('position_changed')
+        assert 1 == keys.count('state_changed')
+        assert 1 == keys.count('reached_end_of_stream')
 
         # TODO: test tag states within gaples
 
     # TODO: this does not belong in this testcase
     def test_current_tags_are_blank_to_begin_with(self):
-        self.assertFalse(self.audio.get_current_tags().get())
+        assert not self.audio.get_current_tags().get()
 
     def test_current_tags_blank_after_end_of_stream(self):
         event = self.listener.wait("reached_end_of_stream").get()
@@ -472,7 +472,7 @@ class AudioEventTest(BaseTest):
         if not event.wait(timeout=1.0):
             self.fail("EOS not received")
 
-        self.assertFalse(self.audio.get_current_tags().get())
+        assert not self.audio.get_current_tags().get()
 
     def test_current_tags_stored(self):
         event = self.listener.wait("reached_end_of_stream").get()
@@ -493,7 +493,7 @@ class AudioEventTest(BaseTest):
         if not event.wait(timeout=1.0):
             self.fail("EOS not received")
 
-        self.assertTrue(tags[0])
+        assert tags[0]
 
     # TODO: test that we reset when we expect between songs
 
@@ -508,8 +508,8 @@ class MixerTest(BaseTest):
     @unittest.SkipTest
     def test_set_mute(self):
         for value in (True, False):
-            self.assertTrue(self.audio.set_mute(value).get())
-            self.assertEqual(value, self.audio.get_mute().get())
+            assert self.audio.set_mute(value).get()
+            assert value == self.audio.get_mute().get()
 
     @unittest.SkipTest
     def test_set_state_encapsulation(self):
@@ -529,14 +529,14 @@ class AudioStateTest(unittest.TestCase):
         self.audio = audio.Audio(config=None, mixer=None)
 
     def test_state_starts_as_stopped(self):
-        self.assertEqual(audio.PlaybackState.STOPPED, self.audio.state)
+        assert audio.PlaybackState.STOPPED == self.audio.state
 
     def test_state_does_not_change_when_in_gst_ready_state(self):
         self.audio._handler.on_playbin_state_changed(
             Gst.State.NULL, Gst.State.READY, Gst.State.VOID_PENDING
         )
 
-        self.assertEqual(audio.PlaybackState.STOPPED, self.audio.state)
+        assert audio.PlaybackState.STOPPED == self.audio.state
 
     def test_state_changes_from_stopped_to_playing_on_play(self):
         self.audio._handler.on_playbin_state_changed(
@@ -549,7 +549,7 @@ class AudioStateTest(unittest.TestCase):
             Gst.State.PAUSED, Gst.State.PLAYING, Gst.State.VOID_PENDING
         )
 
-        self.assertEqual(audio.PlaybackState.PLAYING, self.audio.state)
+        assert audio.PlaybackState.PLAYING == self.audio.state
 
     def test_state_changes_from_playing_to_paused_on_pause(self):
         self.audio.state = audio.PlaybackState.PLAYING
@@ -558,7 +558,7 @@ class AudioStateTest(unittest.TestCase):
             Gst.State.PLAYING, Gst.State.PAUSED, Gst.State.VOID_PENDING
         )
 
-        self.assertEqual(audio.PlaybackState.PAUSED, self.audio.state)
+        assert audio.PlaybackState.PAUSED == self.audio.state
 
     def test_state_changes_from_playing_to_stopped_on_stop(self):
         self.audio.state = audio.PlaybackState.PLAYING
@@ -573,7 +573,7 @@ class AudioStateTest(unittest.TestCase):
         # self.audio._handler.on_playbin_state_changed(
         #     Gst.State.READY, Gst.State.NULL, Gst.State.VOID_PENDING)
 
-        self.assertEqual(audio.PlaybackState.STOPPED, self.audio.state)
+        assert audio.PlaybackState.STOPPED == self.audio.state
 
 
 class AudioBufferingTest(unittest.TestCase):
@@ -589,7 +589,7 @@ class AudioBufferingTest(unittest.TestCase):
 
         self.audio._handler.on_buffering(0)
         playbin.set_state.assert_called_with(Gst.State.PAUSED)
-        self.assertTrue(self.audio._buffering)
+        assert self.audio._buffering
 
     def test_stay_paused_when_buffering_finished(self):
         playbin = self.audio._playbin
@@ -598,8 +598,8 @@ class AudioBufferingTest(unittest.TestCase):
         playbin.set_state.reset_mock()
 
         self.audio._handler.on_buffering(100)
-        self.assertEqual(playbin.set_state.call_count, 0)
-        self.assertFalse(self.audio._buffering)
+        assert playbin.set_state.call_count == 0
+        assert not self.audio._buffering
 
     def test_change_to_paused_while_buffering(self):
         playbin = self.audio._playbin
@@ -613,8 +613,8 @@ class AudioBufferingTest(unittest.TestCase):
         playbin.set_state.reset_mock()
 
         self.audio._handler.on_buffering(100)
-        self.assertEqual(playbin.set_state.call_count, 0)
-        self.assertFalse(self.audio._buffering)
+        assert playbin.set_state.call_count == 0
+        assert not self.audio._buffering
 
     def test_change_to_stopped_while_buffering(self):
         playbin = self.audio._playbin
@@ -628,4 +628,4 @@ class AudioBufferingTest(unittest.TestCase):
 
         self.audio.stop_playback()
         playbin.set_state.assert_called_with(Gst.State.NULL)
-        self.assertFalse(self.audio._buffering)
+        assert not self.audio._buffering

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -448,10 +448,10 @@ class AudioEventTest(BaseTest):
 
         # Check that events counts check out.
         keys = [k for k, v in self.listener.get_events().get()]
-        assert 2 == keys.count('stream_changed')
-        assert 2 == keys.count('position_changed')
-        assert 1 == keys.count('state_changed')
-        assert 1 == keys.count('reached_end_of_stream')
+        assert keys.count("stream_changed") == 2
+        assert keys.count("position_changed") == 2
+        assert keys.count("state_changed") == 1
+        assert keys.count("reached_end_of_stream") == 1
 
         # TODO: test tag states within gaples
 
@@ -509,7 +509,7 @@ class MixerTest(BaseTest):
     def test_set_mute(self):
         for value in (True, False):
             assert self.audio.set_mute(value).get()
-            assert value == self.audio.get_mute().get()
+            assert self.audio.get_mute().get() == value
 
     @unittest.SkipTest
     def test_set_state_encapsulation(self):

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -29,7 +29,7 @@ class ScannerTest(unittest.TestCase):
 
     def check(self, name, key, value):
         name = path_to_data_dir(name)
-        self.assertEqual(self.result[name].tags[key], value)
+        assert self.result[name].tags[key] == value
 
     def check_if_missing_plugin(self):
         for path, result in self.result.items():
@@ -41,14 +41,14 @@ class ScannerTest(unittest.TestCase):
     def test_tags_is_set(self):
         self.scan(self.find("scanner/simple"))
 
-        self.assertTrue(list(self.result.values())[0].tags)
+        assert list(self.result.values())[0].tags
 
     def test_errors_is_not_set(self):
         self.scan(self.find("scanner/simple"))
 
         self.check_if_missing_plugin()
 
-        self.assertTrue(not self.errors)
+        assert (not self.errors)
 
     def test_duration_is_set(self):
         self.scan(self.find("scanner/simple"))
@@ -57,8 +57,8 @@ class ScannerTest(unittest.TestCase):
 
         ogg = path_to_data_dir("scanner/simple/song1.ogg")
         mp3 = path_to_data_dir("scanner/simple/song1.mp3")
-        self.assertEqual(self.result[mp3].duration, 4680)
-        self.assertEqual(self.result[ogg].duration, 4680)
+        assert self.result[mp3].duration == 4680
+        assert self.result[ogg].duration == 4680
 
     def test_artist_is_set(self):
         self.scan(self.find("scanner/simple"))
@@ -86,11 +86,11 @@ class ScannerTest(unittest.TestCase):
 
     def test_nonexistant_dir_does_not_fail(self):
         self.scan(self.find("scanner/does-not-exist"))
-        self.assertTrue(not self.errors)
+        assert (not self.errors)
 
     def test_other_media_is_ignored(self):
         self.scan(self.find("scanner/image"))
-        self.assertFalse(list(self.result.values())[0].playable)
+        assert not list(self.result.values())[0].playable
 
     def test_log_file_that_gst_thinks_is_mpeg_1_is_ignored(self):
         self.scan([path_to_data_dir("scanner/example.log")])
@@ -98,23 +98,23 @@ class ScannerTest(unittest.TestCase):
         self.check_if_missing_plugin()
 
         log = path_to_data_dir("scanner/example.log")
-        self.assertIsNone(self.result[log].duration)
+        assert self.result[log].duration is None
 
     def test_empty_wav_file(self):
         self.scan([path_to_data_dir("scanner/empty.wav")])
         wav = path_to_data_dir("scanner/empty.wav")
-        self.assertEqual(self.result[wav].duration, 0)
+        assert self.result[wav].duration == 0
 
     def test_uri_list(self):
         path = path_to_data_dir("scanner/playlist.m3u")
         self.scan([path])
-        self.assertEqual(self.result[path].mime, "text/uri-list")
+        assert self.result[path].mime == 'text/uri-list'
 
     def test_text_plain(self):
         # GStreamer decode bin hardcodes bad handling of text plain :/
         path = path_to_data_dir("scanner/plain.txt")
         self.scan([path])
-        self.assertIn(path, self.errors)
+        assert path in self.errors
 
     @unittest.SkipTest
     def test_song_without_time_is_handeled(self):

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -48,7 +48,7 @@ class ScannerTest(unittest.TestCase):
 
         self.check_if_missing_plugin()
 
-        assert (not self.errors)
+        assert not self.errors
 
     def test_duration_is_set(self):
         self.scan(self.find("scanner/simple"))
@@ -86,7 +86,7 @@ class ScannerTest(unittest.TestCase):
 
     def test_nonexistant_dir_does_not_fail(self):
         self.scan(self.find("scanner/does-not-exist"))
-        assert (not self.errors)
+        assert not self.errors
 
     def test_other_media_is_ignored(self):
         self.scan(self.find("scanner/image"))
@@ -108,7 +108,7 @@ class ScannerTest(unittest.TestCase):
     def test_uri_list(self):
         path = path_to_data_dir("scanner/playlist.m3u")
         self.scan([path])
-        assert self.result[path].mime == 'text/uri-list'
+        assert self.result[path].mime == "text/uri-list"
 
     def test_text_plain(self):
         # GStreamer decode bin hardcodes bad handling of text plain :/

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -137,7 +137,7 @@ class TagsToTrackTest(unittest.TestCase):
 
     def check(self, expected):
         actual = tags.convert_tags_to_track(self.tags)
-        self.assertEqual(expected, actual)
+        assert expected == actual
 
     def test_track(self):
         self.check(self.track)

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -9,7 +9,7 @@ class LibraryTest(unittest.TestCase):
     def test_default_get_images_impl(self):
         library = dummy_backend.DummyLibraryProvider(backend=None)
 
-        self.assertEqual(library.get_images(["trackuri"]), {})
+        assert library.get_images(["trackuri"]) == {}
 
 
 class PlaylistsTest(unittest.TestCase):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -8,86 +8,86 @@ from tests import path_to_data_dir
 
 class LoadConfigTest(unittest.TestCase):
     def test_load_nothing(self):
-        self.assertEqual({}, config._load([], [], []))
+        assert {} == config._load([], [], [])
 
     def test_load_missing_file(self):
         file0 = path_to_data_dir("file0.conf")
         result = config._load([file0], [], [])
-        self.assertEqual({}, result)
+        assert {} == result
 
     @mock.patch("os.access")
     def test_load_nonreadable_file(self, access_mock):
         access_mock.return_value = False
         file1 = path_to_data_dir("file1.conf")
         result = config._load([file1], [], [])
-        self.assertEqual({}, result)
+        assert {} == result
 
     def test_load_single_default(self):
         default = b"[foo]\nbar = baz"
         expected = {"foo": {"bar": "baz"}}
         result = config._load([], [default], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_unicode_default(self):
         default = "[foo]\nbar = æøå"
         expected = {"foo": {"bar": "æøå"}}
         result = config._load([], [default], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_defaults(self):
         default1 = b"[foo]\nbar = baz"
         default2 = b"[foo2]\n"
         expected = {"foo": {"bar": "baz"}, "foo2": {}}
         result = config._load([], [default1, default2], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_single_override(self):
         override = ("foo", "bar", "baz")
         expected = {"foo": {"bar": "baz"}}
         result = config._load([], [], [override])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_overrides(self):
         override1 = ("foo", "bar", "baz")
         override2 = ("foo2", "bar", "baz")
         expected = {"foo": {"bar": "baz"}, "foo2": {"bar": "baz"}}
         result = config._load([], [], [override1, override2])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_single_file(self):
         file1 = path_to_data_dir("file1.conf")
         expected = {"foo": {"bar": "baz"}}
         result = config._load([file1], [], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_files(self):
         file1 = path_to_data_dir("file1.conf")
         file2 = path_to_data_dir("file2.conf")
         expected = {"foo": {"bar": "baz"}, "foo2": {"bar": "baz"}}
         result = config._load([file1, file2], [], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_directory(self):
         directory = path_to_data_dir("conf1.d")
         expected = {"foo": {"bar": "baz"}, "foo2": {"bar": "baz"}}
         result = config._load([directory], [], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_directory_only_conf_files(self):
         directory = path_to_data_dir("conf2.d")
         expected = {"foo": {"bar": "baz"}}
         result = config._load([directory], [], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_file_with_utf8(self):
         expected = {"foo": {"bar": "æøå"}}
         result = config._load([path_to_data_dir("file3.conf")], [], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_load_file_with_error(self):
         expected = {"foo": {"bar": "baz"}}
         result = config._load([path_to_data_dir("file4.conf")], [], [])
-        self.assertEqual(expected, result)
+        assert expected == result
 
 
 class ValidateTest(unittest.TestCase):
@@ -97,33 +97,33 @@ class ValidateTest(unittest.TestCase):
 
     def test_empty_config_no_schemas(self):
         conf, errors = config._validate({}, [])
-        self.assertEqual({}, conf)
-        self.assertEqual({}, errors)
+        assert {} == conf
+        assert {} == errors
 
     def test_config_no_schemas(self):
         raw_config = {"foo": {"bar": "baz"}}
         conf, errors = config._validate(raw_config, [])
-        self.assertEqual({}, conf)
-        self.assertEqual({}, errors)
+        assert {} == conf
+        assert {} == errors
 
     def test_empty_config_single_schema(self):
         conf, errors = config._validate({}, [self.schema])
-        self.assertEqual({"foo": {"bar": None}}, conf)
-        self.assertEqual({"foo": {"bar": "config key not found."}}, errors)
+        assert {"foo": {"bar": None}} == conf
+        assert {"foo": {"bar": "config key not found."}} == errors
 
     def test_config_single_schema(self):
         raw_config = {"foo": {"bar": "baz"}}
         conf, errors = config._validate(raw_config, [self.schema])
-        self.assertEqual({"foo": {"bar": "baz"}}, conf)
-        self.assertEqual({}, errors)
+        assert {"foo": {"bar": "baz"}} == conf
+        assert {} == errors
 
     def test_config_single_schema_config_error(self):
         raw_config = {"foo": {"bar": "baz"}}
         self.schema["bar"] = mock.Mock()
         self.schema["bar"].deserialize.side_effect = ValueError("bad")
         conf, errors = config._validate(raw_config, [self.schema])
-        self.assertEqual({"foo": {"bar": None}}, conf)
-        self.assertEqual({"foo": {"bar": "bad"}}, errors)
+        assert {"foo": {"bar": None}} == conf
+        assert {"foo": {"bar": "bad"}} == errors
 
     # TODO: add more tests
 
@@ -161,68 +161,54 @@ class PreProcessorTest(unittest.TestCase):
 
     def test_empty_config(self):
         result = config._preprocess("")
-        self.assertEqual(result, "[__COMMENTS__]")
+        assert result == "[__COMMENTS__]"
 
     def test_plain_section(self):
         result = config._preprocess("[section]\nfoo = bar")
-        self.assertEqual(result, "[__COMMENTS__]\n" "[section]\n" "foo = bar")
+        assert result == "[__COMMENTS__]\n[section]\nfoo = bar"
 
     def test_initial_comments(self):
         result = config._preprocess("; foobar")
-        self.assertEqual(result, "[__COMMENTS__]\n" "__SEMICOLON0__ = foobar")
+        assert result == "[__COMMENTS__]\n__SEMICOLON0__ = foobar"
 
         result = config._preprocess("# foobar")
-        self.assertEqual(result, "[__COMMENTS__]\n" "__HASH0__ = foobar")
+        assert result == "[__COMMENTS__]\n__HASH0__ = foobar"
 
         result = config._preprocess("; foo\n# bar")
-        self.assertEqual(
-            result,
-            "[__COMMENTS__]\n" "__SEMICOLON0__ = foo\n" "__HASH1__ = bar",
-        )
+        assert result == "[__COMMENTS__]\n__SEMICOLON0__ = foo\n__HASH1__ = bar"
 
     def test_initial_comment_inline_handling(self):
         result = config._preprocess("; foo ; bar ; baz")
-        self.assertEqual(
-            result,
-            "[__COMMENTS__]\n"
-            "__SEMICOLON0__ = foo\n"
-            "__INLINE1__ = bar\n"
-            "__INLINE2__ = baz",
+        assert result == (
+            "[__COMMENTS__]\n__SEMICOLON0__ = foo\n"
+            "__INLINE1__ = bar\n__INLINE2__ = baz"
         )
 
     def test_inline_semicolon_comment(self):
         result = config._preprocess("[section]\nfoo = bar ; baz")
-        self.assertEqual(
-            result,
-            "[__COMMENTS__]\n" "[section]\n" "foo = bar\n" "__INLINE0__ = baz",
+        assert (
+            result == "[__COMMENTS__]\n[section]\nfoo = bar\n__INLINE0__ = baz"
         )
 
     def test_no_inline_hash_comment(self):
         result = config._preprocess("[section]\nfoo = bar # baz")
-        self.assertEqual(
-            result, "[__COMMENTS__]\n" "[section]\n" "foo = bar # baz"
-        )
+        assert result == "[__COMMENTS__]\n[section]\nfoo = bar # baz"
 
     def test_section_extra_text(self):
         result = config._preprocess("[section] foobar")
-        self.assertEqual(
-            result, "[__COMMENTS__]\n" "[section]\n" "__SECTION0__ = foobar"
-        )
+        assert result == "[__COMMENTS__]\n[section]\n__SECTION0__ = foobar"
 
     def test_section_extra_text_inline_semicolon(self):
         result = config._preprocess("[section] foobar ; baz")
-        self.assertEqual(
-            result,
-            "[__COMMENTS__]\n"
-            "[section]\n"
-            "__SECTION0__ = foobar\n"
-            "__INLINE1__ = baz",
+        assert (
+            result
+            == "[__COMMENTS__]\n[section]\n__SECTION0__ = foobar\n__INLINE1__ = baz"
         )
 
     def test_conversion(self):
         """Tests all of the above cases at once."""
         result = config._preprocess(INPUT_CONFIG)
-        self.assertEqual(result, PROCESSED_CONFIG)
+        assert result == PROCESSED_CONFIG
 
 
 class PostProcessorTest(unittest.TestCase):
@@ -230,27 +216,27 @@ class PostProcessorTest(unittest.TestCase):
 
     def test_empty_config(self):
         result = config._postprocess("[__COMMENTS__]")
-        self.assertEqual(result, "")
+        assert result == ""
 
     def test_plain_section(self):
         result = config._postprocess(
             "[__COMMENTS__]\n" "[section]\n" "foo = bar"
         )
-        self.assertEqual(result, "[section]\nfoo = bar")
+        assert result == "[section]\nfoo = bar"
 
     def test_initial_comments(self):
         result = config._postprocess(
             "[__COMMENTS__]\n" "__SEMICOLON0__ = foobar"
         )
-        self.assertEqual(result, "; foobar")
+        assert result == "; foobar"
 
         result = config._postprocess("[__COMMENTS__]\n" "__HASH0__ = foobar")
-        self.assertEqual(result, "# foobar")
+        assert result == "# foobar"
 
         result = config._postprocess(
             "[__COMMENTS__]\n" "__SEMICOLON0__ = foo\n" "__HASH1__ = bar"
         )
-        self.assertEqual(result, "; foo\n# bar")
+        assert result == "; foo\n# bar"
 
     def test_initial_comment_inline_handling(self):
         result = config._postprocess(
@@ -259,25 +245,23 @@ class PostProcessorTest(unittest.TestCase):
             "__INLINE1__ = bar\n"
             "__INLINE2__ = baz"
         )
-        self.assertEqual(result, "; foo ; bar ; baz")
+        assert result == "; foo ; bar ; baz"
 
     def test_inline_semicolon_comment(self):
         result = config._postprocess(
             "[__COMMENTS__]\n" "[section]\n" "foo = bar\n" "__INLINE0__ = baz"
         )
-        self.assertEqual(result, "[section]\nfoo = bar ; baz")
+        assert result == "[section]\nfoo = bar ; baz"
 
     def test_no_inline_hash_comment(self):
         result = config._preprocess("[section]\nfoo = bar # baz")
-        self.assertEqual(
-            result, "[__COMMENTS__]\n" "[section]\n" "foo = bar # baz"
-        )
+        assert result == "[__COMMENTS__]\n[section]\nfoo = bar # baz"
 
     def test_section_extra_text(self):
         result = config._postprocess(
             "[__COMMENTS__]\n" "[section]\n" "__SECTION0__ = foobar"
         )
-        self.assertEqual(result, "[section] foobar")
+        assert result == "[section] foobar"
 
     def test_section_extra_text_inline_semicolon(self):
         result = config._postprocess(
@@ -286,11 +270,11 @@ class PostProcessorTest(unittest.TestCase):
             "__SECTION0__ = foobar\n"
             "__INLINE1__ = baz"
         )
-        self.assertEqual(result, "[section] foobar ; baz")
+        assert result == "[section] foobar ; baz"
 
     def test_conversion(self):
         result = config._postprocess(PROCESSED_CONFIG)
-        self.assertEqual(result, INPUT_CONFIG)
+        assert result == INPUT_CONFIG
 
 
 def test_format_initial():

--- a/tests/config/test_schemas.py
+++ b/tests/config/test_schemas.py
@@ -22,42 +22,42 @@ class ConfigSchemaTest(unittest.TestCase):
         del self.values["foo"]
 
         result, errors = self.schema.deserialize(self.values)
-        self.assertEqual({"foo": any_unicode}, errors)
-        self.assertIsNone(result.pop("foo"))
-        self.assertIsNotNone(result.pop("bar"))
-        self.assertIsNotNone(result.pop("baz"))
-        self.assertEqual({}, result)
+        assert {"foo": any_unicode} == errors
+        assert result.pop("foo") is None
+        assert result.pop("bar") is not None
+        assert result.pop("baz") is not None
+        assert {} == result
 
     def test_deserialize_with_extra_value(self):
         self.values["extra"] = "123"
 
         result, errors = self.schema.deserialize(self.values)
-        self.assertEqual({"extra": any_unicode}, errors)
-        self.assertIsNotNone(result.pop("foo"))
-        self.assertIsNotNone(result.pop("bar"))
-        self.assertIsNotNone(result.pop("baz"))
-        self.assertEqual({}, result)
+        assert {"extra": any_unicode} == errors
+        assert result.pop("foo") is not None
+        assert result.pop("bar") is not None
+        assert result.pop("baz") is not None
+        assert {} == result
 
     def test_deserialize_with_deserialization_error(self):
         self.schema["foo"].deserialize.side_effect = ValueError("failure")
 
         result, errors = self.schema.deserialize(self.values)
-        self.assertEqual({"foo": "failure"}, errors)
-        self.assertIsNone(result.pop("foo"))
-        self.assertIsNotNone(result.pop("bar"))
-        self.assertIsNotNone(result.pop("baz"))
-        self.assertEqual({}, result)
+        assert {"foo": "failure"} == errors
+        assert result.pop("foo") is None
+        assert result.pop("bar") is not None
+        assert result.pop("baz") is not None
+        assert {} == result
 
     def test_deserialize_with_multiple_deserialization_errors(self):
         self.schema["foo"].deserialize.side_effect = ValueError("failure")
         self.schema["bar"].deserialize.side_effect = ValueError("other")
 
         result, errors = self.schema.deserialize(self.values)
-        self.assertEqual({"foo": "failure", "bar": "other"}, errors)
-        self.assertIsNone(result.pop("foo"))
-        self.assertIsNone(result.pop("bar"))
-        self.assertIsNotNone(result.pop("baz"))
-        self.assertEqual({}, result)
+        assert {"foo": "failure", "bar": "other"} == errors
+        assert result.pop("foo") is None
+        assert result.pop("bar") is None
+        assert result.pop("baz") is not None
+        assert {} == result
 
     def test_deserialize_deserialization_unknown_and_missing_errors(self):
         self.values["extra"] = "123"
@@ -65,22 +65,22 @@ class ConfigSchemaTest(unittest.TestCase):
         del self.values["baz"]
 
         result, errors = self.schema.deserialize(self.values)
-        self.assertIn("unknown", errors["extra"])
-        self.assertNotIn("foo", errors)
-        self.assertIn("failure", errors["bar"])
-        self.assertIn("not found", errors["baz"])
+        assert "unknown" in errors["extra"]
+        assert "foo" not in errors
+        assert "failure" in errors["bar"]
+        assert "not found" in errors["baz"]
 
-        self.assertNotIn("unknown", result)
-        self.assertIn("foo", result)
-        self.assertIsNone(result["bar"])
-        self.assertIsNone(result["baz"])
+        assert "unknown" not in result
+        assert "foo" in result
+        assert result["bar"] is None
+        assert result["baz"] is None
 
     def test_deserialize_deprecated_value(self):
         self.schema["foo"] = types.Deprecated()
 
         result, errors = self.schema.deserialize(self.values)
-        self.assertEqual(["bar", "baz"], sorted(result.keys()))
-        self.assertNotIn("foo", errors)
+        assert ["bar", "baz"] == sorted(result.keys())
+        assert "foo" not in errors
 
 
 class MapConfigSchemaTest(unittest.TestCase):
@@ -88,8 +88,8 @@ class MapConfigSchemaTest(unittest.TestCase):
         schema = schemas.MapConfigSchema("test", types.LogLevel())
         result, errors = schema.deserialize({"foo.bar": "DEBUG", "baz": "INFO"})
 
-        self.assertEqual(logging.DEBUG, result["foo.bar"])
-        self.assertEqual(logging.INFO, result["baz"])
+        assert logging.DEBUG == result["foo.bar"]
+        assert logging.INFO == result["baz"]
 
 
 class DidYouMeanTest(unittest.TestCase):
@@ -97,16 +97,16 @@ class DidYouMeanTest(unittest.TestCase):
         choices = ("enabled", "username", "password", "bitrate", "timeout")
 
         suggestion = schemas._did_you_mean("bitrate", choices)
-        self.assertEqual(suggestion, "bitrate")
+        assert suggestion == "bitrate"
 
         suggestion = schemas._did_you_mean("bitrote", choices)
-        self.assertEqual(suggestion, "bitrate")
+        assert suggestion == "bitrate"
 
         suggestion = schemas._did_you_mean("Bitrot", choices)
-        self.assertEqual(suggestion, "bitrate")
+        assert suggestion == "bitrate"
 
         suggestion = schemas._did_you_mean("BTROT", choices)
-        self.assertEqual(suggestion, "bitrate")
+        assert suggestion == "bitrate"
 
         suggestion = schemas._did_you_mean("btro", choices)
-        self.assertEqual(suggestion, None)
+        assert suggestion is None

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -33,8 +33,8 @@ class CoreActorTest(unittest.TestCase):
     def test_uri_schemes_has_uris_from_all_backends(self):
         result = self.core.get_uri_schemes()
 
-        self.assertIn("dummy1", result)
-        self.assertIn("dummy2", result)
+        assert "dummy1" in result
+        assert "dummy2" in result
 
     def test_backends_with_colliding_uri_schemes_fails(self):
         self.backend2.uri_schemes.get.return_value = ["dummy1", "dummy2"]
@@ -49,7 +49,7 @@ class CoreActorTest(unittest.TestCase):
         )
 
     def test_version(self):
-        self.assertEqual(self.core.get_version(), versioning.get_version())
+        assert self.core.get_version() == versioning.get_version()
 
     @mock.patch("mopidy.core.playback.listener.CoreListener", spec=CoreListener)
     def test_state_changed(self, listener_mock):

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -30,73 +30,73 @@ class BackendEventsTest(unittest.TestCase):
     def test_forwards_backend_playlists_loaded_event_to_frontends(self, send):
         self.core.playlists_loaded().get()
 
-        self.assertEqual(send.call_args[0][0], "playlists_loaded")
+        assert send.call_args[0][0] == "playlists_loaded"
 
     def test_forwards_mixer_volume_changed_event_to_frontends(self, send):
         self.core.volume_changed(volume=60).get()
 
-        self.assertEqual(send.call_args[0][0], "volume_changed")
-        self.assertEqual(send.call_args[1]["volume"], 60)
+        assert send.call_args[0][0] == "volume_changed"
+        assert send.call_args[1]["volume"] == 60
 
     def test_forwards_mixer_mute_changed_event_to_frontends(self, send):
         self.core.mute_changed(mute=True).get()
 
-        self.assertEqual(send.call_args[0][0], "mute_changed")
-        self.assertEqual(send.call_args[1]["mute"], True)
+        assert send.call_args[0][0] == "mute_changed"
+        assert send.call_args[1]["mute"] is True
 
     def test_tracklist_add_sends_tracklist_changed_event(self, send):
         self.core.tracklist.add(uris=["dummy:a"]).get()
 
-        self.assertEqual(send.call_args[0][0], "tracklist_changed")
+        assert send.call_args[0][0] == "tracklist_changed"
 
     def test_tracklist_clear_sends_tracklist_changed_event(self, send):
         self.core.tracklist.add(uris=["dummy:a"]).get()
 
         self.core.tracklist.clear().get()
 
-        self.assertEqual(send.call_args[0][0], "tracklist_changed")
+        assert send.call_args[0][0] == "tracklist_changed"
 
     def test_tracklist_move_sends_tracklist_changed_event(self, send):
         self.core.tracklist.add(uris=["dummy:a", "dummy:b"]).get()
 
         self.core.tracklist.move(0, 1, 1).get()
 
-        self.assertEqual(send.call_args[0][0], "tracklist_changed")
+        assert send.call_args[0][0] == "tracklist_changed"
 
     def test_tracklist_remove_sends_tracklist_changed_event(self, send):
         self.core.tracklist.add(uris=["dummy:a"]).get()
 
         self.core.tracklist.remove({"uri": ["dummy:a"]}).get()
 
-        self.assertEqual(send.call_args[0][0], "tracklist_changed")
+        assert send.call_args[0][0] == "tracklist_changed"
 
     def test_tracklist_shuffle_sends_tracklist_changed_event(self, send):
         self.core.tracklist.add(uris=["dummy:a", "dummy:b"]).get()
 
         self.core.tracklist.shuffle().get()
 
-        self.assertEqual(send.call_args[0][0], "tracklist_changed")
+        assert send.call_args[0][0] == "tracklist_changed"
 
     def test_playlists_refresh_sends_playlists_loaded_event(self, send):
         self.core.playlists.refresh().get()
 
-        self.assertEqual(send.call_args[0][0], "playlists_loaded")
+        assert send.call_args[0][0] == "playlists_loaded"
 
     def test_playlists_refresh_uri_sends_playlists_loaded_event(self, send):
         self.core.playlists.refresh(uri_scheme="dummy").get()
 
-        self.assertEqual(send.call_args[0][0], "playlists_loaded")
+        assert send.call_args[0][0] == "playlists_loaded"
 
     def test_playlists_create_sends_playlist_changed_event(self, send):
         self.core.playlists.create("foo").get()
 
-        self.assertEqual(send.call_args[0][0], "playlist_changed")
+        assert send.call_args[0][0] == "playlist_changed"
 
     def test_playlists_delete_sends_playlist_deleted_event(self, send):
         playlist = self.core.playlists.create("foo").get()
         self.core.playlists.delete(playlist.uri).get()
 
-        self.assertEqual(send.call_args[0][0], "playlist_deleted")
+        assert send.call_args[0][0] == "playlist_deleted"
 
     def test_playlists_save_sends_playlist_changed_event(self, send):
         playlist = self.core.playlists.create("foo").get()
@@ -104,4 +104,4 @@ class BackendEventsTest(unittest.TestCase):
 
         self.core.playlists.save(playlist).get()
 
-        self.assertEqual(send.call_args[0][0], "playlist_changed")
+        assert send.call_args[0][0] == "playlist_changed"

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -20,19 +20,19 @@ class PlaybackHistoryTest(unittest.TestCase):
 
     def test_add_track(self):
         self.history._add_track(self.tracks[0])
-        self.assertEqual(self.history.get_length(), 1)
+        assert self.history.get_length() == 1
 
         self.history._add_track(self.tracks[1])
-        self.assertEqual(self.history.get_length(), 2)
+        assert self.history.get_length() == 2
 
         self.history._add_track(self.tracks[2])
-        self.assertEqual(self.history.get_length(), 3)
+        assert self.history.get_length() == 3
 
     def test_non_tracks_are_rejected(self):
         with self.assertRaises(TypeError):
             self.history._add_track(object())
 
-        self.assertEqual(self.history.get_length(), 0)
+        assert self.history.get_length() == 0
 
     def test_history_entry_contents(self):
         track = self.tracks[0]
@@ -41,11 +41,11 @@ class PlaybackHistoryTest(unittest.TestCase):
         result = self.history.get_history()
         (timestamp, ref) = result[0]
 
-        self.assertIsInstance(timestamp, int)
-        self.assertEqual(track.uri, ref.uri)
-        self.assertIn(track.name, ref.name)
+        assert isinstance(timestamp, int)
+        assert track.uri == ref.uri
+        assert track.name in ref.name
         for artist in track.artists:
-            self.assertIn(artist.name, ref.name)
+            assert artist.name in ref.name
 
 
 class CoreHistorySaveLoadStateTest(unittest.TestCase):
@@ -68,10 +68,10 @@ class CoreHistorySaveLoadStateTest(unittest.TestCase):
 
         value = self.history._save_state()
 
-        self.assertEqual(len(value.history), 2)
+        assert len(value.history) == 2
         # last in, first out
-        self.assertEqual(value.history[0].track, self.refs[1])
-        self.assertEqual(value.history[1].track, self.refs[2])
+        assert value.history[0].track == self.refs[1]
+        assert value.history[1].track == self.refs[2]
 
     def test_load(self):
         state = HistoryState(
@@ -85,19 +85,19 @@ class CoreHistorySaveLoadStateTest(unittest.TestCase):
         self.history._load_state(state, coverage)
 
         hist = self.history.get_history()
-        self.assertEqual(len(hist), 3)
-        self.assertEqual(hist[0], (34, self.refs[0]))
-        self.assertEqual(hist[1], (45, self.refs[2]))
-        self.assertEqual(hist[2], (56, self.refs[1]))
+        assert len(hist) == 3
+        assert hist[0] == (34, self.refs[0])
+        assert hist[1] == (45, self.refs[2])
+        assert hist[2] == (56, self.refs[1])
 
         # after import, adding more tracks must be possible
         self.history._add_track(self.tracks[1])
         hist = self.history.get_history()
-        self.assertEqual(len(hist), 4)
-        self.assertEqual(hist[0][1], self.refs[1])
-        self.assertEqual(hist[1], (34, self.refs[0]))
-        self.assertEqual(hist[2], (45, self.refs[2]))
-        self.assertEqual(hist[3], (56, self.refs[1]))
+        assert len(hist) == 4
+        assert hist[0][1] == self.refs[1]
+        assert hist[1] == (34, self.refs[0])
+        assert hist[2] == (45, self.refs[2])
+        assert hist[3] == (56, self.refs[1])
 
     def test_load_invalid_type(self):
         with self.assertRaises(TypeError):

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -42,15 +42,15 @@ class BaseCoreLibraryTest(unittest.TestCase):
 # TODO: split by method
 class CoreLibraryTest(BaseCoreLibraryTest):
     def test_get_images_returns_empty_dict_for_no_uris(self):
-        self.assertEqual({}, self.core.library.get_images([]))
+        assert {} == self.core.library.get_images([])
 
     def test_get_images_returns_empty_result_for_unknown_uri(self):
         result = self.core.library.get_images(["dummy4:track"])
-        self.assertEqual({"dummy4:track": tuple()}, result)
+        assert {"dummy4:track": tuple()} == result
 
     def test_get_images_returns_empty_result_for_library_less_uri(self):
         result = self.core.library.get_images(["dummy3:track"])
-        self.assertEqual({"dummy3:track": tuple()}, result)
+        assert {"dummy3:track": tuple()} == result
 
     def test_get_images_maps_uri_to_backend(self):
         self.core.library.get_images(["dummy1:track"])
@@ -68,7 +68,7 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         }
 
         result = self.core.library.get_images(["dummy1:track"])
-        self.assertEqual({"dummy1:track": (Image(uri="uri"),)}, result)
+        assert {"dummy1:track": (Image(uri="uri"),)} == result
 
     def test_get_images_merges_results(self):
         self.library1.get_images.return_value.get.return_value = {
@@ -87,28 +87,25 @@ class CoreLibraryTest(BaseCoreLibraryTest):
             "dummy3:track": tuple(),
             "dummy4:track": tuple(),
         }
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_browse_root_returns_dir_ref_for_each_lib_with_root_dir_name(self):
         result = self.core.library.browse(None)
 
-        self.assertEqual(
-            result,
-            [
-                Ref.directory(uri="dummy1:directory", name="dummy1"),
-                Ref.directory(uri="dummy2:directory", name="dummy2"),
-            ],
-        )
-        self.assertFalse(self.library1.browse.called)
-        self.assertFalse(self.library2.browse.called)
-        self.assertFalse(self.backend3.library.browse.called)
+        assert result == [
+            Ref.directory(uri="dummy1:directory", name="dummy1"),
+            Ref.directory(uri="dummy2:directory", name="dummy2"),
+        ]
+        assert not self.library1.browse.called
+        assert not self.library2.browse.called
+        assert not self.backend3.library.browse.called
 
     def test_browse_empty_string_returns_nothing(self):
         result = self.core.library.browse("")
 
-        self.assertEqual(result, [])
-        self.assertFalse(self.library1.browse.called)
-        self.assertFalse(self.library2.browse.called)
+        assert result == []
+        assert not self.library1.browse.called
+        assert not self.library2.browse.called
 
     def test_browse_dummy1_selects_dummy1_backend(self):
         self.library1.browse.return_value.get.return_value = [
@@ -118,8 +115,8 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
         self.core.library.browse("dummy1:directory:/foo")
 
-        self.assertEqual(self.library1.browse.call_count, 1)
-        self.assertEqual(self.library2.browse.call_count, 0)
+        assert self.library1.browse.call_count == 1
+        assert self.library2.browse.call_count == 0
         self.library1.browse.assert_called_with("dummy1:directory:/foo")
 
     def test_browse_dummy2_selects_dummy2_backend(self):
@@ -130,16 +127,16 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
         self.core.library.browse("dummy2:directory:/bar")
 
-        self.assertEqual(self.library1.browse.call_count, 0)
-        self.assertEqual(self.library2.browse.call_count, 1)
+        assert self.library1.browse.call_count == 0
+        assert self.library2.browse.call_count == 1
         self.library2.browse.assert_called_with("dummy2:directory:/bar")
 
     def test_browse_dummy3_returns_nothing(self):
         result = self.core.library.browse("dummy3:test")
 
-        self.assertEqual(result, [])
-        self.assertEqual(self.library1.browse.call_count, 0)
-        self.assertEqual(self.library2.browse.call_count, 0)
+        assert result == []
+        assert self.library1.browse.call_count == 0
+        assert self.library2.browse.call_count == 0
 
     def test_browse_dir_returns_subdirs_and_tracks(self):
         self.library1.browse.return_value.get.return_value = [
@@ -148,16 +145,13 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         ]
 
         result = self.core.library.browse("dummy1:directory:/foo")
-        self.assertEqual(
-            result,
-            [
-                Ref.directory(uri="dummy1:directory:/foo/bar", name="Bar"),
-                Ref.track(uri="dummy1:track:/foo/baz.mp3", name="Baz"),
-            ],
-        )
+        assert result == [
+            Ref.directory(uri="dummy1:directory:/foo/bar", name="Bar"),
+            Ref.track(uri="dummy1:track:/foo/baz.mp3", name="Baz"),
+        ]
 
     def test_lookup_returns_empty_dict_for_no_uris(self):
-        self.assertEqual({}, self.core.library.lookup(uris=[]))
+        assert {} == self.core.library.lookup(uris=[])
 
     def test_lookup_can_handle_uris(self):
         track1 = Track(uri="dummy1:a", name="abc")
@@ -167,14 +161,19 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         self.library2.lookup().get.return_value = [track2]
 
         result = self.core.library.lookup(uris=["dummy1:a", "dummy2:a"])
-        self.assertEqual(result, {"dummy2:a": [track2], "dummy1:a": [track1]})
+        assert result == {
+            "dummy2:a": [track2],
+            "dummy1:a": [track1],
+        }
 
     def test_lookup_uris_returns_empty_list_for_dummy3_track(self):
         result = self.core.library.lookup(uris=["dummy3:a"])
 
-        self.assertEqual(result, {"dummy3:a": []})
-        self.assertFalse(self.library1.lookup.called)
-        self.assertFalse(self.library2.lookup.called)
+        assert result == {
+            "dummy3:a": [],
+        }
+        assert not self.library1.lookup.called
+        assert not self.library2.lookup.called
 
     def test_lookup_ignores_tracks_without_uri_set(self):
         track1 = Track(uri="dummy1:a", name="abc")
@@ -183,25 +182,27 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         self.library1.lookup().get.return_value = [track1, track2]
 
         result = self.core.library.lookup(uris=["dummy1:a"])
-        self.assertEqual(result, {"dummy1:a": [track1]})
+        assert result == {
+            "dummy1:a": [track1],
+        }
 
     def test_refresh_with_uri_selects_dummy1_backend(self):
         self.core.library.refresh("dummy1:a")
 
         self.library1.refresh.assert_called_once_with("dummy1:a")
-        self.assertFalse(self.library2.refresh.called)
+        assert not self.library2.refresh.called
 
     def test_refresh_with_uri_selects_dummy2_backend(self):
         self.core.library.refresh("dummy2:a")
 
-        self.assertFalse(self.library1.refresh.called)
+        assert not self.library1.refresh.called
         self.library2.refresh.assert_called_once_with("dummy2:a")
 
     def test_refresh_with_uri_fails_silently_for_dummy3_uri(self):
         self.core.library.refresh("dummy3:a")
 
-        self.assertFalse(self.library1.refresh.called)
-        self.assertFalse(self.library2.refresh.called)
+        assert not self.library1.refresh.called
+        assert not self.library2.refresh.called
 
     def test_refresh_without_uri_calls_all_backends(self):
         self.core.library.refresh()
@@ -220,8 +221,8 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
         result = self.core.library.search({"any": ["a"]})
 
-        self.assertIn(result1, result)
-        self.assertIn(result2, result)
+        assert result1 in result
+        assert result2 in result
         self.library1.search.assert_called_once_with(
             query={"any": ["a"]}, uris=None, exact=False
         )
@@ -237,7 +238,7 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         self.library1.search.assert_called_once_with(
             query={"any": ["a"]}, uris=["dummy1:", "dummy1:foo"], exact=False
         )
-        self.assertFalse(self.library2.search.called)
+        assert not self.library2.search.called
 
     def test_search_with_uris_selects_both_backends(self):
         self.core.library.search(
@@ -260,8 +261,8 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
         result = self.core.library.search({"any": ["a"]})
 
-        self.assertIn(result1, result)
-        self.assertNotIn(None, result)
+        assert result1 in result
+        assert None not in result
         self.library1.search.assert_called_once_with(
             query={"any": ["a"]}, uris=None, exact=False
         )
@@ -280,8 +281,8 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
         result = self.core.library.search({"any": ["a"]})
 
-        self.assertIn(result1, result)
-        self.assertIn(result2, result)
+        assert result1 in result
+        assert result2 in result
         self.library1.search.assert_called_once_with(
             query={"any": ["a"]}, uris=None, exact=False
         )
@@ -342,27 +343,27 @@ class BrowseBadBackendTest(MockBackendCoreLibraryBase):
     def test_backend_raises_exception_for_root(self, logger):
         # Might happen if root_directory is a property for some weird reason.
         self.library.root_directory.get.side_effect = Exception
-        self.assertEqual([], self.core.library.browse(None))
+        assert [] == self.core.library.browse(None)
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none_for_root(self, logger):
         self.library.root_directory.get.return_value = None
-        self.assertEqual([], self.core.library.browse(None))
+        assert [] == self.core.library.browse(None)
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
     def test_backend_returns_wrong_type_for_root(self, logger):
         self.library.root_directory.get.return_value = 123
-        self.assertEqual([], self.core.library.browse(None))
+        assert [] == self.core.library.browse(None)
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
     def test_backend_raises_exception_for_browse(self, logger):
         self.library.browse.return_value.get.side_effect = Exception
-        self.assertEqual([], self.core.library.browse("dummy:directory"))
+        assert [] == self.core.library.browse("dummy:directory")
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_wrong_type_for_browse(self, logger):
         self.library.browse.return_value.get.return_value = [123]
-        self.assertEqual([], self.core.library.browse("dummy:directory"))
+        assert [] == self.core.library.browse("dummy:directory")
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -370,22 +371,22 @@ class BrowseBadBackendTest(MockBackendCoreLibraryBase):
 class GetDistinctBadBackendTest(MockBackendCoreLibraryBase):
     def test_backend_raises_exception(self, logger):
         self.library.get_distinct.return_value.get.side_effect = Exception
-        self.assertEqual(set(), self.core.library.get_distinct("artist"))
+        assert set() == self.core.library.get_distinct("artist")
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         self.library.get_distinct.return_value.get.return_value = None
-        self.assertEqual(set(), self.core.library.get_distinct("artist"))
-        self.assertFalse(logger.error.called)
+        assert set() == self.core.library.get_distinct("artist")
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         self.library.get_distinct.return_value.get.return_value = "abc"
-        self.assertEqual(set(), self.core.library.get_distinct("artist"))
+        assert set() == self.core.library.get_distinct("artist")
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
     def test_backend_returns_iterable_containing_wrong_types(self, logger):
         self.library.get_distinct.return_value.get.return_value = [1, 2, 3]
-        self.assertEqual(set(), self.core.library.get_distinct("artist"))
+        assert set() == self.core.library.get_distinct("artist")
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -394,37 +395,37 @@ class GetImagesBadBackendTest(MockBackendCoreLibraryBase):
     def test_backend_raises_exception(self, logger):
         uri = "dummy:/1"
         self.library.get_images.return_value.get.side_effect = Exception
-        self.assertEqual({uri: tuple()}, self.core.library.get_images([uri]))
+        assert {uri: tuple()} == self.core.library.get_images([uri])
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         uri = "dummy:/1"
         self.library.get_images.return_value.get.return_value = None
-        self.assertEqual({uri: tuple()}, self.core.library.get_images([uri]))
-        self.assertFalse(logger.error.called)
+        assert {uri: tuple()} == self.core.library.get_images([uri])
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         uri = "dummy:/1"
         self.library.get_images.return_value.get.return_value = "abc"
-        self.assertEqual({uri: tuple()}, self.core.library.get_images([uri]))
+        assert {uri: tuple()} == self.core.library.get_images([uri])
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
     def test_backend_returns_mapping_containing_wrong_types(self, logger):
         uri = "dummy:/1"
         self.library.get_images.return_value.get.return_value = {uri: "abc"}
-        self.assertEqual({uri: tuple()}, self.core.library.get_images([uri]))
+        assert {uri: tuple()} == self.core.library.get_images([uri])
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
     def test_backend_returns_mapping_containing_none(self, logger):
         uri = "dummy:/1"
         self.library.get_images.return_value.get.return_value = {uri: None}
-        self.assertEqual({uri: tuple()}, self.core.library.get_images([uri]))
+        assert {uri: tuple()} == self.core.library.get_images([uri])
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
     def test_backend_returns_unknown_uri(self, logger):
         uri = "dummy:/1"
         self.library.get_images.return_value.get.return_value = {"foo": []}
-        self.assertEqual({uri: tuple()}, self.core.library.get_images([uri]))
+        assert {uri: tuple()} == self.core.library.get_images([uri])
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -433,25 +434,25 @@ class LookupByUrisBadBackendTest(MockBackendCoreLibraryBase):
     def test_backend_raises_exception(self, logger):
         uri = "dummy:/1"
         self.library.lookup.return_value.get.side_effect = Exception
-        self.assertEqual({uri: []}, self.core.library.lookup(uris=[uri]))
+        assert {uri: []} == self.core.library.lookup(uris=[uri])
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         uri = "dummy:/1"
         self.library.lookup.return_value.get.return_value = None
-        self.assertEqual({uri: []}, self.core.library.lookup(uris=[uri]))
-        self.assertFalse(logger.error.called)
+        assert {uri: []} == self.core.library.lookup(uris=[uri])
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         uri = "dummy:/1"
         self.library.lookup.return_value.get.return_value = "abc"
-        self.assertEqual({uri: []}, self.core.library.lookup(uris=[uri]))
+        assert {uri: []} == self.core.library.lookup(uris=[uri])
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
     def test_backend_returns_iterable_containing_wrong_types(self, logger):
         uri = "dummy:/1"
         self.library.lookup.return_value.get.return_value = [123]
-        self.assertEqual({uri: []}, self.core.library.lookup(uris=[uri]))
+        assert {uri: []} == self.core.library.lookup(uris=[uri])
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -472,7 +473,7 @@ class RefreshBadBackendTest(MockBackendCoreLibraryBase):
 class SearchBadBackendTest(MockBackendCoreLibraryBase):
     def test_backend_raises_exception(self, logger):
         self.library.search.return_value.get.side_effect = Exception
-        self.assertEqual([], self.core.library.search(query={"any": ["foo"]}))
+        assert [] == self.core.library.search(query={"any": ["foo"]})
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_raises_lookuperror(self, logger):
@@ -484,10 +485,10 @@ class SearchBadBackendTest(MockBackendCoreLibraryBase):
 
     def test_backend_returns_none(self, logger):
         self.library.search.return_value.get.return_value = None
-        self.assertEqual([], self.core.library.search(query={"any": ["foo"]}))
-        self.assertFalse(logger.error.called)
+        assert [] == self.core.library.search(query={"any": ["foo"]})
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         self.library.search.return_value.get.return_value = "abc"
-        self.assertEqual([], self.core.library.search(query={"any": ["foo"]}))
+        assert [] == self.core.library.search(query={"any": ["foo"]})
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)

--- a/tests/core/test_mixer.py
+++ b/tests/core/test_mixer.py
@@ -17,7 +17,7 @@ class CoreMixerTest(unittest.TestCase):
     def test_get_volume(self):
         self.mixer.get_volume.return_value.get.return_value = 30
 
-        self.assertEqual(self.core.mixer.get_volume(), 30)
+        assert self.core.mixer.get_volume() == 30
         self.mixer.get_volume.assert_called_once_with()
 
     def test_set_volume(self):
@@ -29,7 +29,7 @@ class CoreMixerTest(unittest.TestCase):
     def test_get_mute(self):
         self.mixer.get_mute.return_value.get.return_value = True
 
-        self.assertEqual(self.core.mixer.get_mute(), True)
+        assert self.core.mixer.get_mute() is True
         self.mixer.get_mute.assert_called_once_with()
 
     def test_set_mute(self):
@@ -44,16 +44,16 @@ class CoreNoneMixerTest(unittest.TestCase):
         self.core = core.Core(mixer=None, backends=[])
 
     def test_get_volume_return_none_because_it_is_unknown(self):
-        self.assertEqual(self.core.mixer.get_volume(), None)
+        assert self.core.mixer.get_volume() is None
 
     def test_set_volume_return_false_because_it_failed(self):
-        self.assertEqual(self.core.mixer.set_volume(30), False)
+        assert self.core.mixer.set_volume(30) is False
 
     def test_get_mute_return_none_because_it_is_unknown(self):
-        self.assertEqual(self.core.mixer.get_mute(), None)
+        assert self.core.mixer.get_mute() is None
 
     def test_set_mute_return_false_because_it_failed(self):
-        self.assertEqual(self.core.mixer.set_mute(True), False)
+        assert self.core.mixer.set_mute(True) is False
 
 
 @mock.patch.object(mixer.MixerListener, "send")
@@ -66,15 +66,15 @@ class CoreMixerListenerTest(unittest.TestCase):
         pykka.ActorRegistry.stop_all()
 
     def test_forwards_mixer_volume_changed_event_to_frontends(self, send):
-        self.assertEqual(self.core.mixer.set_volume(volume=60), True)
-        self.assertEqual(send.call_args[0][0], "volume_changed")
-        self.assertEqual(send.call_args[1]["volume"], 60)
+        assert self.core.mixer.set_volume(volume=60) is True
+        assert send.call_args[0][0] == "volume_changed"
+        assert send.call_args[1]["volume"] == 60
 
     def test_forwards_mixer_mute_changed_event_to_frontends(self, send):
         self.core.mixer.set_mute(mute=True)
 
-        self.assertEqual(send.call_args[0][0], "mute_changed")
-        self.assertEqual(send.call_args[1]["mute"], True)
+        assert send.call_args[0][0] == "mute_changed"
+        assert send.call_args[1]["mute"] is True
 
 
 @mock.patch.object(mixer.MixerListener, "send")
@@ -83,12 +83,12 @@ class CoreNoneMixerListenerTest(unittest.TestCase):
         self.core = core.Core(mixer=None, backends=[])
 
     def test_forwards_mixer_volume_changed_event_to_frontends(self, send):
-        self.assertEqual(self.core.mixer.set_volume(volume=60), False)
-        self.assertEqual(send.call_count, 0)
+        assert self.core.mixer.set_volume(volume=60) is False
+        assert send.call_count == 0
 
     def test_forwards_mixer_mute_changed_event_to_frontends(self, send):
         self.core.mixer.set_mute(mute=True)
-        self.assertEqual(send.call_count, 0)
+        assert send.call_count == 0
 
 
 class MockBackendCoreMixerBase(unittest.TestCase):
@@ -101,49 +101,49 @@ class MockBackendCoreMixerBase(unittest.TestCase):
 class GetVolumeBadBackendTest(MockBackendCoreMixerBase):
     def test_backend_raises_exception(self):
         self.mixer.get_volume.return_value.get.side_effect = Exception
-        self.assertEqual(self.core.mixer.get_volume(), None)
+        assert self.core.mixer.get_volume() is None
 
     def test_backend_returns_too_small_value(self):
         self.mixer.get_volume.return_value.get.return_value = -1
-        self.assertEqual(self.core.mixer.get_volume(), None)
+        assert self.core.mixer.get_volume() is None
 
     def test_backend_returns_too_large_value(self):
         self.mixer.get_volume.return_value.get.return_value = 1000
-        self.assertEqual(self.core.mixer.get_volume(), None)
+        assert self.core.mixer.get_volume() is None
 
     def test_backend_returns_wrong_type(self):
         self.mixer.get_volume.return_value.get.return_value = "12"
-        self.assertEqual(self.core.mixer.get_volume(), None)
+        assert self.core.mixer.get_volume() is None
 
 
 class SetVolumeBadBackendTest(MockBackendCoreMixerBase):
     def test_backend_raises_exception(self):
         self.mixer.set_volume.return_value.get.side_effect = Exception
-        self.assertFalse(self.core.mixer.set_volume(30))
+        assert not self.core.mixer.set_volume(30)
 
     def test_backend_returns_wrong_type(self):
         self.mixer.set_volume.return_value.get.return_value = "done"
-        self.assertFalse(self.core.mixer.set_volume(30))
+        assert not self.core.mixer.set_volume(30)
 
 
 class GetMuteBadBackendTest(MockBackendCoreMixerBase):
     def test_backend_raises_exception(self):
         self.mixer.get_mute.return_value.get.side_effect = Exception
-        self.assertEqual(self.core.mixer.get_mute(), None)
+        assert self.core.mixer.get_mute() is None
 
     def test_backend_returns_wrong_type(self):
         self.mixer.get_mute.return_value.get.return_value = "12"
-        self.assertEqual(self.core.mixer.get_mute(), None)
+        assert self.core.mixer.get_mute() is None
 
 
 class SetMuteBadBackendTest(MockBackendCoreMixerBase):
     def test_backend_raises_exception(self):
         self.mixer.set_mute.return_value.get.side_effect = Exception
-        self.assertFalse(self.core.mixer.set_mute(True))
+        assert not self.core.mixer.set_mute(True)
 
     def test_backend_returns_wrong_type(self):
         self.mixer.set_mute.return_value.get.return_value = "done"
-        self.assertFalse(self.core.mixer.set_mute(True))
+        assert not self.core.mixer.set_mute(True)
 
 
 class CoreMixerSaveLoadStateTest(unittest.TestCase):
@@ -158,7 +158,7 @@ class CoreMixerSaveLoadStateTest(unittest.TestCase):
         self.core.mixer.set_volume(volume)
         self.core.mixer.set_mute(mute)
         value = self.core.mixer._save_state()
-        self.assertEqual(target, value)
+        assert target == value
 
     def test_save_unmute(self):
         volume = 33
@@ -167,7 +167,7 @@ class CoreMixerSaveLoadStateTest(unittest.TestCase):
         self.core.mixer.set_volume(volume)
         self.core.mixer.set_mute(mute)
         value = self.core.mixer._save_state()
-        self.assertEqual(target, value)
+        assert target == value
 
     def test_load(self):
         self.core.mixer.set_volume(11)
@@ -175,7 +175,7 @@ class CoreMixerSaveLoadStateTest(unittest.TestCase):
         target = MixerState(volume=volume)
         coverage = ["mixer"]
         self.core.mixer._load_state(target, coverage)
-        self.assertEqual(volume, self.core.mixer.get_volume())
+        assert volume == self.core.mixer.get_volume()
 
     def test_load_not_covered(self):
         self.core.mixer.set_volume(21)
@@ -183,24 +183,24 @@ class CoreMixerSaveLoadStateTest(unittest.TestCase):
         target = MixerState(volume=56, mute=False)
         coverage = ["other"]
         self.core.mixer._load_state(target, coverage)
-        self.assertEqual(21, self.core.mixer.get_volume())
-        self.assertEqual(True, self.core.mixer.get_mute())
+        assert 21 == self.core.mixer.get_volume()
+        assert self.core.mixer.get_mute() is True
 
     def test_load_mute_on(self):
         self.core.mixer.set_mute(False)
-        self.assertEqual(False, self.core.mixer.get_mute())
+        assert self.core.mixer.get_mute() is False
         target = MixerState(mute=True)
         coverage = ["mixer"]
         self.core.mixer._load_state(target, coverage)
-        self.assertEqual(True, self.core.mixer.get_mute())
+        assert self.core.mixer.get_mute() is True
 
     def test_load_mute_off(self):
         self.core.mixer.set_mute(True)
-        self.assertEqual(True, self.core.mixer.get_mute())
+        assert self.core.mixer.get_mute() is True
         target = MixerState(mute=False)
         coverage = ["mixer"]
         self.core.mixer._load_state(target, coverage)
-        self.assertEqual(False, self.core.mixer.get_mute())
+        assert self.core.mixer.get_mute() is False
 
     def test_load_invalid_type(self):
         with self.assertRaises(TypeError):

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -56,19 +56,19 @@ class PlaylistTest(BasePlaylistsTest):
     def test_as_list_combines_result_from_backends(self):
         result = self.core.playlists.as_list()
 
-        self.assertIn(self.plr1a, result)
-        self.assertIn(self.plr1b, result)
-        self.assertIn(self.plr2a, result)
-        self.assertIn(self.plr2b, result)
+        assert self.plr1a in result
+        assert self.plr1b in result
+        assert self.plr2a in result
+        assert self.plr2b in result
 
     def test_as_list_ignores_backends_that_dont_support_it(self):
         self.sp2.as_list.return_value.get.side_effect = NotImplementedError
 
         result = self.core.playlists.as_list()
 
-        self.assertEqual(len(result), 2)
-        self.assertIn(self.plr1a, result)
-        self.assertIn(self.plr1b, result)
+        assert len(result) == 2
+        assert self.plr1a in result
+        assert self.plr1b in result
 
     def test_get_items_selects_the_matching_backend(self):
         ref = Ref.track()
@@ -76,16 +76,16 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.get_items("dummy2:pl:a")
 
-        self.assertEqual([ref], result)
-        self.assertFalse(self.sp1.get_items.called)
+        assert [ref] == result
+        assert not self.sp1.get_items.called
         self.sp2.get_items.assert_called_once_with("dummy2:pl:a")
 
     def test_get_items_with_unknown_uri_scheme_does_nothing(self):
         result = self.core.playlists.get_items("unknown:a")
 
-        self.assertIsNone(result)
-        self.assertFalse(self.sp1.delete.called)
-        self.assertFalse(self.sp2.delete.called)
+        assert result is None
+        assert not self.sp1.delete.called
+        assert not self.sp2.delete.called
 
     def test_create_without_uri_scheme_uses_first_backend(self):
         playlist = Playlist()
@@ -93,9 +93,9 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.create("foo")
 
-        self.assertEqual(playlist, result)
+        assert playlist == result
         self.sp1.create.assert_called_once_with("foo")
-        self.assertFalse(self.sp2.create.called)
+        assert not self.sp2.create.called
 
     def test_create_without_uri_scheme_ignores_none_result(self):
         playlist = Playlist()
@@ -104,7 +104,7 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.create("foo")
 
-        self.assertEqual(playlist, result)
+        assert playlist == result
         self.sp1.create.assert_called_once_with("foo")
         self.sp2.create.assert_called_once_with("foo")
 
@@ -115,7 +115,7 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.create("foo")
 
-        self.assertEqual(playlist, result)
+        assert playlist == result
         self.sp1.create.assert_called_once_with("foo")
         self.sp2.create.assert_called_once_with("foo")
 
@@ -125,8 +125,8 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.create("foo", uri_scheme="dummy2")
 
-        self.assertEqual(playlist, result)
-        self.assertFalse(self.sp1.create.called)
+        assert playlist == result
+        assert not self.sp1.create.called
         self.sp2.create.assert_called_once_with("foo")
 
     def test_create_with_unsupported_uri_scheme_uses_first_backend(self):
@@ -135,56 +135,56 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.create("foo", uri_scheme="dummy3")
 
-        self.assertEqual(playlist, result)
+        assert playlist == result
         self.sp1.create.assert_called_once_with("foo")
-        self.assertFalse(self.sp2.create.called)
+        assert not self.sp2.create.called
 
     def test_delete_selects_the_dummy1_backend(self):
         success = self.core.playlists.delete("dummy1:a")
 
-        self.assertTrue(success)
+        assert success
         self.sp1.delete.assert_called_once_with("dummy1:a")
-        self.assertFalse(self.sp2.delete.called)
+        assert not self.sp2.delete.called
 
     def test_delete_selects_the_dummy2_backend(self):
         success = self.core.playlists.delete("dummy2:a")
 
-        self.assertTrue(success)
-        self.assertFalse(self.sp1.delete.called)
+        assert success
+        assert not self.sp1.delete.called
         self.sp2.delete.assert_called_once_with("dummy2:a")
 
     def test_delete_with_unknown_uri_scheme_does_nothing(self):
         success = self.core.playlists.delete("unknown:a")
 
-        self.assertFalse(success)
-        self.assertFalse(self.sp1.delete.called)
-        self.assertFalse(self.sp2.delete.called)
+        assert not success
+        assert not self.sp1.delete.called
+        assert not self.sp2.delete.called
 
     def test_delete_ignores_backend_without_playlist_support(self):
         success = self.core.playlists.delete("dummy3:a")
 
-        self.assertFalse(success)
-        self.assertFalse(self.sp1.delete.called)
-        self.assertFalse(self.sp2.delete.called)
+        assert not success
+        assert not self.sp1.delete.called
+        assert not self.sp2.delete.called
 
     def test_lookup_selects_the_dummy1_backend(self):
         self.core.playlists.lookup("dummy1:a")
 
         self.sp1.lookup.assert_called_once_with("dummy1:a")
-        self.assertFalse(self.sp2.lookup.called)
+        assert not self.sp2.lookup.called
 
     def test_lookup_selects_the_dummy2_backend(self):
         self.core.playlists.lookup("dummy2:a")
 
-        self.assertFalse(self.sp1.lookup.called)
+        assert not self.sp1.lookup.called
         self.sp2.lookup.assert_called_once_with("dummy2:a")
 
     def test_lookup_track_in_backend_without_playlists_fails(self):
         result = self.core.playlists.lookup("dummy3:a")
 
-        self.assertIsNone(result)
-        self.assertFalse(self.sp1.lookup.called)
-        self.assertFalse(self.sp2.lookup.called)
+        assert result is None
+        assert not self.sp1.lookup.called
+        assert not self.sp2.lookup.called
 
     def test_refresh_without_uri_scheme_refreshes_all_backends(self):
         self.core.playlists.refresh()
@@ -195,20 +195,20 @@ class PlaylistTest(BasePlaylistsTest):
     def test_refresh_with_uri_scheme_refreshes_matching_backend(self):
         self.core.playlists.refresh(uri_scheme="dummy2")
 
-        self.assertFalse(self.sp1.refresh.called)
+        assert not self.sp1.refresh.called
         self.sp2.refresh.assert_called_once_with()
 
     def test_refresh_with_unknown_uri_scheme_refreshes_nothing(self):
         self.core.playlists.refresh(uri_scheme="foobar")
 
-        self.assertFalse(self.sp1.refresh.called)
-        self.assertFalse(self.sp2.refresh.called)
+        assert not self.sp1.refresh.called
+        assert not self.sp2.refresh.called
 
     def test_refresh_ignores_backend_without_playlist_support(self):
         self.core.playlists.refresh(uri_scheme="dummy3")
 
-        self.assertFalse(self.sp1.refresh.called)
-        self.assertFalse(self.sp2.refresh.called)
+        assert not self.sp1.refresh.called
+        assert not self.sp2.refresh.called
 
     def test_save_selects_the_dummy1_backend(self):
         playlist = Playlist(uri="dummy1:a")
@@ -216,9 +216,9 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.save(playlist)
 
-        self.assertEqual(playlist, result)
+        assert playlist == result
         self.sp1.save.assert_called_once_with(playlist)
-        self.assertFalse(self.sp2.save.called)
+        assert not self.sp2.save.called
 
     def test_save_selects_the_dummy2_backend(self):
         playlist = Playlist(uri="dummy2:a")
@@ -226,34 +226,34 @@ class PlaylistTest(BasePlaylistsTest):
 
         result = self.core.playlists.save(playlist)
 
-        self.assertEqual(playlist, result)
-        self.assertFalse(self.sp1.save.called)
+        assert playlist == result
+        assert not self.sp1.save.called
         self.sp2.save.assert_called_once_with(playlist)
 
     def test_save_does_nothing_if_playlist_uri_is_unset(self):
         result = self.core.playlists.save(Playlist())
 
-        self.assertIsNone(result)
-        self.assertFalse(self.sp1.save.called)
-        self.assertFalse(self.sp2.save.called)
+        assert result is None
+        assert not self.sp1.save.called
+        assert not self.sp2.save.called
 
     def test_save_does_nothing_if_playlist_uri_has_unknown_scheme(self):
         result = self.core.playlists.save(Playlist(uri="foobar:a"))
 
-        self.assertIsNone(result)
-        self.assertFalse(self.sp1.save.called)
-        self.assertFalse(self.sp2.save.called)
+        assert result is None
+        assert not self.sp1.save.called
+        assert not self.sp2.save.called
 
     def test_save_ignores_backend_without_playlist_support(self):
         result = self.core.playlists.save(Playlist(uri="dummy3:a"))
 
-        self.assertIsNone(result)
-        self.assertFalse(self.sp1.save.called)
-        self.assertFalse(self.sp2.save.called)
+        assert result is None
+        assert not self.sp1.save.called
+        assert not self.sp2.save.called
 
     def test_get_uri_schemes(self):
         result = self.core.playlists.get_uri_schemes()
-        self.assertEqual(result, ["dummy1", "dummy2"])
+        assert result == ["dummy1", "dummy2"]
 
 
 class MockBackendCorePlaylistsBase(unittest.TestCase):
@@ -272,17 +272,17 @@ class MockBackendCorePlaylistsBase(unittest.TestCase):
 class AsListBadBackendsTest(MockBackendCorePlaylistsBase):
     def test_backend_raises_exception(self, logger):
         self.playlists.as_list.return_value.get.side_effect = Exception
-        self.assertEqual([], self.core.playlists.as_list())
+        assert [] == self.core.playlists.as_list()
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         self.playlists.as_list.return_value.get.return_value = None
-        self.assertEqual([], self.core.playlists.as_list())
-        self.assertFalse(logger.error.called)
+        assert [] == self.core.playlists.as_list()
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         self.playlists.as_list.return_value.get.return_value = "abc"
-        self.assertEqual([], self.core.playlists.as_list())
+        assert [] == self.core.playlists.as_list()
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -290,17 +290,17 @@ class AsListBadBackendsTest(MockBackendCorePlaylistsBase):
 class GetItemsBadBackendsTest(MockBackendCorePlaylistsBase):
     def test_backend_raises_exception(self, logger):
         self.playlists.get_items.return_value.get.side_effect = Exception
-        self.assertIsNone(self.core.playlists.get_items("dummy:/1"))
+        assert self.core.playlists.get_items("dummy:/1") is None
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         self.playlists.get_items.return_value.get.return_value = None
-        self.assertIsNone(self.core.playlists.get_items("dummy:/1"))
-        self.assertFalse(logger.error.called)
+        assert self.core.playlists.get_items("dummy:/1") is None
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         self.playlists.get_items.return_value.get.return_value = "abc"
-        self.assertIsNone(self.core.playlists.get_items("dummy:/1"))
+        assert self.core.playlists.get_items("dummy:/1") is None
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -308,17 +308,17 @@ class GetItemsBadBackendsTest(MockBackendCorePlaylistsBase):
 class CreateBadBackendsTest(MockBackendCorePlaylistsBase):
     def test_backend_raises_exception(self, logger):
         self.playlists.create.return_value.get.side_effect = Exception
-        self.assertIsNone(self.core.playlists.create("foobar"))
+        assert self.core.playlists.create("foobar") is None
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         self.playlists.create.return_value.get.return_value = None
-        self.assertIsNone(self.core.playlists.create("foobar"))
-        self.assertFalse(logger.error.called)
+        assert self.core.playlists.create("foobar") is None
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         self.playlists.create.return_value.get.return_value = "abc"
-        self.assertIsNone(self.core.playlists.create("foobar"))
+        assert self.core.playlists.create("foobar") is None
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -326,7 +326,7 @@ class CreateBadBackendsTest(MockBackendCorePlaylistsBase):
 class DeleteBadBackendsTest(MockBackendCorePlaylistsBase):
     def test_backend_raises_exception(self, logger):
         self.playlists.delete.return_value.get.side_effect = Exception
-        self.assertFalse(self.core.playlists.delete("dummy:/1"))
+        assert not self.core.playlists.delete("dummy:/1")
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
 
@@ -334,17 +334,17 @@ class DeleteBadBackendsTest(MockBackendCorePlaylistsBase):
 class LookupBadBackendsTest(MockBackendCorePlaylistsBase):
     def test_backend_raises_exception(self, logger):
         self.playlists.lookup.return_value.get.side_effect = Exception
-        self.assertIsNone(self.core.playlists.lookup("dummy:/1"))
+        assert self.core.playlists.lookup("dummy:/1") is None
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         self.playlists.lookup.return_value.get.return_value = None
-        self.assertIsNone(self.core.playlists.lookup("dummy:/1"))
-        self.assertFalse(logger.error.called)
+        assert self.core.playlists.lookup("dummy:/1") is None
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         self.playlists.lookup.return_value.get.return_value = "abc"
-        self.assertIsNone(self.core.playlists.lookup("dummy:/1"))
+        assert self.core.playlists.lookup("dummy:/1") is None
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)
 
 
@@ -354,14 +354,14 @@ class RefreshBadBackendsTest(MockBackendCorePlaylistsBase):
     def test_backend_raises_exception(self, send, logger):
         self.playlists.refresh.return_value.get.side_effect = Exception
         self.core.playlists.refresh()
-        self.assertFalse(send.called)
+        assert not send.called
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     @mock.patch("mopidy.core.listener.CoreListener.send")
     def test_backend_raises_exception_called_with_uri(self, send, logger):
         self.playlists.refresh.return_value.get.side_effect = Exception
         self.core.playlists.refresh("dummy")
-        self.assertFalse(send.called)
+        assert not send.called
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
 
@@ -370,17 +370,17 @@ class SaveBadBackendsTest(MockBackendCorePlaylistsBase):
     def test_backend_raises_exception(self, logger):
         playlist = Playlist(uri="dummy:/1")
         self.playlists.save.return_value.get.side_effect = Exception
-        self.assertIsNone(self.core.playlists.save(playlist))
+        assert self.core.playlists.save(playlist) is None
         logger.exception.assert_called_with(mock.ANY, "DummyBackend")
 
     def test_backend_returns_none(self, logger):
         playlist = Playlist(uri="dummy:/1")
         self.playlists.save.return_value.get.return_value = None
-        self.assertIsNone(self.core.playlists.save(playlist))
-        self.assertFalse(logger.error.called)
+        assert self.core.playlists.save(playlist) is None
+        assert not logger.error.called
 
     def test_backend_returns_wrong_type(self, logger):
         playlist = Playlist(uri="dummy:/1")
         self.playlists.save.return_value.get.return_value = "abc"
-        self.assertIsNone(self.core.playlists.save(playlist))
+        assert self.core.playlists.save(playlist) is None
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -39,9 +39,9 @@ class TracklistTest(unittest.TestCase):
         tl_tracks = self.core.tracklist.add(uris=["dummy1:a"])
 
         self.library.lookup.assert_called_once_with("dummy1:a")
-        self.assertEqual(1, len(tl_tracks))
-        self.assertEqual(self.tracks[0], tl_tracks[0].track)
-        self.assertEqual(tl_tracks, self.core.tracklist.get_tl_tracks()[-1:])
+        assert 1 == len(tl_tracks)
+        assert self.tracks[0] == tl_tracks[0].track
+        assert tl_tracks == self.core.tracklist.get_tl_tracks()[(-1):]
 
     def test_add_by_uris_looks_up_uris_in_library(self):
         self.library.lookup.reset_mock()
@@ -56,21 +56,22 @@ class TracklistTest(unittest.TestCase):
                 mock.call("dummy1:c"),
             ]
         )
-        self.assertEqual(3, len(tl_tracks))
-        self.assertEqual(self.tracks[0], tl_tracks[0].track)
-        self.assertEqual(self.tracks[1], tl_tracks[1].track)
-        self.assertEqual(self.tracks[2], tl_tracks[2].track)
-        self.assertEqual(
-            tl_tracks, self.core.tracklist.get_tl_tracks()[-len(tl_tracks) :]
+        assert 3 == len(tl_tracks)
+        assert self.tracks[0] == tl_tracks[0].track
+        assert self.tracks[1] == tl_tracks[1].track
+        assert self.tracks[2] == tl_tracks[2].track
+        assert (
+            tl_tracks
+            == self.core.tracklist.get_tl_tracks()[(-len(tl_tracks)) :]
         )
 
     def test_remove_removes_tl_tracks_matching_query(self):
         tl_tracks = self.core.tracklist.remove({"name": ["foo"]})
 
-        self.assertEqual(2, len(tl_tracks))
+        assert 2 == len(tl_tracks)
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
-        self.assertEqual(1, self.core.tracklist.get_length())
+        assert 1 == self.core.tracklist.get_length()
         self.assertListEqual(
             self.tl_tracks[2:], self.core.tracklist.get_tl_tracks()
         )
@@ -78,10 +79,10 @@ class TracklistTest(unittest.TestCase):
     def test_remove_works_with_dict_instead_of_kwargs(self):
         tl_tracks = self.core.tracklist.remove({"name": ["foo"]})
 
-        self.assertEqual(2, len(tl_tracks))
+        assert 2 == len(tl_tracks)
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
-        self.assertEqual(1, self.core.tracklist.get_length())
+        assert 1 == self.core.tracklist.get_length()
         self.assertListEqual(
             self.tl_tracks[2:], self.core.tracklist.get_tl_tracks()
         )
@@ -89,13 +90,13 @@ class TracklistTest(unittest.TestCase):
     def test_filter_returns_tl_tracks_matching_query(self):
         tl_tracks = self.core.tracklist.filter({"name": ["foo"]})
 
-        self.assertEqual(2, len(tl_tracks))
+        assert 2 == len(tl_tracks)
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
     def test_filter_works_with_dict_instead_of_kwargs(self):
         tl_tracks = self.core.tracklist.filter({"name": ["foo"]})
 
-        self.assertEqual(2, len(tl_tracks))
+        assert 2 == len(tl_tracks)
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
     def test_filter_fails_if_values_isnt_iterable(self):
@@ -133,16 +134,16 @@ class TracklistIndexTest(unittest.TestCase):
         )
 
     def test_index_returns_index_of_track(self):
-        self.assertEqual(0, self.core.tracklist.index(self.tl_tracks[0]))
-        self.assertEqual(1, self.core.tracklist.index(self.tl_tracks[1]))
-        self.assertEqual(2, self.core.tracklist.index(self.tl_tracks[2]))
+        assert 0 == self.core.tracklist.index(self.tl_tracks[0])
+        assert 1 == self.core.tracklist.index(self.tl_tracks[1])
+        assert 2 == self.core.tracklist.index(self.tl_tracks[2])
 
     def test_index_returns_none_if_item_not_found(self):
         tl_track = TlTrack(0, Track())
-        self.assertEqual(self.core.tracklist.index(tl_track), None)
+        assert self.core.tracklist.index(tl_track) is None
 
     def test_index_returns_none_if_called_with_none(self):
-        self.assertEqual(self.core.tracklist.index(None), None)
+        assert self.core.tracklist.index(None) is None
 
     def test_index_errors_out_for_invalid_tltrack(self):
         with self.assertRaises(ValueError):
@@ -150,15 +151,15 @@ class TracklistIndexTest(unittest.TestCase):
 
     def test_index_return_index_when_called_with_tlids(self):
         tl_tracks = self.tl_tracks
-        self.assertEqual(0, self.core.tracklist.index(tlid=tl_tracks[0].tlid))
-        self.assertEqual(1, self.core.tracklist.index(tlid=tl_tracks[1].tlid))
-        self.assertEqual(2, self.core.tracklist.index(tlid=tl_tracks[2].tlid))
+        assert 0 == self.core.tracklist.index(tlid=tl_tracks[0].tlid)
+        assert 1 == self.core.tracklist.index(tlid=tl_tracks[1].tlid)
+        assert 2 == self.core.tracklist.index(tlid=tl_tracks[2].tlid)
 
     def test_index_returns_none_if_tlid_not_found(self):
-        self.assertEqual(self.core.tracklist.index(tlid=123), None)
+        assert self.core.tracklist.index(tlid=123) is None
 
     def test_index_returns_none_if_called_with_tlid_none(self):
-        self.assertEqual(self.core.tracklist.index(tlid=None), None)
+        assert self.core.tracklist.index(tlid=None) is None
 
     def test_index_errors_out_for_invalid_tlid(self):
         with self.assertRaises(ValueError):
@@ -172,10 +173,10 @@ class TracklistIndexTest(unittest.TestCase):
             self.tl_tracks[2],
         ]
 
-        self.assertEqual(None, self.core.tracklist.index())
-        self.assertEqual(0, self.core.tracklist.index())
-        self.assertEqual(1, self.core.tracklist.index())
-        self.assertEqual(2, self.core.tracklist.index())
+        assert self.core.tracklist.index() is None
+        assert 0 == self.core.tracklist.index()
+        assert 1 == self.core.tracklist.index()
+        assert 2 == self.core.tracklist.index()
 
 
 class TracklistSaveLoadStateTest(unittest.TestCase):
@@ -218,7 +219,7 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
             tl_tracks=tl_tracks,
         )
         value = self.core.tracklist._save_state()
-        self.assertEqual(target, value)
+        assert target == value
 
     def test_load(self):
         old_version = self.core.tracklist.get_version()
@@ -232,19 +233,19 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
         )
         coverage = ["mode", "tracklist"]
         self.core.tracklist._load_state(target, coverage)
-        self.assertEqual(False, self.core.tracklist.get_consume())
-        self.assertEqual(True, self.core.tracklist.get_repeat())
-        self.assertEqual(True, self.core.tracklist.get_single())
-        self.assertEqual(False, self.core.tracklist.get_random())
-        self.assertEqual(12, self.core.tracklist._next_tlid)
-        self.assertEqual(4, self.core.tracklist.get_length())
-        self.assertEqual(self.tl_tracks, self.core.tracklist.get_tl_tracks())
-        self.assertGreater(self.core.tracklist.get_version(), old_version)
+        assert self.core.tracklist.get_consume() is False
+        assert self.core.tracklist.get_repeat() is True
+        assert self.core.tracklist.get_single() is True
+        assert self.core.tracklist.get_random() is False
+        assert 12 == self.core.tracklist._next_tlid
+        assert 4 == self.core.tracklist.get_length()
+        assert self.tl_tracks == self.core.tracklist.get_tl_tracks()
+        assert self.core.tracklist.get_version() > old_version
 
         # after load, adding more tracks must be possible
         self.core.tracklist.add(uris=[self.tracks[1].uri])
-        self.assertEqual(13, self.core.tracklist._next_tlid)
-        self.assertEqual(5, self.core.tracklist.get_length())
+        assert 13 == self.core.tracklist._next_tlid
+        assert 5 == self.core.tracklist.get_length()
 
     def test_load_mode_only(self):
         old_version = self.core.tracklist.get_version()
@@ -258,14 +259,14 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
         )
         coverage = ["mode"]
         self.core.tracklist._load_state(target, coverage)
-        self.assertEqual(False, self.core.tracklist.get_consume())
-        self.assertEqual(True, self.core.tracklist.get_repeat())
-        self.assertEqual(True, self.core.tracklist.get_single())
-        self.assertEqual(False, self.core.tracklist.get_random())
-        self.assertEqual(1, self.core.tracklist._next_tlid)
-        self.assertEqual(0, self.core.tracklist.get_length())
-        self.assertEqual([], self.core.tracklist.get_tl_tracks())
-        self.assertEqual(self.core.tracklist.get_version(), old_version)
+        assert self.core.tracklist.get_consume() is False
+        assert self.core.tracklist.get_repeat() is True
+        assert self.core.tracklist.get_single() is True
+        assert self.core.tracklist.get_random() is False
+        assert 1 == self.core.tracklist._next_tlid
+        assert 0 == self.core.tracklist.get_length()
+        assert [] == self.core.tracklist.get_tl_tracks()
+        assert self.core.tracklist.get_version() == old_version
 
     def test_load_tracklist_only(self):
         old_version = self.core.tracklist.get_version()
@@ -279,14 +280,14 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
         )
         coverage = ["tracklist"]
         self.core.tracklist._load_state(target, coverage)
-        self.assertEqual(False, self.core.tracklist.get_consume())
-        self.assertEqual(False, self.core.tracklist.get_repeat())
-        self.assertEqual(False, self.core.tracklist.get_single())
-        self.assertEqual(False, self.core.tracklist.get_random())
-        self.assertEqual(12, self.core.tracklist._next_tlid)
-        self.assertEqual(4, self.core.tracklist.get_length())
-        self.assertEqual(self.tl_tracks, self.core.tracklist.get_tl_tracks())
-        self.assertGreater(self.core.tracklist.get_version(), old_version)
+        assert self.core.tracklist.get_consume() is False
+        assert self.core.tracklist.get_repeat() is False
+        assert self.core.tracklist.get_single() is False
+        assert self.core.tracklist.get_random() is False
+        assert 12 == self.core.tracklist._next_tlid
+        assert 4 == self.core.tracklist.get_length()
+        assert self.tl_tracks == self.core.tracklist.get_tl_tracks()
+        assert self.core.tracklist.get_version() > old_version
 
     def test_load_invalid_type(self):
         with self.assertRaises(TypeError):

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -28,20 +28,16 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def test_static_handler(self):
         response = self.fetch("/test_handlers.py", method="GET")
 
-        self.assertEqual(200, response.code)
-        self.assertEqual(
-            response.headers["X-Mopidy-Version"], mopidy.__version__
-        )
-        self.assertEqual(response.headers["Cache-Control"], "no-cache")
+        assert 200 == response.code
+        assert response.headers["X-Mopidy-Version"] == mopidy.__version__
+        assert response.headers["Cache-Control"] == "no-cache"
 
     def test_static_default_filename(self):
         response = self.fetch("/", method="GET")
 
-        self.assertEqual(200, response.code)
-        self.assertEqual(
-            response.headers["X-Mopidy-Version"], mopidy.__version__
-        )
-        self.assertEqual(response.headers["Cache-Control"], "no-cache")
+        assert 200 == response.code
+        assert response.headers["X-Mopidy-Version"] == mopidy.__version__
+        assert response.headers["Cache-Control"] == "no-cache"
 
 
 class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
@@ -72,14 +68,14 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
         conn = yield self.connection()
         conn.write_message("invalid request")
         message = yield conn.read_message()
-        self.assertTrue(message)
+        assert message
 
     @tornado.testing.gen_test
     def test_broadcast_makes_it_to_client(self):
         conn = yield self.connection()
         handlers.WebSocketHandler.broadcast("message", self.io_loop)
         message = yield conn.read_message()
-        self.assertEqual(message, "message")
+        assert message == "message"
 
     @tornado.testing.gen_test
     def test_broadcast_to_client_that_just_closed_connection(self):
@@ -104,48 +100,34 @@ class CheckOriginTests(unittest.TestCase):
         self.allowed = set()
 
     def test_missing_origin_blocked(self):
-        self.assertFalse(
-            handlers.check_origin(None, self.headers, self.allowed)
-        )
+        assert not handlers.check_origin(None, self.headers, self.allowed)
 
     def test_empty_origin_allowed(self):
-        self.assertTrue(handlers.check_origin("", self.headers, self.allowed))
+        assert handlers.check_origin("", self.headers, self.allowed)
 
     def test_chrome_file_origin_allowed(self):
-        self.assertTrue(
-            handlers.check_origin("file://", self.headers, self.allowed)
-        )
+        assert handlers.check_origin("file://", self.headers, self.allowed)
 
     def test_firefox_null_origin_allowed(self):
-        self.assertTrue(
-            handlers.check_origin("null", self.headers, self.allowed)
-        )
+        assert handlers.check_origin("null", self.headers, self.allowed)
 
     def test_same_host_origin_allowed(self):
-        self.assertTrue(
-            handlers.check_origin(
-                "http://localhost:6680", self.headers, self.allowed
-            )
+        assert handlers.check_origin(
+            "http://localhost:6680", self.headers, self.allowed
         )
 
     def test_different_host_origin_blocked(self):
-        self.assertFalse(
-            handlers.check_origin(
-                "http://other:6680", self.headers, self.allowed
-            )
+        assert not handlers.check_origin(
+            "http://other:6680", self.headers, self.allowed
         )
 
     def test_different_port_blocked(self):
-        self.assertFalse(
-            handlers.check_origin(
-                "http://localhost:80", self.headers, self.allowed
-            )
+        assert not handlers.check_origin(
+            "http://localhost:80", self.headers, self.allowed
         )
 
     def test_extra_origin_allowed(self):
         self.allowed.add("other:6680")
-        self.assertTrue(
-            handlers.check_origin(
-                "http://other:6680", self.headers, self.allowed
-            )
+        assert handlers.check_origin(
+            "http://other:6680", self.headers, self.allowed
         )

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -52,8 +52,8 @@ class RootRedirectTest(HttpServerTest):
     def test_should_redirect_to_mopidy_app(self):
         response = self.fetch("/", method="GET", follow_redirects=False)
 
-        self.assertEqual(response.code, 302)
-        self.assertEqual(response.headers["Location"], "/mopidy/")
+        assert response.code == 302
+        assert response.headers["Location"] == "/mopidy/"
 
 
 class MopidyAppTest(HttpServerTest):
@@ -61,47 +61,41 @@ class MopidyAppTest(HttpServerTest):
         response = self.fetch("/mopidy/", method="GET")
         body = tornado.escape.to_unicode(response.body)
 
-        self.assertIn(
-            "This web server is a part of the Mopidy music server.", body
-        )
-        self.assertIn("testapp", body)
-        self.assertIn("teststatic", body)
-        self.assertEqual(
-            response.headers["X-Mopidy-Version"], mopidy.__version__
-        )
-        self.assertEqual(response.headers["Cache-Control"], "no-cache")
+        assert "This web server is a part of the Mopidy music server." in body
+        assert "testapp" in body
+        assert "teststatic" in body
+        assert response.headers["X-Mopidy-Version"] == mopidy.__version__
+        assert response.headers["Cache-Control"] == "no-cache"
 
     def test_without_slash_should_redirect(self):
         response = self.fetch("/mopidy", method="GET", follow_redirects=False)
 
-        self.assertEqual(response.code, 301)
-        self.assertEqual(response.headers["Location"], "/mopidy/")
+        assert response.code == 301
+        assert response.headers["Location"] == "/mopidy/"
 
     def test_should_return_static_files(self):
         response = self.fetch("/mopidy/mopidy.css", method="GET")
 
-        self.assertIn("html {", tornado.escape.to_unicode(response.body))
-        self.assertEqual(
-            response.headers["X-Mopidy-Version"], mopidy.__version__
-        )
-        self.assertEqual(response.headers["Cache-Control"], "no-cache")
+        assert "html {" in tornado.escape.to_unicode(response.body)
+        assert response.headers["X-Mopidy-Version"] == mopidy.__version__
+        assert response.headers["Cache-Control"] == "no-cache"
 
 
 class MopidyWebSocketHandlerTest(HttpServerTest):
     def test_should_return_ws(self):
         response = self.fetch("/mopidy/ws", method="GET")
 
-        self.assertEqual(
-            'Can "Upgrade" only to "WebSocket".',
-            tornado.escape.to_unicode(response.body),
+        assert (
+            'Can "Upgrade" only to "WebSocket".'
+            == tornado.escape.to_unicode(response.body)
         )
 
     def test_should_return_ws_old(self):
         response = self.fetch("/mopidy/ws/", method="GET")
 
-        self.assertEqual(
-            'Can "Upgrade" only to "WebSocket".',
-            tornado.escape.to_unicode(response.body),
+        assert (
+            'Can "Upgrade" only to "WebSocket".'
+            == tornado.escape.to_unicode(response.body)
         )
 
 
@@ -116,18 +110,15 @@ class MopidyRPCHandlerTest(HttpServerTest):
             headers={"Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            {
-                "jsonrpc": "2.0",
-                "id": None,
-                "error": {
-                    "message": "Invalid Request",
-                    "code": -32600,
-                    "data": "'jsonrpc' member must be included",
-                },
+        assert {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {
+                "message": "Invalid Request",
+                "code": (-32600),
+                "data": "'jsonrpc' member must be included",
             },
-            tornado.escape.json_decode(response.body),
-        )
+        } == tornado.escape.json_decode(response.body)
 
     def test_should_return_parse_error(self):
         cmd = "{[[[]}"
@@ -139,14 +130,11 @@ class MopidyRPCHandlerTest(HttpServerTest):
             headers={"Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            {
-                "jsonrpc": "2.0",
-                "id": None,
-                "error": {"message": "Parse error", "code": -32700},
-            },
-            tornado.escape.json_decode(response.body),
-        )
+        assert {
+            "jsonrpc": "2.0",
+            "id": None,
+            "error": {"message": "Parse error", "code": (-32700)},
+        } == tornado.escape.json_decode(response.body)
 
     def test_should_return_mopidy_version(self):
         cmd = tornado.escape.json_encode(
@@ -165,18 +153,19 @@ class MopidyRPCHandlerTest(HttpServerTest):
             headers={"Content-Type": "application/json"},
         )
 
-        self.assertEqual(
-            {"jsonrpc": "2.0", "id": 1, "result": mopidy.__version__},
-            tornado.escape.json_decode(response.body),
-        )
+        assert {
+            "jsonrpc": "2.0",
+            "id": 1,
+            "result": mopidy.__version__,
+        } == tornado.escape.json_decode(response.body)
 
     def test_should_return_extra_headers(self):
         response = self.fetch("/mopidy/rpc", method="HEAD")
 
-        self.assertIn("Accept", response.headers)
-        self.assertIn("X-Mopidy-Version", response.headers)
-        self.assertIn("Cache-Control", response.headers)
-        self.assertIn("Content-Type", response.headers)
+        assert "Accept" in response.headers
+        assert "X-Mopidy-Version" in response.headers
+        assert "Cache-Control" in response.headers
+        assert "Content-Type" in response.headers
 
     def test_should_require_correct_content_type(self):
         cmd = tornado.escape.json_encode(
@@ -195,10 +184,8 @@ class MopidyRPCHandlerTest(HttpServerTest):
             headers={"Content-Type": "text/plain"},
         )
 
-        self.assertEqual(response.code, 415)
-        self.assertEqual(
-            response.reason, "Content-Type must be application/json"
-        )
+        assert response.code == 415
+        assert response.reason == "Content-Type must be application/json"
 
     def test_different_origin_returns_access_denied(self):
         response = self.fetch(
@@ -207,10 +194,8 @@ class MopidyRPCHandlerTest(HttpServerTest):
             headers={"Host": "me:6680", "Origin": "http://evil:666"},
         )
 
-        self.assertEqual(response.code, 403)
-        self.assertEqual(
-            response.reason, "Access denied for origin http://evil:666"
-        )
+        assert response.code == 403
+        assert response.reason == "Access denied for origin http://evil:666"
 
     def test_same_origin_returns_cors_headers(self):
         response = self.fetch(
@@ -219,11 +204,11 @@ class MopidyRPCHandlerTest(HttpServerTest):
             headers={"Host": "me:6680", "Origin": "http://me:6680"},
         )
 
-        self.assertEqual(
-            response.headers["Access-Control-Allow-Origin"], "http://me:6680"
+        assert (
+            response.headers["Access-Control-Allow-Origin"] == "http://me:6680"
         )
-        self.assertEqual(
-            response.headers["Access-Control-Allow-Headers"], "Content-Type"
+        assert (
+            response.headers["Access-Control-Allow-Headers"] == "Content-Type"
         )
 
 
@@ -251,14 +236,14 @@ class MopidyRPCHandlerNoCSRFProtectionTest(HttpServerTest):
             headers={"Content-Type": "text/plain"},
         )
 
-        self.assertEqual(response.code, 200)
+        assert response.code == 200
 
     def test_should_ignore_missing_content_type(self):
         response = self.fetch(
             "/mopidy/rpc", method="POST", body=self.get_cmd(), headers={}
         )
 
-        self.assertEqual(response.code, 200)
+        assert response.code == 200
 
     def test_different_origin_returns_allowed(self):
         response = self.fetch(
@@ -267,7 +252,7 @@ class MopidyRPCHandlerNoCSRFProtectionTest(HttpServerTest):
             headers={"Host": "me:6680", "Origin": "http://evil:666"},
         )
 
-        self.assertEqual(response.code, 204)
+        assert response.code == 204
 
     def test_should_not_return_cors_headers(self):
         response = self.fetch(
@@ -276,8 +261,8 @@ class MopidyRPCHandlerNoCSRFProtectionTest(HttpServerTest):
             headers={"Host": "me:6680", "Origin": "http://me:6680"},
         )
 
-        self.assertNotIn("Access-Control-Allow-Origin", response.headers)
-        self.assertNotIn("Access-Control-Allow-Headers", response.headers)
+        assert "Access-Control-Allow-Origin" not in response.headers
+        assert "Access-Control-Allow-Headers" not in response.headers
 
 
 class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
@@ -298,17 +283,15 @@ class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
     def test_without_slash_should_redirect(self):
         response = self.fetch("/static", method="GET", follow_redirects=False)
 
-        self.assertEqual(response.code, 301)
-        self.assertEqual(response.headers["Location"], "/static/")
+        assert response.code == 301
+        assert response.headers["Location"] == "/static/"
 
     def test_can_serve_static_files(self):
         response = self.fetch("/static/test_server.py", method="GET")
 
-        self.assertEqual(200, response.code)
-        self.assertEqual(
-            response.headers["X-Mopidy-Version"], mopidy.__version__
-        )
-        self.assertEqual(response.headers["Cache-Control"], "no-cache")
+        assert 200 == response.code
+        assert response.headers["X-Mopidy-Version"] == mopidy.__version__
+        assert response.headers["Cache-Control"] == "no-cache"
 
 
 def wsgi_app_factory(config, core):
@@ -345,11 +328,11 @@ class HttpServerWithWsgiAppTest(tornado.testing.AsyncHTTPTestCase):
     def test_without_slash_should_redirect(self):
         response = self.fetch("/wsgi", method="GET", follow_redirects=False)
 
-        self.assertEqual(response.code, 301)
-        self.assertEqual(response.headers["Location"], "/wsgi/")
+        assert response.code == 301
+        assert response.headers["Location"] == "/wsgi/"
 
     def test_can_wrap_wsgi_apps(self):
         response = self.fetch("/wsgi/", method="GET")
 
-        self.assertEqual(200, response.code)
-        self.assertIn("Hello, world!", tornado.escape.to_unicode(response.body))
+        assert 200 == response.code
+        assert "Hello, world!" in tornado.escape.to_unicode(response.body)

--- a/tests/internal/network/test_connection.py
+++ b/tests/internal/network/test_connection.py
@@ -63,12 +63,12 @@ class ConnectionTest(unittest.TestCase):
         network.Connection.__init__(
             self.mock, protocol, protocol_kwargs, sock, addr, sentinel.timeout
         )
-        self.assertEqual(sock, self.mock._sock)
-        self.assertEqual(protocol, self.mock.protocol)
-        self.assertEqual(protocol_kwargs, self.mock.protocol_kwargs)
-        self.assertEqual(sentinel.timeout, self.mock.timeout)
-        self.assertEqual(sentinel.host, self.mock.host)
-        self.assertEqual(sentinel.port, self.mock.port)
+        assert sock == self.mock._sock
+        assert protocol == self.mock.protocol
+        assert protocol_kwargs == self.mock.protocol_kwargs
+        assert sentinel.timeout == self.mock.timeout
+        assert sentinel.host == self.mock.host
+        assert sentinel.port == self.mock.port
 
     def test_init_handles_ipv6_addr(self):
         addr = (
@@ -84,8 +84,8 @@ class ConnectionTest(unittest.TestCase):
         network.Connection.__init__(
             self.mock, protocol, protocol_kwargs, sock, addr, sentinel.timeout
         )
-        self.assertEqual(sentinel.host, self.mock.host)
-        self.assertEqual(sentinel.port, self.mock.port)
+        assert sentinel.host == self.mock.host
+        assert sentinel.port == self.mock.port
 
     def test_stop_disables_recv_send_and_timeout(self):
         self.mock.stopping = False
@@ -137,7 +137,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock = Mock(spec=socket.SocketType)
 
         network.Connection.stop(self.mock, sentinel.reason)
-        self.assertEqual(True, self.mock.stopping)
+        assert self.mock.stopping is True
 
     def test_stop_does_not_proceed_when_already_stopping(self):
         self.mock.stopping = True
@@ -145,8 +145,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock = Mock(spec=socket.SocketType)
 
         network.Connection.stop(self.mock, sentinel.reason)
-        self.assertEqual(0, self.mock.actor_ref.stop.call_count)
-        self.assertEqual(0, self.mock._sock.close.call_count)
+        assert 0 == self.mock.actor_ref.stop.call_count
+        assert 0 == self.mock._sock.close.call_count
 
     @patch.object(network.logger, "log", new=Mock())
     def test_stop_logs_reason(self):
@@ -194,7 +194,7 @@ class ConnectionTest(unittest.TestCase):
             GLib.IO_IN | GLib.IO_ERR | GLib.IO_HUP,
             self.mock.recv_callback,
         )
-        self.assertEqual(sentinel.tag, self.mock.recv_id)
+        assert sentinel.tag == self.mock.recv_id
 
     @patch.object(GLib, "io_add_watch", new=Mock())
     def test_enable_recv_already_registered(self):
@@ -202,14 +202,14 @@ class ConnectionTest(unittest.TestCase):
         self.mock.recv_id = sentinel.tag
 
         network.Connection.enable_recv(self.mock)
-        self.assertEqual(0, GLib.io_add_watch.call_count)
+        assert 0 == GLib.io_add_watch.call_count
 
     def test_enable_recv_does_not_change_tag(self):
         self.mock.recv_id = sentinel.tag
         self.mock._sock = Mock(spec=socket.SocketType)
 
         network.Connection.enable_recv(self.mock)
-        self.assertEqual(sentinel.tag, self.mock.recv_id)
+        assert sentinel.tag == self.mock.recv_id
 
     @patch.object(GLib, "source_remove", new=Mock())
     def test_disable_recv_deregisters(self):
@@ -217,15 +217,15 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.disable_recv(self.mock)
         GLib.source_remove.assert_called_once_with(sentinel.tag)
-        self.assertEqual(None, self.mock.recv_id)
+        assert self.mock.recv_id is None
 
     @patch.object(GLib, "source_remove", new=Mock())
     def test_disable_recv_already_deregistered(self):
         self.mock.recv_id = None
 
         network.Connection.disable_recv(self.mock)
-        self.assertEqual(0, GLib.source_remove.call_count)
-        self.assertEqual(None, self.mock.recv_id)
+        assert 0 == GLib.source_remove.call_count
+        assert self.mock.recv_id is None
 
     def test_enable_recv_on_closed_socket(self):
         self.mock.recv_id = None
@@ -234,7 +234,7 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.enable_recv(self.mock)
         self.mock.stop.assert_called_once_with(any_unicode)
-        self.assertEqual(None, self.mock.recv_id)
+        assert self.mock.recv_id is None
 
     @patch.object(GLib, "io_add_watch", new=Mock())
     def test_enable_send_registers_with_glib(self):
@@ -249,7 +249,7 @@ class ConnectionTest(unittest.TestCase):
             GLib.IO_OUT | GLib.IO_ERR | GLib.IO_HUP,
             self.mock.send_callback,
         )
-        self.assertEqual(sentinel.tag, self.mock.send_id)
+        assert sentinel.tag == self.mock.send_id
 
     @patch.object(GLib, "io_add_watch", new=Mock())
     def test_enable_send_already_registered(self):
@@ -257,14 +257,14 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send_id = sentinel.tag
 
         network.Connection.enable_send(self.mock)
-        self.assertEqual(0, GLib.io_add_watch.call_count)
+        assert 0 == GLib.io_add_watch.call_count
 
     def test_enable_send_does_not_change_tag(self):
         self.mock.send_id = sentinel.tag
         self.mock._sock = Mock(spec=socket.SocketType)
 
         network.Connection.enable_send(self.mock)
-        self.assertEqual(sentinel.tag, self.mock.send_id)
+        assert sentinel.tag == self.mock.send_id
 
     @patch.object(GLib, "source_remove", new=Mock())
     def test_disable_send_deregisters(self):
@@ -272,15 +272,15 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.disable_send(self.mock)
         GLib.source_remove.assert_called_once_with(sentinel.tag)
-        self.assertEqual(None, self.mock.send_id)
+        assert self.mock.send_id is None
 
     @patch.object(GLib, "source_remove", new=Mock())
     def test_disable_send_already_deregistered(self):
         self.mock.send_id = None
 
         network.Connection.disable_send(self.mock)
-        self.assertEqual(0, GLib.source_remove.call_count)
-        self.assertEqual(None, self.mock.send_id)
+        assert 0 == GLib.source_remove.call_count
+        assert self.mock.send_id is None
 
     def test_enable_send_on_closed_socket(self):
         self.mock.send_id = None
@@ -288,7 +288,7 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.fileno.side_effect = socket.error(errno.EBADF, "")
 
         network.Connection.enable_send(self.mock)
-        self.assertEqual(None, self.mock.send_id)
+        assert self.mock.send_id is None
 
     @patch.object(GLib, "timeout_add_seconds", new=Mock())
     def test_enable_timeout_clears_existing_timeouts(self):
@@ -306,34 +306,34 @@ class ConnectionTest(unittest.TestCase):
         GLib.timeout_add_seconds.assert_called_once_with(
             10, self.mock.timeout_callback
         )
-        self.assertEqual(sentinel.tag, self.mock.timeout_id)
+        assert sentinel.tag == self.mock.timeout_id
 
     @patch.object(GLib, "timeout_add_seconds", new=Mock())
     def test_enable_timeout_does_not_add_timeout(self):
         self.mock.timeout = 0
         network.Connection.enable_timeout(self.mock)
-        self.assertEqual(0, GLib.timeout_add_seconds.call_count)
+        assert 0 == GLib.timeout_add_seconds.call_count
 
         self.mock.timeout = -1
         network.Connection.enable_timeout(self.mock)
-        self.assertEqual(0, GLib.timeout_add_seconds.call_count)
+        assert 0 == GLib.timeout_add_seconds.call_count
 
         self.mock.timeout = None
         network.Connection.enable_timeout(self.mock)
-        self.assertEqual(0, GLib.timeout_add_seconds.call_count)
+        assert 0 == GLib.timeout_add_seconds.call_count
 
     def test_enable_timeout_does_not_call_disable_for_invalid_timeout(self):
         self.mock.timeout = 0
         network.Connection.enable_timeout(self.mock)
-        self.assertEqual(0, self.mock.disable_timeout.call_count)
+        assert 0 == self.mock.disable_timeout.call_count
 
         self.mock.timeout = -1
         network.Connection.enable_timeout(self.mock)
-        self.assertEqual(0, self.mock.disable_timeout.call_count)
+        assert 0 == self.mock.disable_timeout.call_count
 
         self.mock.timeout = None
         network.Connection.enable_timeout(self.mock)
-        self.assertEqual(0, self.mock.disable_timeout.call_count)
+        assert 0 == self.mock.disable_timeout.call_count
 
     @patch.object(GLib, "source_remove", new=Mock())
     def test_disable_timeout_deregisters(self):
@@ -341,15 +341,15 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.disable_timeout(self.mock)
         GLib.source_remove.assert_called_once_with(sentinel.tag)
-        self.assertEqual(None, self.mock.timeout_id)
+        assert self.mock.timeout_id is None
 
     @patch.object(GLib, "source_remove", new=Mock())
     def test_disable_timeout_already_deregistered(self):
         self.mock.timeout_id = None
 
         network.Connection.disable_timeout(self.mock)
-        self.assertEqual(0, GLib.source_remove.call_count)
-        self.assertEqual(None, self.mock.timeout_id)
+        assert 0 == GLib.source_remove.call_count
+        assert self.mock.timeout_id is None
 
     def test_queue_send_acquires_and_releases_lock(self):
         self.mock.send_lock = Mock()
@@ -366,8 +366,8 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.queue_send(self.mock, b"data")
         self.mock.send.assert_called_once_with(b"data")
-        self.assertEqual(0, self.mock.enable_send.call_count)
-        self.assertEqual(b"", self.mock.send_buffer)
+        assert 0 == self.mock.enable_send.call_count
+        assert b"" == self.mock.send_buffer
 
     def test_queue_send_calls_enable_send_for_partial_send(self):
         self.mock.send_buffer = b""
@@ -377,7 +377,7 @@ class ConnectionTest(unittest.TestCase):
         network.Connection.queue_send(self.mock, b"data")
         self.mock.send.assert_called_once_with(b"data")
         self.mock.enable_send.assert_called_once_with()
-        self.assertEqual(b"ta", self.mock.send_buffer)
+        assert b"ta" == self.mock.send_buffer
 
     def test_queue_send_calls_send_with_existing_buffer(self):
         self.mock.send_buffer = b"foo"
@@ -386,17 +386,15 @@ class ConnectionTest(unittest.TestCase):
 
         network.Connection.queue_send(self.mock, b"bar")
         self.mock.send.assert_called_once_with(b"foobar")
-        self.assertEqual(0, self.mock.enable_send.call_count)
-        self.assertEqual(b"", self.mock.send_buffer)
+        assert 0 == self.mock.enable_send.call_count
+        assert b"" == self.mock.send_buffer
 
     def test_recv_callback_respects_io_err(self):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock.actor_ref = Mock()
 
-        self.assertTrue(
-            network.Connection.recv_callback(
-                self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_ERR
-            )
+        assert network.Connection.recv_callback(
+            self.mock, sentinel.fd, (GLib.IO_IN | GLib.IO_ERR)
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -404,10 +402,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock.actor_ref = Mock()
 
-        self.assertTrue(
-            network.Connection.recv_callback(
-                self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP
-            )
+        assert network.Connection.recv_callback(
+            self.mock, sentinel.fd, (GLib.IO_IN | GLib.IO_HUP)
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -415,10 +411,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock.actor_ref = Mock()
 
-        self.assertTrue(
-            network.Connection.recv_callback(
-                self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR
-            )
+        assert network.Connection.recv_callback(
+            self.mock, sentinel.fd, ((GLib.IO_IN | GLib.IO_HUP) | GLib.IO_ERR)
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -427,8 +421,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.recv.return_value = b"data"
         self.mock.actor_ref = Mock()
 
-        self.assertTrue(
-            network.Connection.recv_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.recv_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
         self.mock.actor_ref.tell.assert_called_once_with({"received": b"data"})
 
@@ -438,8 +432,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
         self.mock.actor_ref.tell.side_effect = pykka.ActorDeadError()
 
-        self.assertTrue(
-            network.Connection.recv_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.recv_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -448,36 +442,31 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock.recv.return_value = b""
         self.mock.actor_ref = Mock()
 
-        self.assertTrue(
-            network.Connection.recv_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.recv_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
-        self.assertEqual(
-            self.mock.mock_calls,
-            [
-                call._sock.recv(any_int),
-                call.disable_recv(),
-                call.actor_ref.tell({"close": True}),
-            ],
-        )
+        assert self.mock.mock_calls == [
+            call._sock.recv(any_int),
+            call.disable_recv(),
+            call.actor_ref.tell({"close": True}),
+        ]
 
     def test_recv_callback_recoverable_error(self):
         self.mock._sock = Mock(spec=socket.SocketType)
 
         for error in (errno.EWOULDBLOCK, errno.EINTR):
             self.mock._sock.recv.side_effect = socket.error(error, "")
-            self.assertTrue(
-                network.Connection.recv_callback(
-                    self.mock, sentinel.fd, GLib.IO_IN
-                )
+            assert network.Connection.recv_callback(
+                self.mock, sentinel.fd, GLib.IO_IN
             )
-            self.assertEqual(0, self.mock.stop.call_count)
+            assert 0 == self.mock.stop.call_count
 
     def test_recv_callback_unrecoverable_error(self):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock._sock.recv.side_effect = socket.error
 
-        self.assertTrue(
-            network.Connection.recv_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.recv_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -488,10 +477,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
         self.mock.send_buffer = b""
 
-        self.assertTrue(
-            network.Connection.send_callback(
-                self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_ERR
-            )
+        assert network.Connection.send_callback(
+            self.mock, sentinel.fd, (GLib.IO_IN | GLib.IO_ERR)
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -502,10 +489,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
         self.mock.send_buffer = b""
 
-        self.assertTrue(
-            network.Connection.send_callback(
-                self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP
-            )
+        assert network.Connection.send_callback(
+            self.mock, sentinel.fd, (GLib.IO_IN | GLib.IO_HUP)
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -516,10 +501,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock.actor_ref = Mock()
         self.mock.send_buffer = b""
 
-        self.assertTrue(
-            network.Connection.send_callback(
-                self.mock, sentinel.fd, GLib.IO_IN | GLib.IO_HUP | GLib.IO_ERR
-            )
+        assert network.Connection.send_callback(
+            self.mock, sentinel.fd, ((GLib.IO_IN | GLib.IO_HUP) | GLib.IO_ERR)
         )
         self.mock.stop.assert_called_once_with(any_unicode)
 
@@ -530,8 +513,8 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock._sock.send.return_value = 0
 
-        self.assertTrue(
-            network.Connection.send_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.send_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
         self.mock.send_lock.acquire.assert_called_once_with(False)
         self.mock.send_lock.release.assert_called_once_with()
@@ -543,11 +526,11 @@ class ConnectionTest(unittest.TestCase):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock._sock.send.return_value = 0
 
-        self.assertTrue(
-            network.Connection.send_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.send_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
         self.mock.send_lock.acquire.assert_called_once_with(False)
-        self.assertEqual(0, self.mock._sock.send.call_count)
+        assert 0 == self.mock._sock.send.call_count
 
     def test_send_callback_sends_all_data(self):
         self.mock.send_lock = Mock()
@@ -555,12 +538,12 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send_buffer = b"data"
         self.mock.send.return_value = b""
 
-        self.assertTrue(
-            network.Connection.send_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.send_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
         self.mock.disable_send.assert_called_once_with()
         self.mock.send.assert_called_once_with(b"data")
-        self.assertEqual(b"", self.mock.send_buffer)
+        assert b"" == self.mock.send_buffer
 
     def test_send_callback_sends_partial_data(self):
         self.mock.send_lock = Mock()
@@ -568,11 +551,11 @@ class ConnectionTest(unittest.TestCase):
         self.mock.send_buffer = b"data"
         self.mock.send.return_value = b"ta"
 
-        self.assertTrue(
-            network.Connection.send_callback(self.mock, sentinel.fd, GLib.IO_IN)
+        assert network.Connection.send_callback(
+            self.mock, sentinel.fd, GLib.IO_IN
         )
         self.mock.send.assert_called_once_with(b"data")
-        self.assertEqual(b"ta", self.mock.send_buffer)
+        assert b"ta" == self.mock.send_buffer
 
     def test_send_recoverable_error(self):
         self.mock._sock = Mock(spec=socket.SocketType)
@@ -581,43 +564,43 @@ class ConnectionTest(unittest.TestCase):
             self.mock._sock.send.side_effect = socket.error(error, "")
 
             network.Connection.send(self.mock, b"data")
-            self.assertEqual(0, self.mock.stop.call_count)
+            assert 0 == self.mock.stop.call_count
 
     def test_send_calls_socket_send(self):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock._sock.send.return_value = 4
 
-        self.assertEqual(b"", network.Connection.send(self.mock, b"data"))
+        assert b"" == network.Connection.send(self.mock, b"data")
         self.mock._sock.send.assert_called_once_with(b"data")
 
     def test_send_calls_socket_send_partial_send(self):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock._sock.send.return_value = 2
 
-        self.assertEqual(b"ta", network.Connection.send(self.mock, b"data"))
+        assert b"ta" == network.Connection.send(self.mock, b"data")
         self.mock._sock.send.assert_called_once_with(b"data")
 
     def test_send_unrecoverable_error(self):
         self.mock._sock = Mock(spec=socket.SocketType)
         self.mock._sock.send.side_effect = socket.error
 
-        self.assertEqual(b"", network.Connection.send(self.mock, b"data"))
+        assert b"" == network.Connection.send(self.mock, b"data")
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_timeout_callback(self):
         self.mock.timeout = 10
 
-        self.assertFalse(network.Connection.timeout_callback(self.mock))
+        assert not network.Connection.timeout_callback(self.mock)
         self.mock.stop.assert_called_once_with(any_unicode)
 
     def test_str(self):
         self.mock.host = "foo"
         self.mock.port = 999
 
-        self.assertEqual("[foo]:999", network.Connection.__str__(self.mock))
+        assert "[foo]:999" == network.Connection.__str__(self.mock)
 
     def test_str_without_port(self):
         self.mock.host = "foo"
         self.mock.port = None
 
-        self.assertEqual("[foo]", network.Connection.__str__(self.mock))
+        assert "[foo]" == network.Connection.__str__(self.mock)

--- a/tests/internal/network/test_server.py
+++ b/tests/internal/network/test_server.py
@@ -73,11 +73,11 @@ class ServerTest(unittest.TestCase):
             max_connections=sentinel.max_connections,
             timeout=sentinel.timeout,
         )
-        self.assertEqual(sentinel.protocol, self.mock.protocol)
-        self.assertEqual(sentinel.max_connections, self.mock.max_connections)
-        self.assertEqual(sentinel.timeout, self.mock.timeout)
-        self.assertEqual(sock, self.mock.server_socket)
-        self.assertEqual((str(sentinel.host), sentinel.port), self.mock.address)
+        assert sentinel.protocol == self.mock.protocol
+        assert sentinel.max_connections == self.mock.max_connections
+        assert sentinel.timeout == self.mock.timeout
+        assert sock == self.mock.server_socket
+        assert (str(sentinel.host), sentinel.port) == self.mock.address
 
     def test_create_server_socket_no_port(self):
         with self.assertRaises(exceptions.ValidationError):
@@ -195,17 +195,15 @@ class ServerTest(unittest.TestCase):
         )
         self.mock.maximum_connections_exceeded.return_value = False
 
-        self.assertTrue(
-            network.Server.handle_connection(
-                self.mock, sentinel.fileno, GLib.IO_IN
-            )
+        assert network.Server.handle_connection(
+            self.mock, sentinel.fileno, GLib.IO_IN
         )
         self.mock.accept_connection.assert_called_once_with()
         self.mock.maximum_connections_exceeded.assert_called_once_with()
         self.mock.init_connection.assert_called_once_with(
             sentinel.sock, sentinel.addr
         )
-        self.assertEqual(0, self.mock.reject_connection.call_count)
+        assert 0 == self.mock.reject_connection.call_count
 
     def test_handle_connection_exceeded_connections(self):
         self.mock.accept_connection.return_value = (
@@ -214,17 +212,15 @@ class ServerTest(unittest.TestCase):
         )
         self.mock.maximum_connections_exceeded.return_value = True
 
-        self.assertTrue(
-            network.Server.handle_connection(
-                self.mock, sentinel.fileno, GLib.IO_IN
-            )
+        assert network.Server.handle_connection(
+            self.mock, sentinel.fileno, GLib.IO_IN
         )
         self.mock.accept_connection.assert_called_once_with()
         self.mock.maximum_connections_exceeded.assert_called_once_with()
         self.mock.reject_connection.assert_called_once_with(
             sentinel.sock, sentinel.addr
         )
-        self.assertEqual(0, self.mock.init_connection.call_count)
+        assert 0 == self.mock.init_connection.call_count
 
     def test_accept_connection(self):
         sock = Mock(spec=socket.socket)
@@ -233,8 +229,8 @@ class ServerTest(unittest.TestCase):
         self.mock.server_socket = sock
 
         sock, addr = network.Server.accept_connection(self.mock)
-        self.assertEqual(connected_sock, sock)
-        self.assertEqual(sentinel.addr, addr)
+        assert connected_sock == sock
+        assert sentinel.addr == addr
 
     def test_accept_connection_unix(self):
         sock = Mock(spec=socket.socket)
@@ -245,8 +241,8 @@ class ServerTest(unittest.TestCase):
         self.mock.server_socket = sock
 
         sock, addr = network.Server.accept_connection(self.mock)
-        self.assertEqual(connected_sock, sock)
-        self.assertEqual((sentinel.sockname, None), addr)
+        assert connected_sock == sock
+        assert (sentinel.sockname, None) == addr
 
     def test_accept_connection_recoverable_error(self):
         sock = Mock(spec=socket.socket)
@@ -269,23 +265,23 @@ class ServerTest(unittest.TestCase):
         self.mock.max_connections = 10
 
         self.mock.number_of_connections.return_value = 11
-        self.assertTrue(network.Server.maximum_connections_exceeded(self.mock))
+        assert network.Server.maximum_connections_exceeded(self.mock)
 
         self.mock.number_of_connections.return_value = 10
-        self.assertTrue(network.Server.maximum_connections_exceeded(self.mock))
+        assert network.Server.maximum_connections_exceeded(self.mock)
 
         self.mock.number_of_connections.return_value = 9
-        self.assertFalse(network.Server.maximum_connections_exceeded(self.mock))
+        assert not network.Server.maximum_connections_exceeded(self.mock)
 
     @patch("pykka.ActorRegistry.get_by_class")
     def test_number_of_connections(self, get_by_class):
         self.mock.protocol = sentinel.protocol
 
         get_by_class.return_value = [1, 2, 3]
-        self.assertEqual(3, network.Server.number_of_connections(self.mock))
+        assert 3 == network.Server.number_of_connections(self.mock)
 
         get_by_class.return_value = []
-        self.assertEqual(0, network.Server.number_of_connections(self.mock))
+        assert 0 == network.Server.number_of_connections(self.mock)
 
     @patch.object(network, "Connection", new=Mock())
     def test_init_connection(self):

--- a/tests/internal/network/test_utils.py
+++ b/tests/internal/network/test_utils.py
@@ -9,65 +9,66 @@ class FormatHostnameTest(unittest.TestCase):
     @patch("mopidy.internal.network.has_ipv6", True)
     def test_format_hostname_prefixes_ipv4_addresses_when_ipv6_available(self):
         network.has_ipv6 = True
-        self.assertEqual(network.format_hostname("0.0.0.0"), "::ffff:0.0.0.0")
-        self.assertEqual(network.format_hostname("1.0.0.1"), "::ffff:1.0.0.1")
+        assert network.format_hostname("0.0.0.0") == "::ffff:0.0.0.0"
+        assert network.format_hostname("1.0.0.1") == "::ffff:1.0.0.1"
 
     @patch("mopidy.internal.network.has_ipv6", False)
     def test_format_hostname_does_nothing_when_only_ipv4_available(self):
         network.has_ipv6 = False
-        self.assertEqual(network.format_hostname("0.0.0.0"), "0.0.0.0")
+        assert network.format_hostname("0.0.0.0") == "0.0.0.0"
 
 
 class FormatAddressTest(unittest.TestCase):
     def test_format_address_ipv4(self):
         address = (sentinel.host, sentinel.port)
-        self.assertEqual(
-            network.format_address(address),
-            f"[{sentinel.host}]:{sentinel.port}",
+        assert (
+            network.format_address(address)
+            == f"[{sentinel.host}]:{sentinel.port}"
         )
 
     def test_format_address_ipv6(self):
         address = (sentinel.host, sentinel.port, sentinel.flow, sentinel.scope)
-        self.assertEqual(
-            network.format_address(address),
-            f"[{sentinel.host}]:{sentinel.port}",
+        assert (
+            network.format_address(address)
+            == f"[{sentinel.host}]:{sentinel.port}"
         )
 
     def test_format_address_unix(self):
         address = (sentinel.path, None)
-        self.assertEqual(network.format_address(address), f"[{sentinel.path}]")
+        assert network.format_address(address) == f"[{sentinel.path}]"
 
 
 class GetSocketAddress(unittest.TestCase):
     def test_get_socket_address(self):
         host = str(sentinel.host)
         port = sentinel.port
-        self.assertEqual(network.get_socket_address(host, port), (host, port))
+        assert network.get_socket_address(host, port) == (host, port)
 
     def test_get_socket_address_unix(self):
         host = str(sentinel.host)
         port = sentinel.port
-        self.assertEqual(
-            network.get_socket_address("unix:" + host, port), (host, None)
+        assert network.get_socket_address(("unix:" + host), port) == (
+            host,
+            None,
         )
 
 
 class TryIPv6SocketTest(unittest.TestCase):
     @patch("socket.has_ipv6", False)
     def test_system_that_claims_no_ipv6_support(self):
-        self.assertFalse(network.try_ipv6_socket())
+        assert not network.try_ipv6_socket()
 
     @patch("socket.has_ipv6", True)
     @patch("socket.socket")
     def test_system_with_broken_ipv6(self, socket_mock):
         socket_mock.side_effect = IOError()
-        self.assertFalse(network.try_ipv6_socket())
+        assert not network.try_ipv6_socket()
 
     @patch("socket.has_ipv6", True)
     @patch("socket.socket")
     def test_with_working_ipv6(self, socket_mock):
         socket_mock.return_value = Mock()
-        self.assertTrue(network.try_ipv6_socket())
+        assert network.try_ipv6_socket()
 
 
 class CreateSocketTest(unittest.TestCase):
@@ -75,17 +76,13 @@ class CreateSocketTest(unittest.TestCase):
     @patch("socket.socket")
     def test_ipv4_socket(self, socket_mock):
         network.create_tcp_socket()
-        self.assertEqual(
-            socket_mock.call_args[0], (socket.AF_INET, socket.SOCK_STREAM)
-        )
+        assert socket_mock.call_args[0] == (socket.AF_INET, socket.SOCK_STREAM)
 
     @patch("mopidy.internal.network.has_ipv6", True)
     @patch("socket.socket")
     def test_ipv6_socket(self, socket_mock):
         network.create_tcp_socket()
-        self.assertEqual(
-            socket_mock.call_args[0], (socket.AF_INET6, socket.SOCK_STREAM)
-        )
+        assert socket_mock.call_args[0] == (socket.AF_INET6, socket.SOCK_STREAM)
 
     @unittest.SkipTest
     def test_ipv6_only_is_set(self):

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -33,51 +33,51 @@ class DepsTest(unittest.TestCase):
 
         result = deps.format_dependency_list(adapters)
 
-        self.assertIn("Python: FooPython 2.7.3", result)
+        assert "Python: FooPython 2.7.3" in result
 
-        self.assertIn("Platform: Loonix 4.0.1", result)
+        assert "Platform: Loonix 4.0.1" in result
 
-        self.assertIn("Pykka: 1.1 from /foo/bar", result)
-        self.assertNotIn("/baz.py", result)
-        self.assertIn("Detailed information: Quux", result)
+        assert "Pykka: 1.1 from /foo/bar" in result
+        assert "/baz.py" not in result
+        assert "Detailed information: Quux" in result
 
-        self.assertIn("Foo: not found", result)
+        assert "Foo: not found" in result
 
-        self.assertIn("Mopidy: 0.13", result)
-        self.assertIn("  pylast: 0.5", result)
-        self.assertIn("    setuptools: 0.6", result)
+        assert "Mopidy: 0.13" in result
+        assert "  pylast: 0.5" in result
+        assert "    setuptools: 0.6" in result
 
     def test_executable_info(self):
         result = deps.executable_info()
 
-        self.assertEqual("Executable", result["name"])
-        self.assertIn(sys.argv[0], result["version"])
+        assert "Executable" == result["name"]
+        assert sys.argv[0] in result["version"]
 
     def test_platform_info(self):
         result = deps.platform_info()
 
-        self.assertEqual("Platform", result["name"])
-        self.assertIn(platform.platform(), result["version"])
+        assert "Platform" == result["name"]
+        assert platform.platform() in result["version"]
 
     def test_python_info(self):
         result = deps.python_info()
 
-        self.assertEqual("Python", result["name"])
-        self.assertIn(platform.python_implementation(), result["version"])
-        self.assertIn(platform.python_version(), result["version"])
-        self.assertIn("python", result["path"])
-        self.assertNotIn("platform.py", result["path"])
+        assert "Python" == result["name"]
+        assert platform.python_implementation() in result["version"]
+        assert platform.python_version() in result["version"]
+        assert "python" in result["path"]
+        assert "platform.py" not in result["path"]
 
     def test_gstreamer_info(self):
         result = deps.gstreamer_info()
 
-        self.assertEqual("GStreamer", result["name"])
-        self.assertEqual(".".join(map(str, Gst.version())), result["version"])
-        self.assertIn("gi", result["path"])
-        self.assertNotIn("__init__.py", result["path"])
-        self.assertIn("Python wrapper: python-gi", result["other"])
-        self.assertIn(gi.__version__, result["other"])
-        self.assertIn("Relevant elements:", result["other"])
+        assert "GStreamer" == result["name"]
+        assert ".".join(map(str, Gst.version())) == result["version"]
+        assert "gi" in result["path"]
+        assert "__init__.py" not in result["path"]
+        assert "Python wrapper: python-gi" in result["other"]
+        assert gi.__version__ in result["other"]
+        assert "Relevant elements:" in result["other"]
 
     @mock.patch("pkg_resources.get_distribution")
     def test_pkg_info(self, get_distribution_mock):
@@ -107,17 +107,17 @@ class DepsTest(unittest.TestCase):
 
         result = deps.pkg_info()
 
-        self.assertEqual("Mopidy", result["name"])
-        self.assertEqual("0.13", result["version"])
-        self.assertIn("mopidy", result["path"])
+        assert "Mopidy" == result["name"]
+        assert "0.13" == result["version"]
+        assert "mopidy" in result["path"]
 
         dep_info_pykka = result["dependencies"][0]
-        self.assertEqual("Pykka", dep_info_pykka["name"])
-        self.assertEqual("1.1", dep_info_pykka["version"])
+        assert "Pykka" == dep_info_pykka["name"]
+        assert "1.1" == dep_info_pykka["version"]
 
         dep_info_setuptools = dep_info_pykka["dependencies"][0]
-        self.assertEqual("setuptools", dep_info_setuptools["name"])
-        self.assertEqual("0.6", dep_info_setuptools["version"])
+        assert "setuptools" == dep_info_setuptools["name"]
+        assert "0.6" == dep_info_setuptools["version"]
 
     @mock.patch("pkg_resources.get_distribution")
     def test_pkg_info_for_missing_dist(self, get_distribution_mock):
@@ -125,9 +125,9 @@ class DepsTest(unittest.TestCase):
 
         result = deps.pkg_info()
 
-        self.assertEqual("Mopidy", result["name"])
-        self.assertNotIn("version", result)
-        self.assertNotIn("path", result)
+        assert "Mopidy" == result["name"]
+        assert "version" not in result
+        assert "path" not in result
 
     @mock.patch("pkg_resources.get_distribution")
     def test_pkg_info_for_wrong_dist_version(self, get_distribution_mock):
@@ -135,6 +135,6 @@ class DepsTest(unittest.TestCase):
 
         result = deps.pkg_info()
 
-        self.assertEqual("Mopidy", result["name"])
-        self.assertNotIn("version", result)
-        self.assertNotIn("path", result)
+        assert "Mopidy" == result["name"]
+        assert "version" not in result
+        assert "path" not in result

--- a/tests/internal/test_encoding.py
+++ b/tests/internal/test_encoding.py
@@ -14,7 +14,7 @@ class LocaleDecodeTest(unittest.TestCase):
         )
         expected = "[Errno 98] Adresse d\xe9j\xe0 utilis\xe9e"
 
-        self.assertEqual(expected, result)
+        assert expected == result
 
     def test_can_decode_an_ioerror_with_french_content(self, mock):
         mock.return_value = "UTF-8"
@@ -27,21 +27,21 @@ class LocaleDecodeTest(unittest.TestCase):
             r"[Errno 98] b'Adresse d\xc3\xa9j\xc3\xa0 utilis\xc3\xa9e'",  # Py3
         ]
 
-        self.assertIn(result, expected)
+        assert result in expected
 
     def test_does_not_use_locale_to_decode_unicode_strings(self, mock):
         mock.return_value = "UTF-8"
 
         encoding.locale_decode("abc")
 
-        self.assertFalse(mock.called)
+        assert not mock.called
 
     def test_does_not_use_locale_to_decode_ascii_bytestrings(self, mock):
         mock.return_value = "UTF-8"
 
         encoding.locale_decode(b"abc")
 
-        self.assertFalse(mock.called)
+        assert not mock.called
 
     def test_replaces_unknown_bytes_instead_of_crashing(self, mock):
         mock.return_value = "US-ASCII"

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -86,7 +86,7 @@ class JsonRpcSerializationTest(JsonRpcTestBase):
         response = self.jrw.handle_json(request)
 
         self.jrw.handle_data.assert_called_once_with({"foo": "request"})
-        self.assertEqual(response, '{"foo": "response"}')
+        assert response == '{"foo": "response"}'
 
     def test_handle_json_decodes_mopidy_models(self):
         self.jrw.handle_data = mock.Mock()
@@ -106,27 +106,27 @@ class JsonRpcSerializationTest(JsonRpcTestBase):
         request = "[]"
         response = json.loads(self.jrw.handle_json(request))
 
-        self.assertIn("foo", response)
-        self.assertIn("__model__", response["foo"])
-        self.assertEqual(response["foo"]["__model__"], "Artist")
-        self.assertIn("name", response["foo"])
-        self.assertEqual(response["foo"]["name"], "bar")
+        assert "foo" in response
+        assert "__model__" in response["foo"]
+        assert response["foo"]["__model__"] == "Artist"
+        assert "name" in response["foo"]
+        assert response["foo"]["name"] == "bar"
 
     def test_handle_json_returns_nothing_for_notices(self):
         request = '{"jsonrpc": "2.0", "method": "core.get_uri_schemes"}'
         response = self.jrw.handle_json(request)
 
-        self.assertEqual(response, None)
+        assert response is None
 
     def test_invalid_json_command_causes_parse_error(self):
         request = '{"jsonrpc": "2.0", "method": "foobar, "params": "bar", "baz]'
         response = self.jrw.handle_json(request)
         response = json.loads(response)
 
-        self.assertEqual(response["jsonrpc"], "2.0")
+        assert response["jsonrpc"] == "2.0"
         error = response["error"]
-        self.assertEqual(error["code"], -32700)
-        self.assertEqual(error["message"], "Parse error")
+        assert error["code"] == (-32700)
+        assert error["message"] == "Parse error"
 
     def test_invalid_json_batch_causes_parse_error(self):
         request = """[
@@ -136,10 +136,10 @@ class JsonRpcSerializationTest(JsonRpcTestBase):
         response = self.jrw.handle_json(request)
         response = json.loads(response)
 
-        self.assertEqual(response["jsonrpc"], "2.0")
+        assert response["jsonrpc"] == "2.0"
         error = response["error"]
-        self.assertEqual(error["code"], -32700)
-        self.assertEqual(error["message"], "Parse error")
+        assert error["code"] == (-32700)
+        assert error["message"] == "Parse error"
 
 
 class JsonRpcSingleCommandTest(JsonRpcTestBase):
@@ -151,10 +151,10 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["jsonrpc"], "2.0")
-        self.assertEqual(response["id"], 1)
-        self.assertNotIn("error", response)
-        self.assertEqual(response["result"], "Hello, world!")
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "error" not in response
+        assert response["result"] == "Hello, world!"
 
     def test_call_method_on_plain_object(self):
         request = {
@@ -164,10 +164,10 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["jsonrpc"], "2.0")
-        self.assertEqual(response["id"], 1)
-        self.assertNotIn("error", response)
-        self.assertEqual(response["result"], "TI83")
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "error" not in response
+        assert response["result"] == "TI83"
 
     def test_call_method_which_returns_dict_from_plain_object(self):
         request = {
@@ -177,11 +177,11 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["jsonrpc"], "2.0")
-        self.assertEqual(response["id"], 1)
-        self.assertNotIn("error", response)
-        self.assertIn("add", response["result"])
-        self.assertIn("sub", response["result"])
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "error" not in response
+        assert "add" in response["result"]
+        assert "sub" in response["result"]
 
     def test_call_method_on_actor_root(self):
         request = {
@@ -191,10 +191,10 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["jsonrpc"], "2.0")
-        self.assertEqual(response["id"], 1)
-        self.assertNotIn("error", response)
-        self.assertEqual(response["result"], ["dummy"])
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "error" not in response
+        assert response["result"] == ["dummy"]
 
     def test_call_method_on_actor_member(self):
         request = {
@@ -204,7 +204,7 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["result"], 0)
+        assert response["result"] == 0
 
     def test_call_method_which_is_a_directly_mounted_actor_member(self):
         # 'get_uri_schemes' isn't a regular callable, but a Pykka
@@ -218,10 +218,10 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["jsonrpc"], "2.0")
-        self.assertEqual(response["id"], 1)
-        self.assertNotIn("error", response)
-        self.assertEqual(response["result"], ["dummy"])
+        assert response["jsonrpc"] == "2.0"
+        assert response["id"] == 1
+        assert "error" not in response
+        assert response["result"] == ["dummy"]
 
     def test_call_method_with_positional_params(self):
         request = {
@@ -232,7 +232,7 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["result"], 7)
+        assert response["result"] == 7
 
     def test_call_methods_with_named_params(self):
         request = {
@@ -243,7 +243,7 @@ class JsonRpcSingleCommandTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(response["result"], 7)
+        assert response["result"] == 7
 
 
 class JsonRpcSingleNotificationTest(JsonRpcTestBase):
@@ -254,10 +254,10 @@ class JsonRpcSingleNotificationTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response)
+        assert response is None
 
     def test_notification_makes_an_observable_change(self):
-        self.assertEqual(self.calc.get_mem(), None)
+        assert self.calc.get_mem() is None
 
         request = {
             "jsonrpc": "2.0",
@@ -266,8 +266,8 @@ class JsonRpcSingleNotificationTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response)
-        self.assertEqual(self.calc.get_mem(), 37)
+        assert response is None
+        assert self.calc.get_mem() == 37
 
     def test_notification_unknown_method_returns_nothing(self):
         request = {
@@ -277,7 +277,7 @@ class JsonRpcSingleNotificationTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response)
+        assert response is None
 
 
 class JsonRpcBatchTest(JsonRpcTestBase):
@@ -291,12 +291,12 @@ class JsonRpcBatchTest(JsonRpcTestBase):
         ]
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(len(response), 3)
+        assert len(response) == 3
 
         response = {row["id"]: row for row in response}
-        self.assertEqual(response[1]["result"], False)
-        self.assertEqual(response[2]["result"], True)
-        self.assertEqual(response[3]["result"], False)
+        assert response[1]["result"] is False
+        assert response[2]["result"] is True
+        assert response[3]["result"] is False
 
     def test_batch_of_commands_and_notifications_returns_some(self):
         self.core.tracklist.set_random(True).get()
@@ -308,12 +308,12 @@ class JsonRpcBatchTest(JsonRpcTestBase):
         ]
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(len(response), 2)
+        assert len(response) == 2
 
         response = {row["id"]: row for row in response}
-        self.assertNotIn(1, response)
-        self.assertEqual(response[2]["result"], True)
-        self.assertEqual(response[3]["result"], False)
+        assert 1 not in response
+        assert response[2]["result"] is True
+        assert response[3]["result"] is False
 
     def test_batch_of_only_notifications_returns_nothing(self):
         self.core.tracklist.set_random(True).get()
@@ -325,7 +325,7 @@ class JsonRpcBatchTest(JsonRpcTestBase):
         ]
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response)
+        assert response is None
 
 
 class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
@@ -338,17 +338,17 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertNotIn("result", response)
+        assert "result" not in response
 
         error = response["error"]
-        self.assertEqual(error["code"], 0)
-        self.assertEqual(error["message"], "Application error")
+        assert error["code"] == 0
+        assert error["message"] == "Application error"
 
         data = error["data"]
-        self.assertEqual(data["type"], "ValueError")
-        self.assertIn("What did you expect?", data["message"])
-        self.assertIn("traceback", data)
-        self.assertIn("Traceback (most recent call last):", data["traceback"])
+        assert data["type"] == "ValueError"
+        assert "What did you expect?" in data["message"]
+        assert "traceback" in data
+        assert "Traceback (most recent call last):" in data["traceback"]
 
     def test_missing_jsonrpc_member_causes_invalid_request_error(self):
         request = {
@@ -357,11 +357,11 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(error["data"], "'jsonrpc' member must be included")
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert error["data"] == "'jsonrpc' member must be included"
 
     def test_wrong_jsonrpc_version_causes_invalid_request_error(self):
         request = {
@@ -371,11 +371,11 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(error["data"], "'jsonrpc' value must be '2.0'")
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert error["data"] == "'jsonrpc' value must be '2.0'"
 
     def test_missing_method_member_causes_invalid_request_error(self):
         request = {
@@ -384,11 +384,11 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(error["data"], "'method' member must be included")
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert error["data"] == "'method' member must be included"
 
     def test_invalid_method_value_causes_invalid_request_error(self):
         request = {
@@ -398,11 +398,11 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(error["data"], "'method' must be a string")
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert error["data"] == "'method' must be a string"
 
     def test_invalid_params_value_causes_invalid_request_error(self):
         request = {
@@ -413,12 +413,12 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         }
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(
-            error["data"], "'params', if given, must be an array or an object"
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert (
+            error["data"] == "'params', if given, must be an array or an object"
         )
 
     def test_method_on_without_object_causes_unknown_method_error(self):
@@ -430,10 +430,11 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         response = self.jrw.handle_data(request)
 
         error = response["error"]
-        self.assertEqual(error["code"], -32601)
-        self.assertEqual(error["message"], "Method not found")
-        self.assertEqual(
-            error["data"], "Could not find object mount in method name 'bogus'"
+        assert error["code"] == (-32601)
+        assert error["message"] == "Method not found"
+        assert (
+            error["data"]
+            == "Could not find object mount in method name 'bogus'"
         )
 
     def test_method_on_unknown_object_causes_unknown_method_error(self):
@@ -445,9 +446,9 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         response = self.jrw.handle_data(request)
 
         error = response["error"]
-        self.assertEqual(error["code"], -32601)
-        self.assertEqual(error["message"], "Method not found")
-        self.assertEqual(error["data"], "No object found at 'bogus'")
+        assert error["code"] == (-32601)
+        assert error["message"] == "Method not found"
+        assert error["data"] == "No object found at 'bogus'"
 
     def test_unknown_method_on_known_object_causes_unknown_method_error(self):
         request = {
@@ -458,11 +459,9 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         response = self.jrw.handle_data(request)
 
         error = response["error"]
-        self.assertEqual(error["code"], -32601)
-        self.assertEqual(error["message"], "Method not found")
-        self.assertEqual(
-            error["data"], "Object mounted at 'core' has no member 'bogus'"
-        )
+        assert error["code"] == (-32601)
+        assert error["message"] == "Method not found"
+        assert error["data"] == "Object mounted at 'core' has no member 'bogus'"
 
     def test_private_method_causes_unknown_method_error(self):
         request = {
@@ -473,9 +472,9 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         response = self.jrw.handle_data(request)
 
         error = response["error"]
-        self.assertEqual(error["code"], -32601)
-        self.assertEqual(error["message"], "Method not found")
-        self.assertEqual(error["data"], "Private methods are not exported")
+        assert error["code"] == (-32601)
+        assert error["message"] == "Method not found"
+        assert error["data"] == "Private methods are not exported"
 
     def test_invalid_params_causes_invalid_params_error(self):
         request = {
@@ -487,17 +486,17 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         response = self.jrw.handle_data(request)
 
         error = response["error"]
-        self.assertEqual(error["code"], -32602)
-        self.assertEqual(error["message"], "Invalid params")
+        assert error["code"] == (-32602)
+        assert error["message"] == "Invalid params"
 
         data = error["data"]
-        self.assertEqual(data["type"], "TypeError")
-        self.assertEqual(
-            data["message"],
-            "get_uri_schemes() takes 1 positional argument but 2 were given",
+        assert data["type"] == "TypeError"
+        assert (
+            data["message"]
+            == "get_uri_schemes() takes 1 positional argument but 2 were given"
         )
-        self.assertIn("traceback", data)
-        self.assertIn("Traceback (most recent call last):", data["traceback"])
+        assert "traceback" in data
+        assert "Traceback (most recent call last):" in data["traceback"]
 
 
 class JsonRpcBatchErrorTest(JsonRpcTestBase):
@@ -505,35 +504,35 @@ class JsonRpcBatchErrorTest(JsonRpcTestBase):
         request = []
         response = self.jrw.handle_data(request)
 
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(error["data"], "Batch list cannot be empty")
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert error["data"] == "Batch list cannot be empty"
 
     def test_batch_with_invalid_command_causes_invalid_request_error(self):
         request = [1]
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(len(response), 1)
+        assert len(response) == 1
         response = response[0]
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(error["data"], "Request must be an object")
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert error["data"] == "Request must be an object"
 
     def test_batch_with_invalid_commands_causes_invalid_request_error(self):
         request = [1, 2, 3]
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(len(response), 3)
+        assert len(response) == 3
         response = response[2]
-        self.assertIsNone(response["id"])
+        assert response["id"] is None
         error = response["error"]
-        self.assertEqual(error["code"], -32600)
-        self.assertEqual(error["message"], "Invalid Request")
-        self.assertEqual(error["data"], "Request must be an object")
+        assert error["code"] == (-32600)
+        assert error["message"] == "Invalid Request"
+        assert error["data"] == "Request must be an object"
 
     def test_batch_of_both_successfull_and_failing_requests(self):
         request = [
@@ -575,13 +574,13 @@ class JsonRpcBatchErrorTest(JsonRpcTestBase):
         ]
         response = self.jrw.handle_data(request)
 
-        self.assertEqual(len(response), 5)
+        assert len(response) == 5
         response = {row["id"]: row for row in response}
-        self.assertEqual(response["1"]["result"], False)
-        self.assertEqual(response["2"]["result"], None)
-        self.assertEqual(response[None]["error"]["code"], -32600)
-        self.assertEqual(response["5"]["error"]["code"], -32601)
-        self.assertEqual(response["9"]["result"], False)
+        assert response["1"]["result"] is False
+        assert response["2"]["result"] is None
+        assert response[None]["error"]["code"] == (-32600)
+        assert response["5"]["error"]["code"] == (-32601)
+        assert response["9"]["result"] is False
 
 
 class JsonRpcInspectorTest(JsonRpcTestBase):
@@ -594,46 +593,46 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
 
         methods = inspector.describe()
 
-        self.assertIn("hello", methods)
-        self.assertEqual(len(methods["hello"]["params"]), 0)
+        assert "hello" in methods
+        assert len(methods["hello"]["params"]) == 0
 
     def test_inspector_can_describe_an_object_with_methods(self):
         inspector = jsonrpc.JsonRpcInspector({"calc": Calculator})
 
         methods = inspector.describe()
 
-        self.assertIn("calc.add", methods)
-        self.assertEqual(
-            methods["calc.add"]["description"],
-            "Returns the sum of the given numbers",
+        assert "calc.add" in methods
+        assert (
+            methods["calc.add"]["description"]
+            == "Returns the sum of the given numbers"
         )
 
-        self.assertIn("calc.sub", methods)
-        self.assertIn("calc.take_it_all", methods)
-        self.assertNotIn("calc._secret", methods)
-        self.assertNotIn("calc.__init__", methods)
+        assert "calc.sub" in methods
+        assert "calc.take_it_all" in methods
+        assert "calc._secret" not in methods
+        assert "calc.__init__" not in methods
 
         method = methods["calc.take_it_all"]
-        self.assertIn("params", method)
+        assert "params" in method
 
         params = method["params"]
 
-        self.assertEqual(params[0]["name"], "a")
-        self.assertNotIn("default", params[0])
+        assert params[0]["name"] == "a"
+        assert "default" not in params[0]
 
-        self.assertEqual(params[1]["name"], "b")
-        self.assertNotIn("default", params[1])
+        assert params[1]["name"] == "b"
+        assert "default" not in params[1]
 
-        self.assertEqual(params[2]["name"], "c")
-        self.assertEqual(params[2]["default"], True)
+        assert params[2]["name"] == "c"
+        assert params[2]["default"] is True
 
-        self.assertEqual(params[3]["name"], "args")
-        self.assertNotIn("default", params[3])
-        self.assertEqual(params[3]["varargs"], True)
+        assert params[3]["name"] == "args"
+        assert "default" not in params[3]
+        assert params[3]["varargs"] is True
 
-        self.assertEqual(params[4]["name"], "kwargs")
-        self.assertNotIn("default", params[4])
-        self.assertEqual(params[4]["kwargs"], True)
+        assert params[4]["name"] == "kwargs"
+        assert "default" not in params[4]
+        assert params[4]["kwargs"] is True
 
     def test_inspector_can_describe_a_bunch_of_large_classes(self):
         inspector = jsonrpc.JsonRpcInspector(
@@ -648,21 +647,19 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
 
         methods = inspector.describe()
 
-        self.assertIn("core.get_uri_schemes", methods)
-        self.assertEqual(len(methods["core.get_uri_schemes"]["params"]), 0)
+        assert "core.get_uri_schemes" in methods
+        assert len(methods["core.get_uri_schemes"]["params"]) == 0
 
-        self.assertIn("core.library.lookup", methods)
-        self.assertEqual(
-            methods["core.library.lookup"]["params"][0]["name"], "uris"
-        )
+        assert "core.library.lookup" in methods
+        assert methods["core.library.lookup"]["params"][0]["name"] == "uris"
 
-        self.assertIn("core.playback.next", methods)
-        self.assertEqual(len(methods["core.playback.next"]["params"]), 0)
+        assert "core.playback.next" in methods
+        assert len(methods["core.playback.next"]["params"]) == 0
 
-        self.assertIn("core.playlists.as_list", methods)
-        self.assertEqual(len(methods["core.playlists.as_list"]["params"]), 0)
+        assert "core.playlists.as_list" in methods
+        assert len(methods["core.playlists.as_list"]["params"]) == 0
 
-        self.assertIn("core.tracklist.filter", methods)
-        self.assertEqual(
-            methods["core.tracklist.filter"]["params"][0]["name"], "criteria"
+        assert "core.tracklist.filter" in methods
+        assert (
+            methods["core.tracklist.filter"]["params"][0]["name"] == "criteria"
         )

--- a/tests/internal/test_models.py
+++ b/tests/internal/test_models.py
@@ -21,14 +21,14 @@ class HistoryTrackTest(unittest.TestCase):
     def test_track(self):
         track = Ref.track()
         result = HistoryTrack(track=track)
-        self.assertEqual(result.track, track)
+        assert result.track == track
         with self.assertRaises(AttributeError):
             result.track = None
 
     def test_timestamp(self):
         timestamp = 1234
         result = HistoryTrack(timestamp=timestamp)
-        self.assertEqual(result.timestamp, timestamp)
+        assert result.timestamp == timestamp
         with self.assertRaises(AttributeError):
             result.timestamp = None
 
@@ -36,14 +36,14 @@ class HistoryTrackTest(unittest.TestCase):
         result = HistoryTrack(track=Ref.track(), timestamp=1234)
         serialized = json.dumps(result, cls=ModelJSONEncoder)
         deserialized = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(result, deserialized)
+        assert result == deserialized
 
 
 class HistoryStateTest(unittest.TestCase):
     def test_history_list(self):
         history = (HistoryTrack(), HistoryTrack())
         result = HistoryState(history=history)
-        self.assertEqual(result.history, history)
+        assert result.history == history
         with self.assertRaises(AttributeError):
             result.history = None
 
@@ -56,14 +56,14 @@ class HistoryStateTest(unittest.TestCase):
         result = HistoryState(history=(HistoryTrack(), HistoryTrack()))
         serialized = json.dumps(result, cls=ModelJSONEncoder)
         deserialized = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(result, deserialized)
+        assert result == deserialized
 
 
 class MixerStateTest(unittest.TestCase):
     def test_volume(self):
         volume = 37
         result = MixerState(volume=volume)
-        self.assertEqual(result.volume, volume)
+        assert result.volume == volume
         with self.assertRaises(AttributeError):
             result.volume = None
 
@@ -75,33 +75,33 @@ class MixerStateTest(unittest.TestCase):
     def test_mute_false(self):
         mute = False
         result = MixerState(mute=mute)
-        self.assertEqual(result.mute, mute)
+        assert result.mute == mute
         with self.assertRaises(AttributeError):
             result.mute = None
 
     def test_mute_true(self):
         mute = True
         result = MixerState(mute=mute)
-        self.assertEqual(result.mute, mute)
+        assert result.mute == mute
         with self.assertRaises(AttributeError):
             result.mute = False
 
     def test_mute_default(self):
         result = MixerState()
-        self.assertEqual(result.mute, False)
+        assert result.mute is False
 
     def test_to_json_and_back(self):
         result = MixerState(volume=77)
         serialized = json.dumps(result, cls=ModelJSONEncoder)
         deserialized = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(result, deserialized)
+        assert result == deserialized
 
 
 class PlaybackStateTest(unittest.TestCase):
     def test_position(self):
         time_position = 123456
         result = PlaybackState(time_position=time_position)
-        self.assertEqual(result.time_position, time_position)
+        assert result.time_position == time_position
         with self.assertRaises(AttributeError):
             result.time_position = None
 
@@ -113,14 +113,14 @@ class PlaybackStateTest(unittest.TestCase):
     def test_tl_track(self):
         tlid = 42
         result = PlaybackState(tlid=tlid)
-        self.assertEqual(result.tlid, tlid)
+        assert result.tlid == tlid
         with self.assertRaises(AttributeError):
             result.tlid = None
 
     def test_tl_track_none(self):
         tlid = None
         result = PlaybackState(tlid=tlid)
-        self.assertEqual(result.tlid, tlid)
+        assert result.tlid == tlid
         with self.assertRaises(AttributeError):
             result.tl_track = None
 
@@ -132,7 +132,7 @@ class PlaybackStateTest(unittest.TestCase):
     def test_state(self):
         state = "playing"
         result = PlaybackState(state=state)
-        self.assertEqual(result.state, state)
+        assert result.state == state
         with self.assertRaises(AttributeError):
             result.state = None
 
@@ -145,21 +145,21 @@ class PlaybackStateTest(unittest.TestCase):
         result = PlaybackState(state="playing", tlid=4321)
         serialized = json.dumps(result, cls=ModelJSONEncoder)
         deserialized = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(result, deserialized)
+        assert result == deserialized
 
 
 class TracklistStateTest(unittest.TestCase):
     def test_repeat_true(self):
         repeat = True
         result = TracklistState(repeat=repeat)
-        self.assertEqual(result.repeat, repeat)
+        assert result.repeat == repeat
         with self.assertRaises(AttributeError):
             result.repeat = None
 
     def test_repeat_false(self):
         repeat = False
         result = TracklistState(repeat=repeat)
-        self.assertEqual(result.repeat, repeat)
+        assert result.repeat == repeat
         with self.assertRaises(AttributeError):
             result.repeat = None
 
@@ -171,28 +171,28 @@ class TracklistStateTest(unittest.TestCase):
     def test_consume_true(self):
         val = True
         result = TracklistState(consume=val)
-        self.assertEqual(result.consume, val)
+        assert result.consume == val
         with self.assertRaises(AttributeError):
             result.repeat = None
 
     def test_random_true(self):
         val = True
         result = TracklistState(random=val)
-        self.assertEqual(result.random, val)
+        assert result.random == val
         with self.assertRaises(AttributeError):
             result.random = None
 
     def test_single_true(self):
         val = True
         result = TracklistState(single=val)
-        self.assertEqual(result.single, val)
+        assert result.single == val
         with self.assertRaises(AttributeError):
             result.single = None
 
     def test_next_tlid(self):
         val = 654
         result = TracklistState(next_tlid=val)
-        self.assertEqual(result.next_tlid, val)
+        assert result.next_tlid == val
         with self.assertRaises(AttributeError):
             result.next_tlid = None
 
@@ -204,7 +204,7 @@ class TracklistStateTest(unittest.TestCase):
     def test_tracks(self):
         tracks = (TlTrack(), TlTrack())
         result = TracklistState(tl_tracks=tracks)
-        self.assertEqual(result.tl_tracks, tracks)
+        assert result.tl_tracks == tracks
         with self.assertRaises(AttributeError):
             result.tl_tracks = None
 
@@ -217,4 +217,4 @@ class TracklistStateTest(unittest.TestCase):
         result = TracklistState(tl_tracks=(TlTrack(), TlTrack()), next_tlid=4)
         serialized = json.dumps(result, cls=ModelJSONEncoder)
         deserialized = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(result, deserialized)
+        assert result == deserialized

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -125,13 +125,13 @@ class GetOrCreateFileTest(unittest.TestCase):
 
 class GetUnixSocketPathTest(unittest.TestCase):
     def test_correctly_matched_socket_path(self):
-        self.assertEqual(
-            path.get_unix_socket_path("unix:/tmp/mopidy.socket"),
-            "/tmp/mopidy.socket",
+        assert (
+            path.get_unix_socket_path("unix:/tmp/mopidy.socket")
+            == "/tmp/mopidy.socket"
         )
 
     def test_correctly_no_match_socket_path(self):
-        self.assertIsNone(path.get_unix_socket_path("127.0.0.1"))
+        assert path.get_unix_socket_path("127.0.0.1") is None
 
 
 class PathToFileURITest(unittest.TestCase):

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -44,19 +44,19 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
     def test_created_playlist_is_persisted(self):
         uri = "m3u:test.m3u"
         path = self.playlists_dir / "test.m3u"
-        self.assertFalse(path.exists())
+        assert not path.exists()
 
         playlist = self.core.playlists.create("test")
-        self.assertEqual("test", playlist.name)
-        self.assertEqual(uri, playlist.uri)
-        self.assertTrue(path.exists())
+        assert "test" == playlist.name
+        assert uri == playlist.uri
+        assert path.exists()
 
     def test_create_sanitizes_playlist_name(self):
         playlist = self.core.playlists.create("  ../../test FOO baR ")
-        self.assertEqual("..|..|test FOO baR", playlist.name)
+        assert "..|..|test FOO baR" == playlist.name
         path = self.playlists_dir / "..|..|test FOO baR.m3u"
-        self.assertEqual(self.playlists_dir, path.parent)
-        self.assertTrue(path.exists())
+        assert self.playlists_dir == path.parent
+        assert path.exists()
 
     def test_saved_playlist_is_persisted(self):
         uri1 = "m3u:test1.m3u"
@@ -66,36 +66,36 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         path2 = self.playlists_dir / "test2.m3u"
 
         playlist = self.core.playlists.create("test1")
-        self.assertEqual("test1", playlist.name)
-        self.assertEqual(uri1, playlist.uri)
-        self.assertTrue(path1.exists())
-        self.assertFalse(path2.exists())
+        assert "test1" == playlist.name
+        assert uri1 == playlist.uri
+        assert path1.exists()
+        assert not path2.exists()
 
         playlist = self.core.playlists.save(playlist.replace(name="test2"))
-        self.assertEqual("test2", playlist.name)
-        self.assertEqual(uri2, playlist.uri)
-        self.assertFalse(path1.exists())
-        self.assertTrue(path2.exists())
+        assert "test2" == playlist.name
+        assert uri2 == playlist.uri
+        assert not path1.exists()
+        assert path2.exists()
 
     def test_deleted_playlist_is_removed(self):
         uri = "m3u:test.m3u"
         path = self.playlists_dir / "test.m3u"
 
-        self.assertFalse(path.exists())
+        assert not path.exists()
 
         playlist = self.core.playlists.create("test")
-        self.assertEqual("test", playlist.name)
-        self.assertEqual(uri, playlist.uri)
-        self.assertTrue(path.exists())
+        assert "test" == playlist.name
+        assert uri == playlist.uri
+        assert path.exists()
 
         success = self.core.playlists.delete(playlist.uri)
-        self.assertTrue(success)
-        self.assertFalse(path.exists())
+        assert success
+        assert not path.exists()
 
     def test_delete_on_path_outside_playlist_dir_returns_none(self):
         success = self.core.playlists.delete("m3u:///etc/passwd")
 
-        self.assertFalse(success)
+        assert not success
 
     def test_playlist_contents_is_written_to_disk(self):
         track = Track(uri=generate_song(1))
@@ -105,7 +105,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         contents = path.read_text()
 
-        self.assertEqual(track.uri, contents.strip())
+        assert track.uri == contents.strip()
 
     def test_extended_playlist_contents_is_written_to_disk(self):
         track = Track(uri=generate_song(1), name="Test", length=60000)
@@ -115,7 +115,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         m3u = path.read_text().splitlines()
 
-        self.assertEqual(["#EXTM3U", "#EXTINF:-1,Test", track.uri], m3u)
+        assert ["#EXTM3U", "#EXTINF:-1,Test", track.uri] == m3u
 
     def test_latin1_playlist_contents_is_written_to_disk(self):
         track = Track(uri=generate_song(1), name="Test\x9f", length=60000)
@@ -128,7 +128,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         track_uri = track.uri
         if not isinstance(track_uri, bytes):
             track_uri = track.uri.encode()
-        self.assertEqual([b"#EXTM3U", b"#EXTINF:-1,Test\x9f", track_uri], m3u)
+        assert [b"#EXTM3U", b"#EXTINF:-1,Test\x9f", track_uri] == m3u
 
     def test_utf8_playlist_contents_is_replaced_and_written_to_disk(self):
         track = Track(uri=generate_song(1), name="Test\u07b4", length=60000)
@@ -141,7 +141,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         track_uri = track.uri
         if not isinstance(track_uri, bytes):
             track_uri = track.uri.encode()
-        self.assertEqual([b"#EXTM3U", b"#EXTINF:-1,Test?", track_uri], m3u)
+        assert [b"#EXTM3U", b"#EXTINF:-1,Test?", track_uri] == m3u
 
     def test_playlists_are_loaded_at_startup(self):
         track = Track(uri="dummy:track:path2")
@@ -149,11 +149,11 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         playlist = playlist.replace(tracks=[track])
         playlist = self.core.playlists.save(playlist)
 
-        self.assertEqual(len(self.core.playlists.as_list()), 1)
+        assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.lookup(playlist.uri)
-        self.assertEqual(playlist.uri, result.uri)
-        self.assertEqual(playlist.name, result.name)
-        self.assertEqual(track.uri, result.tracks[0].uri)
+        assert playlist.uri == result.uri
+        assert playlist.name == result.name
+        assert track.uri == result.tracks[0].uri
 
     @unittest.skipIf(
         platform.system() == "Darwin",
@@ -167,9 +167,9 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         self.core.playlists.refresh()
 
-        self.assertEqual(len(self.core.playlists.as_list()), 1)
+        assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.as_list()
-        self.assertEqual("\ufffd\ufffd\ufffd", result[0].name)
+        assert "���" == result[0].name
 
     @unittest.SkipTest
     def test_playlists_dir_is_created(self):
@@ -177,104 +177,102 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
     def test_create_returns_playlist_with_name_set(self):
         playlist = self.core.playlists.create("test")
-        self.assertEqual(playlist.name, "test")
+        assert playlist.name == "test"
 
     def test_create_returns_playlist_with_uri_set(self):
         playlist = self.core.playlists.create("test")
-        self.assertTrue(playlist.uri)
+        assert playlist.uri
 
     def test_create_adds_playlist_to_playlists_collection(self):
         playlist = self.core.playlists.create("test")
         playlists = self.core.playlists.as_list()
-        self.assertIn(playlist.uri, [ref.uri for ref in playlists])
+        assert playlist.uri in [ref.uri for ref in playlists]
 
     def test_as_list_empty_to_start_with(self):
-        self.assertEqual(len(self.core.playlists.as_list()), 0)
+        assert len(self.core.playlists.as_list()) == 0
 
     def test_as_list_ignores_non_playlists(self):
         path = self.playlists_dir / "test.foo"
         path.touch()
-        self.assertTrue(path.exists())
+        assert path.exists()
 
         self.core.playlists.refresh()
 
-        self.assertEqual(len(self.core.playlists.as_list()), 0)
+        assert len(self.core.playlists.as_list()) == 0
 
     def test_delete_non_existant_playlist(self):
         self.core.playlists.delete("m3u:unknown")
 
     def test_delete_playlist_removes_it_from_the_collection(self):
         playlist = self.core.playlists.create("test")
-        self.assertEqual(playlist, self.core.playlists.lookup(playlist.uri))
+        assert playlist == self.core.playlists.lookup(playlist.uri)
 
         self.core.playlists.delete(playlist.uri)
 
-        self.assertIsNone(self.core.playlists.lookup(playlist.uri))
+        assert self.core.playlists.lookup(playlist.uri) is None
 
     def test_delete_playlist_without_file(self):
         playlist = self.core.playlists.create("test")
-        self.assertEqual(playlist, self.core.playlists.lookup(playlist.uri))
+        assert playlist == self.core.playlists.lookup(playlist.uri)
 
         path = self.playlists_dir / "test.m3u"
-        self.assertTrue(path.exists())
+        assert path.exists()
 
         path.unlink()
-        self.assertFalse(path.exists())
+        assert not path.exists()
 
         self.core.playlists.delete(playlist.uri)
-        self.assertIsNone(self.core.playlists.lookup(playlist.uri))
+        assert self.core.playlists.lookup(playlist.uri) is None
 
     def test_lookup_finds_playlist_by_uri(self):
         original_playlist = self.core.playlists.create("test")
 
         looked_up_playlist = self.core.playlists.lookup(original_playlist.uri)
 
-        self.assertEqual(original_playlist, looked_up_playlist)
+        assert original_playlist == looked_up_playlist
 
     def test_lookup_on_path_outside_playlist_dir_returns_none(self):
         result = self.core.playlists.lookup("m3u:///etc/passwd")
 
-        self.assertIsNone(result)
+        assert result is None
 
     def test_refresh(self):
         playlist = self.core.playlists.create("test")
-        self.assertEqual(playlist, self.core.playlists.lookup(playlist.uri))
+        assert playlist == self.core.playlists.lookup(playlist.uri)
 
         self.core.playlists.refresh()
 
-        self.assertEqual(playlist, self.core.playlists.lookup(playlist.uri))
+        assert playlist == self.core.playlists.lookup(playlist.uri)
 
     def test_save_replaces_existing_playlist_with_updated_playlist(self):
         playlist1 = self.core.playlists.create("test1")
-        self.assertEqual(playlist1, self.core.playlists.lookup(playlist1.uri))
+        assert playlist1 == self.core.playlists.lookup(playlist1.uri)
 
         playlist2 = playlist1.replace(name="test2")
         playlist2 = self.core.playlists.save(playlist2)
-        self.assertIsNone(self.core.playlists.lookup(playlist1.uri))
-        self.assertEqual(playlist2, self.core.playlists.lookup(playlist2.uri))
+        assert self.core.playlists.lookup(playlist1.uri) is None
+        assert playlist2 == self.core.playlists.lookup(playlist2.uri)
 
     def test_create_replaces_existing_playlist_with_updated_playlist(self):
         track = Track(uri=generate_song(1))
         playlist1 = self.core.playlists.create("test")
         playlist1 = self.core.playlists.save(playlist1.replace(tracks=[track]))
-        self.assertEqual(playlist1, self.core.playlists.lookup(playlist1.uri))
+        assert playlist1 == self.core.playlists.lookup(playlist1.uri)
 
         playlist2 = self.core.playlists.create("test")
-        self.assertEqual(playlist1.uri, playlist2.uri)
-        self.assertNotEqual(
-            playlist1, self.core.playlists.lookup(playlist1.uri)
-        )
-        self.assertEqual(playlist2, self.core.playlists.lookup(playlist1.uri))
+        assert playlist1.uri == playlist2.uri
+        assert playlist1 != self.core.playlists.lookup(playlist1.uri)
+        assert playlist2 == self.core.playlists.lookup(playlist1.uri)
 
     def test_save_playlist_with_new_uri(self):
         uri = "m3u:test.m3u"
         self.core.playlists.save(Playlist(uri=uri))
         path = self.playlists_dir / "test.m3u"
-        self.assertTrue(path.exists())
+        assert path.exists()
 
     def test_save_on_path_outside_playlist_dir_returns_none(self):
         result = self.core.playlists.save(Playlist(uri="m3u:///tmp/test.m3u"))
-        self.assertIsNone(result)
+        assert result is None
 
     def test_playlist_with_unknown_track(self):
         track = Track(uri="file:///dev/null")
@@ -282,11 +280,11 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         playlist = playlist.replace(tracks=[track])
         playlist = self.core.playlists.save(playlist)
 
-        self.assertEqual(len(self.core.playlists.as_list()), 1)
+        assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.lookup("m3u:test.m3u")
-        self.assertEqual("m3u:test.m3u", result.uri)
-        self.assertEqual(playlist.name, result.name)
-        self.assertEqual(track.uri, result.tracks[0].uri)
+        assert "m3u:test.m3u" == result.uri
+        assert playlist.name == result.name
+        assert track.uri == result.tracks[0].uri
 
     def test_playlist_with_absolute_path(self):
         track = Track(uri="/tmp/test.mp3")
@@ -295,11 +293,11 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         playlist = playlist.replace(tracks=[track])
         playlist = self.core.playlists.save(playlist)
 
-        self.assertEqual(len(self.core.playlists.as_list()), 1)
+        assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.lookup("m3u:test.m3u")
-        self.assertEqual("m3u:test.m3u", result.uri)
-        self.assertEqual(playlist.name, result.name)
-        self.assertEqual(filepath.as_uri(), result.tracks[0].uri)
+        assert "m3u:test.m3u" == result.uri
+        assert playlist.name == result.name
+        assert filepath.as_uri() == result.tracks[0].uri
 
     def test_playlist_with_relative_path(self):
         track = Track(uri="test.mp3")
@@ -308,15 +306,15 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         playlist = playlist.replace(tracks=[track])
         playlist = self.core.playlists.save(playlist)
 
-        self.assertEqual(len(self.core.playlists.as_list()), 1)
+        assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.lookup("m3u:test.m3u")
-        self.assertEqual("m3u:test.m3u", result.uri)
-        self.assertEqual(playlist.name, result.name)
-        self.assertEqual(filepath.as_uri(), result.tracks[0].uri)
+        assert "m3u:test.m3u" == result.uri
+        assert playlist.name == result.name
+        assert filepath.as_uri() == result.tracks[0].uri
 
     def test_playlist_sort_order(self):
         def check_order(playlists, names):
-            self.assertEqual(names, [playlist.name for playlist in playlists])
+            assert names == [playlist.name for playlist in playlists]
 
         self.core.playlists.create("c")
         self.core.playlists.create("a")
@@ -345,20 +343,20 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         item_refs = self.core.playlists.get_items(playlist.uri)
 
-        self.assertEqual(len(item_refs), 1)
-        self.assertEqual(item_refs[0].type, "track")
-        self.assertEqual(item_refs[0].uri, "dummy:a")
-        self.assertEqual(item_refs[0].name, "A")
+        assert len(item_refs) == 1
+        assert item_refs[0].type == "track"
+        assert item_refs[0].uri == "dummy:a"
+        assert item_refs[0].name == "A"
 
     def test_get_items_of_unknown_playlist_returns_none(self):
         item_refs = self.core.playlists.get_items("dummy:unknown")
 
-        self.assertIsNone(item_refs)
+        assert item_refs is None
 
     def test_get_items_from_file_outside_playlist_dir_returns_none(self):
         item_refs = self.core.playlists.get_items("m3u:///etc/passwd")
 
-        self.assertIsNone(item_refs)
+        assert item_refs is None
 
 
 class M3UPlaylistsProviderBaseDirectoryTest(M3UPlaylistsProviderTest):

--- a/tests/models/test_fields.py
+++ b/tests/models/test_fields.py
@@ -24,58 +24,58 @@ class FieldDescriptorTest(unittest.TestCase):
     def test_raw_field_accesible_through_class(self):
         field = Field()
         instance = create_instance(field)
-        self.assertEqual(field, instance.__class__.attr)
+        assert field == instance.__class__.attr
 
     def test_field_knows_its_name(self):
         instance = create_instance(Field())
-        self.assertEqual("attr", instance.__class__.attr._name)
+        assert "attr" == instance.__class__.attr._name
 
     def test_field_has_none_as_default(self):
         instance = create_instance(Field())
-        self.assertIsNone(instance.attr)
+        assert instance.attr is None
 
     def test_field_does_not_store_default(self):
         instance = create_instance(Field())
-        self.assertFalse(hasattr(instance, "_attr"))
+        assert not hasattr(instance, "_attr")
 
     def test_field_assigment_and_retrival(self):
         instance = create_instance(Field())
         instance.attr = 1234
-        self.assertEqual(1234, instance.attr)
+        assert 1234 == instance.attr
 
     def test_field_can_be_reassigned(self):
         instance = create_instance(Field())
         instance.attr = 1234
         instance.attr = 5678
-        self.assertEqual(5678, instance.attr)
+        assert 5678 == instance.attr
 
     def test_field_can_be_deleted(self):
         instance = create_instance(Field())
         instance.attr = 1234
         del instance.attr
-        self.assertEqual(None, instance.attr)
-        self.assertFalse(hasattr(instance, "_attr"))
+        assert instance.attr is None
+        assert not hasattr(instance, "_attr")
 
     def test_field_can_be_set_to_none(self):
         instance = create_instance(Field())
         instance.attr = 1234
         instance.attr = None
-        self.assertEqual(None, instance.attr)
-        self.assertFalse(hasattr(instance, "_attr"))
+        assert instance.attr is None
+        assert not hasattr(instance, "_attr")
 
     def test_field_can_be_set_default(self):
         default = object()
         instance = create_instance(Field(default=default))
         instance.attr = 1234
         instance.attr = default
-        self.assertEqual(default, instance.attr)
-        self.assertFalse(hasattr(instance, "_attr"))
+        assert default == instance.attr
+        assert not hasattr(instance, "_attr")
 
 
 class FieldTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(Field(default=1234))
-        self.assertEqual(1234, instance.attr)
+        assert 1234 == instance.attr
 
     def test_type_checking(self):
         instance = create_instance(Field(type=set))
@@ -103,17 +103,17 @@ class FieldTest(unittest.TestCase):
 class StringTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(String(default="abc"))
-        self.assertEqual("abc", instance.attr)
+        assert "abc" == instance.attr
 
     def test_native_str_allowed(self):
         instance = create_instance(String())
         instance.attr = "abc"
-        self.assertEqual("abc", instance.attr)
+        assert "abc" == instance.attr
 
     def test_unicode_allowed(self):
         instance = create_instance(String())
         instance.attr = "abc"
-        self.assertEqual("abc", instance.attr)
+        assert "abc" == instance.attr
 
     def test_other_disallowed(self):
         instance = create_instance(String())
@@ -123,28 +123,28 @@ class StringTest(unittest.TestCase):
     def test_empty_string(self):
         instance = create_instance(String())
         instance.attr = ""
-        self.assertEqual("", instance.attr)
+        assert "" == instance.attr
 
 
 class IdentifierTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(Identifier(default="abc"))
-        self.assertEqual("abc", instance.attr)
+        assert "abc" == instance.attr
 
     def test_native_str_allowed(self):
         instance = create_instance(Identifier())
         instance.attr = "abc"
-        self.assertEqual("abc", instance.attr)
+        assert "abc" == instance.attr
 
     def test_unicode_allowed(self):
         instance = create_instance(Identifier())
         instance.attr = "abc"
-        self.assertEqual("abc", instance.attr)
+        assert "abc" == instance.attr
 
     def test_unicode_with_nonascii_allowed(self):
         instance = create_instance(Identifier())
         instance.attr = "æøå"
-        self.assertEqual("æøå", instance.attr)
+        assert "æøå" == instance.attr
 
     def test_other_disallowed(self):
         instance = create_instance(Identifier())
@@ -154,18 +154,18 @@ class IdentifierTest(unittest.TestCase):
     def test_empty_string(self):
         instance = create_instance(Identifier())
         instance.attr = ""
-        self.assertEqual("", instance.attr)
+        assert "" == instance.attr
 
 
 class IntegerTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(Integer(default=1234))
-        self.assertEqual(1234, instance.attr)
+        assert 1234 == instance.attr
 
     def test_int_allowed(self):
         instance = create_instance(Integer())
         instance.attr = int(123)
-        self.assertEqual(123, instance.attr)
+        assert 123 == instance.attr
 
     def test_float_disallowed(self):
         instance = create_instance(Integer())
@@ -185,7 +185,7 @@ class IntegerTest(unittest.TestCase):
     def test_min_validation(self):
         instance = create_instance(Integer(min=0))
         instance.attr = 0
-        self.assertEqual(0, instance.attr)
+        assert 0 == instance.attr
 
         with self.assertRaises(ValueError):
             instance.attr = -1
@@ -193,7 +193,7 @@ class IntegerTest(unittest.TestCase):
     def test_max_validation(self):
         instance = create_instance(Integer(max=10))
         instance.attr = 10
-        self.assertEqual(10, instance.attr)
+        assert 10 == instance.attr
 
         with self.assertRaises(ValueError):
             instance.attr = 11
@@ -202,17 +202,17 @@ class IntegerTest(unittest.TestCase):
 class BooleanTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(Boolean(default=True))
-        self.assertEqual(True, instance.attr)
+        assert instance.attr is True
 
     def test_true_allowed(self):
         instance = create_instance(Boolean())
         instance.attr = True
-        self.assertEqual(True, instance.attr)
+        assert instance.attr is True
 
     def test_false_allowed(self):
         instance = create_instance(Boolean())
         instance.attr = False
-        self.assertEqual(False, instance.attr)
+        assert instance.attr is False
 
     def test_int_forbidden(self):
         instance = create_instance(Boolean())
@@ -223,17 +223,17 @@ class BooleanTest(unittest.TestCase):
 class CollectionTest(unittest.TestCase):
     def test_container_instance_is_default(self):
         instance = create_instance(Collection(type=int, container=frozenset))
-        self.assertEqual(frozenset(), instance.attr)
+        assert frozenset() == instance.attr
 
     def test_empty_collection(self):
         instance = create_instance(Collection(type=int, container=frozenset))
         instance.attr = []
-        self.assertEqual(frozenset(), instance.attr)
+        assert frozenset() == instance.attr
 
     def test_collection_gets_stored_in_container(self):
         instance = create_instance(Collection(type=int, container=frozenset))
         instance.attr = [1, 2, 3]
-        self.assertEqual(frozenset([1, 2, 3]), instance.attr)
+        assert frozenset([1, 2, 3]) == instance.attr
 
     def test_collection_with_wrong_type(self):
         instance = create_instance(Collection(type=int, container=frozenset))

--- a/tests/models/test_legacy.py
+++ b/tests/models/test_legacy.py
@@ -20,8 +20,8 @@ class SubModel(ImmutableObject):
 
 class GenericCopyTest(unittest.TestCase):
     def compare(self, orig, other):
-        self.assertEqual(orig, other)
-        self.assertNotEqual(id(orig), id(other))
+        assert orig == other
+        assert id(orig) != id(other)
 
     def test_copying_model(self):
         model = Model()
@@ -30,19 +30,19 @@ class GenericCopyTest(unittest.TestCase):
     def test_copying_model_with_basic_values(self):
         model = Model(name="foo", uri="bar")
         other = model.replace(name="baz")
-        self.assertEqual("baz", other.name)
-        self.assertEqual("bar", other.uri)
+        assert "baz" == other.name
+        assert "bar" == other.uri
 
     def test_copying_model_with_missing_values(self):
         model = Model(uri="bar")
         other = model.replace(name="baz")
-        self.assertEqual("baz", other.name)
-        self.assertEqual("bar", other.uri)
+        assert "baz" == other.name
+        assert "bar" == other.uri
 
     def test_copying_model_with_private_internal_value(self):
         model = Model(models=[SubModel(name=123)])
         other = model.replace(models=[SubModel(name=345)])
-        self.assertIn(SubModel(name=345), other.models)
+        assert SubModel(name=345) in other.models
 
     def test_copying_model_with_invalid_key(self):
         with self.assertRaises(TypeError):
@@ -50,48 +50,47 @@ class GenericCopyTest(unittest.TestCase):
 
     def test_copying_model_to_remove(self):
         model = Model(name="foo").replace(name=None)
-        self.assertEqual(model, Model())
+        assert model == Model()
 
 
 class ModelTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         model = Model(uri=uri)
-        self.assertEqual(model.uri, uri)
+        assert model.uri == uri
         with self.assertRaises(AttributeError):
             model.uri = None
 
     def test_name(self):
         name = "a name"
         model = Model(name=name)
-        self.assertEqual(model.name, name)
+        assert model.name == name
         with self.assertRaises(AttributeError):
             model.name = None
 
     def test_submodels(self):
         models = [SubModel(name=123), SubModel(name=456)]
         model = Model(models=models)
-        self.assertEqual(set(model.models), set(models))
+        assert set(model.models) == set(models)
         with self.assertRaises(AttributeError):
             model.models = None
 
     def test_models_none(self):
-        self.assertEqual(set(), Model(models=None).models)
+        assert set() == Model(models=None).models
 
     def test_invalid_kwarg(self):
         with self.assertRaises(TypeError):
             Model(foo="baz")
 
     def test_repr_without_models(self):
-        self.assertEqual(
-            "Model(name='name', uri='uri')",
-            repr(Model(uri="uri", name="name")),
+        assert "Model(name='name', uri='uri')" == repr(
+            Model(uri="uri", name="name")
         )
 
     def test_repr_with_models(self):
-        self.assertEqual(
-            "Model(models=[SubModel(name=123)], name='name', uri='uri')",
-            repr(Model(uri="uri", name="name", models=[SubModel(name=123)])),
+        assert (
+            "Model(models=[SubModel(name=123)], name='name', uri='uri')"
+            == repr(Model(uri="uri", name="name", models=[SubModel(name=123)]))
         )
 
     def test_serialize_without_models(self):
@@ -115,56 +114,56 @@ class ModelTest(unittest.TestCase):
     def test_eq_uri(self):
         model1 = Model(uri="uri1")
         model2 = Model(uri="uri1")
-        self.assertEqual(model1, model2)
-        self.assertEqual(hash(model1), hash(model2))
+        assert model1 == model2
+        assert hash(model1) == hash(model2)
 
     def test_eq_name(self):
         model1 = Model(name="name1")
         model2 = Model(name="name1")
-        self.assertEqual(model1, model2)
-        self.assertEqual(hash(model1), hash(model2))
+        assert model1 == model2
+        assert hash(model1) == hash(model2)
 
     def test_eq_models(self):
         models = [SubModel()]
         model1 = Model(models=models)
         model2 = Model(models=models)
-        self.assertEqual(model1, model2)
-        self.assertEqual(hash(model1), hash(model2))
+        assert model1 == model2
+        assert hash(model1) == hash(model2)
 
     def test_eq_models_order(self):
         submodel1 = SubModel(name="name1")
         submodel2 = SubModel(name="name2")
         model1 = Model(models=[submodel1, submodel2])
         model2 = Model(models=[submodel2, submodel1])
-        self.assertEqual(model1, model2)
-        self.assertEqual(hash(model1), hash(model2))
+        assert model1 == model2
+        assert hash(model1) == hash(model2)
 
     def test_eq_none(self):
-        self.assertNotEqual(Model(), None)
+        assert Model() is not None
 
     def test_eq_other(self):
-        self.assertNotEqual(Model(), "other")
+        assert Model() != "other"
 
     def test_ne_uri(self):
         model1 = Model(uri="uri1")
         model2 = Model(uri="uri2")
-        self.assertNotEqual(model1, model2)
-        self.assertNotEqual(hash(model1), hash(model2))
+        assert model1 != model2
+        assert hash(model1) != hash(model2)
 
     def test_ne_name(self):
         model1 = Model(name="name1")
         model2 = Model(name="name2")
-        self.assertNotEqual(model1, model2)
-        self.assertNotEqual(hash(model1), hash(model2))
+        assert model1 != model2
+        assert hash(model1) != hash(model2)
 
     def test_ne_models(self):
         model1 = Model(models=[SubModel(name="name1")])
         model2 = Model(models=[SubModel(name="name2")])
-        self.assertNotEqual(model1, model2)
-        self.assertNotEqual(hash(model1), hash(model2))
+        assert model1 != model2
+        assert hash(model1) != hash(model2)
 
     def test_ignores_values_with_default_value_none(self):
         model1 = Model(name="name1")
         model2 = Model(name="name1", uri=None)
-        self.assertEqual(model1, model2)
-        self.assertEqual(hash(model1), hash(model2))
+        assert model1 == model2
+        assert hash(model1) == hash(model2)

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -47,23 +47,23 @@ class InheritanceTest(unittest.TestCase):
 
 class CachingTest(unittest.TestCase):
     def test_same_instance(self):
-        self.assertIs(Track(), Track())
+        assert Track() is Track()
 
     def test_same_instance_with_values(self):
-        self.assertIs(Track(uri="test"), Track(uri="test"))
+        assert Track(uri="test") is Track(uri="test")
 
     def test_different_instance_with_different_values(self):
-        self.assertIsNot(Track(uri="test1"), Track(uri="test2"))
+        assert Track(uri="test1") is not Track(uri="test2")
 
     def test_different_instance_with_replace(self):
         t = Track(uri="test1")
-        self.assertIsNot(t, t.replace(uri="test2"))
+        assert t is not t.replace(uri="test2")
 
 
 class GenericReplaceTest(unittest.TestCase):
     def compare(self, orig, other):
-        self.assertEqual(orig, other)
-        self.assertEqual(id(orig), id(other))
+        assert orig == other
+        assert id(orig) == id(other)
 
     def test_replace_track(self):
         track = Track()
@@ -84,21 +84,21 @@ class GenericReplaceTest(unittest.TestCase):
     def test_replace_track_with_basic_values(self):
         track = Track(name="foo", uri="bar")
         other = track.replace(name="baz")
-        self.assertEqual("baz", other.name)
-        self.assertEqual("bar", other.uri)
+        assert "baz" == other.name
+        assert "bar" == other.uri
 
     def test_replace_track_with_missing_values(self):
         track = Track(uri="bar")
         other = track.replace(name="baz")
-        self.assertEqual("baz", other.name)
-        self.assertEqual("bar", other.uri)
+        assert "baz" == other.name
+        assert "bar" == other.uri
 
     def test_replace_track_with_private_internal_value(self):
         artist1 = Artist(name="foo")
         artist2 = Artist(name="bar")
         track = Track(artists=[artist1])
         other = track.replace(artists=[artist2])
-        self.assertIn(artist2, other.artists)
+        assert artist2 in other.artists
 
     def test_replace_track_with_invalid_key(self):
         with self.assertRaises(TypeError):
@@ -106,21 +106,21 @@ class GenericReplaceTest(unittest.TestCase):
 
     def test_replace_track_to_remove(self):
         track = Track(name="foo").replace(name=None)
-        self.assertFalse(hasattr(track, "_name"))
+        assert not hasattr(track, "_name")
 
 
 class RefTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         ref = Ref(uri=uri)
-        self.assertEqual(ref.uri, uri)
+        assert ref.uri == uri
         with self.assertRaises(AttributeError):
             ref.uri = None
 
     def test_name(self):
         name = "a name"
         ref = Ref(name=name)
-        self.assertEqual(ref.name, name)
+        assert ref.name == name
         with self.assertRaises(AttributeError):
             ref.name = None
 
@@ -135,9 +135,8 @@ class RefTest(unittest.TestCase):
             Ref(foo="baz")
 
     def test_repr_without_results(self):
-        self.assertEqual(
-            "Ref(name='foo', type='artist', uri='uri')",
-            repr(Ref(uri="uri", name="foo", type="artist")),
+        assert "Ref(name='foo', type='artist', uri='uri')" == repr(
+            Ref(uri="uri", name="foo", type="artist")
         )
 
     def test_serialize_without_results(self):
@@ -149,63 +148,63 @@ class RefTest(unittest.TestCase):
         ref1 = Ref(uri="uri")
         serialized = json.dumps(ref1, cls=ModelJSONEncoder)
         ref2 = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(ref1, ref2)
+        assert ref1 == ref2
 
     def test_type_constants(self):
-        self.assertEqual(Ref.ALBUM, "album")
-        self.assertEqual(Ref.ARTIST, "artist")
-        self.assertEqual(Ref.DIRECTORY, "directory")
-        self.assertEqual(Ref.PLAYLIST, "playlist")
-        self.assertEqual(Ref.TRACK, "track")
+        assert Ref.ALBUM == "album"
+        assert Ref.ARTIST == "artist"
+        assert Ref.DIRECTORY == "directory"
+        assert Ref.PLAYLIST == "playlist"
+        assert Ref.TRACK == "track"
 
     def test_album_constructor(self):
         ref = Ref.album(uri="foo", name="bar")
-        self.assertEqual(ref.uri, "foo")
-        self.assertEqual(ref.name, "bar")
-        self.assertEqual(ref.type, Ref.ALBUM)
+        assert ref.uri == "foo"
+        assert ref.name == "bar"
+        assert ref.type == Ref.ALBUM
 
     def test_artist_constructor(self):
         ref = Ref.artist(uri="foo", name="bar")
-        self.assertEqual(ref.uri, "foo")
-        self.assertEqual(ref.name, "bar")
-        self.assertEqual(ref.type, Ref.ARTIST)
+        assert ref.uri == "foo"
+        assert ref.name == "bar"
+        assert ref.type == Ref.ARTIST
 
     def test_directory_constructor(self):
         ref = Ref.directory(uri="foo", name="bar")
-        self.assertEqual(ref.uri, "foo")
-        self.assertEqual(ref.name, "bar")
-        self.assertEqual(ref.type, Ref.DIRECTORY)
+        assert ref.uri == "foo"
+        assert ref.name == "bar"
+        assert ref.type == Ref.DIRECTORY
 
     def test_playlist_constructor(self):
         ref = Ref.playlist(uri="foo", name="bar")
-        self.assertEqual(ref.uri, "foo")
-        self.assertEqual(ref.name, "bar")
-        self.assertEqual(ref.type, Ref.PLAYLIST)
+        assert ref.uri == "foo"
+        assert ref.name == "bar"
+        assert ref.type == Ref.PLAYLIST
 
     def test_track_constructor(self):
         ref = Ref.track(uri="foo", name="bar")
-        self.assertEqual(ref.uri, "foo")
-        self.assertEqual(ref.name, "bar")
-        self.assertEqual(ref.type, Ref.TRACK)
+        assert ref.uri == "foo"
+        assert ref.name == "bar"
+        assert ref.type == Ref.TRACK
 
 
 class ImageTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         image = Image(uri=uri)
-        self.assertEqual(image.uri, uri)
+        assert image.uri == uri
         with self.assertRaises(AttributeError):
             image.uri = None
 
     def test_width(self):
         image = Image(width=100)
-        self.assertEqual(image.width, 100)
+        assert image.width == 100
         with self.assertRaises(AttributeError):
             image.width = None
 
     def test_height(self):
         image = Image(height=100)
-        self.assertEqual(image.height, 100)
+        assert image.height == 100
         with self.assertRaises(AttributeError):
             image.height = None
 
@@ -218,21 +217,21 @@ class ArtistTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         artist = Artist(uri=uri)
-        self.assertEqual(artist.uri, uri)
+        assert artist.uri == uri
         with self.assertRaises(AttributeError):
             artist.uri = None
 
     def test_name(self):
         name = "a name"
         artist = Artist(name=name)
-        self.assertEqual(artist.name, name)
+        assert artist.name == name
         with self.assertRaises(AttributeError):
             artist.name = None
 
     def test_musicbrainz_id(self):
         mb_id = "mb-id"
         artist = Artist(musicbrainz_id=mb_id)
-        self.assertEqual(artist.musicbrainz_id, mb_id)
+        assert artist.musicbrainz_id == mb_id
         with self.assertRaises(AttributeError):
             artist.musicbrainz_id = None
 
@@ -248,9 +247,8 @@ class ArtistTest(unittest.TestCase):
             Artist(serialize="baz")
 
     def test_repr(self):
-        self.assertEqual(
-            "Artist(name='name', uri='uri')",
-            repr(Artist(uri="uri", name="name")),
+        assert "Artist(name='name', uri='uri')" == repr(
+            Artist(uri="uri", name="name")
         )
 
     def test_serialize(self):
@@ -269,7 +267,7 @@ class ArtistTest(unittest.TestCase):
         artist1 = Artist(uri="uri", name="name")
         serialized = json.dumps(artist1, cls=ModelJSONEncoder)
         artist2 = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(artist1, artist2)
+        assert artist1 == artist2
 
     def test_to_json_and_back_with_unknown_field(self):
         artist = Artist(uri="uri", name="name").serialize()
@@ -295,108 +293,108 @@ class ArtistTest(unittest.TestCase):
     def test_eq_name(self):
         artist1 = Artist(name="name")
         artist2 = Artist(name="name")
-        self.assertEqual(artist1, artist2)
-        self.assertEqual(hash(artist1), hash(artist2))
+        assert artist1 == artist2
+        assert hash(artist1) == hash(artist2)
 
     def test_eq_uri(self):
         artist1 = Artist(uri="uri")
         artist2 = Artist(uri="uri")
-        self.assertEqual(artist1, artist2)
-        self.assertEqual(hash(artist1), hash(artist2))
+        assert artist1 == artist2
+        assert hash(artist1) == hash(artist2)
 
     def test_eq_musibrainz_id(self):
         artist1 = Artist(musicbrainz_id="id")
         artist2 = Artist(musicbrainz_id="id")
-        self.assertEqual(artist1, artist2)
-        self.assertEqual(hash(artist1), hash(artist2))
+        assert artist1 == artist2
+        assert hash(artist1) == hash(artist2)
 
     def test_eq(self):
         artist1 = Artist(uri="uri", name="name", musicbrainz_id="id")
         artist2 = Artist(uri="uri", name="name", musicbrainz_id="id")
-        self.assertEqual(artist1, artist2)
-        self.assertEqual(hash(artist1), hash(artist2))
+        assert artist1 == artist2
+        assert hash(artist1) == hash(artist2)
 
     def test_eq_none(self):
-        self.assertNotEqual(Artist(), None)
+        assert Artist() is not None
 
     def test_eq_other(self):
-        self.assertNotEqual(Artist(), "other")
+        assert Artist() != "other"
 
     def test_ne_name(self):
         artist1 = Artist(name="name1")
         artist2 = Artist(name="name2")
-        self.assertNotEqual(artist1, artist2)
-        self.assertNotEqual(hash(artist1), hash(artist2))
+        assert artist1 != artist2
+        assert hash(artist1) != hash(artist2)
 
     def test_ne_uri(self):
         artist1 = Artist(uri="uri1")
         artist2 = Artist(uri="uri2")
-        self.assertNotEqual(artist1, artist2)
-        self.assertNotEqual(hash(artist1), hash(artist2))
+        assert artist1 != artist2
+        assert hash(artist1) != hash(artist2)
 
     def test_ne_musicbrainz_id(self):
         artist1 = Artist(musicbrainz_id="id1")
         artist2 = Artist(musicbrainz_id="id2")
-        self.assertNotEqual(artist1, artist2)
-        self.assertNotEqual(hash(artist1), hash(artist2))
+        assert artist1 != artist2
+        assert hash(artist1) != hash(artist2)
 
     def test_ne(self):
         artist1 = Artist(uri="uri1", name="name1", musicbrainz_id="id1")
         artist2 = Artist(uri="uri2", name="name2", musicbrainz_id="id2")
-        self.assertNotEqual(artist1, artist2)
-        self.assertNotEqual(hash(artist1), hash(artist2))
+        assert artist1 != artist2
+        assert hash(artist1) != hash(artist2)
 
 
 class AlbumTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         album = Album(uri=uri)
-        self.assertEqual(album.uri, uri)
+        assert album.uri == uri
         with self.assertRaises(AttributeError):
             album.uri = None
 
     def test_name(self):
         name = "a name"
         album = Album(name=name)
-        self.assertEqual(album.name, name)
+        assert album.name == name
         with self.assertRaises(AttributeError):
             album.name = None
 
     def test_artists(self):
         artist = Artist()
         album = Album(artists=[artist])
-        self.assertIn(artist, album.artists)
+        assert artist in album.artists
         with self.assertRaises(AttributeError):
             album.artists = None
 
     def test_artists_none(self):
-        self.assertEqual(set(), Album(artists=None).artists)
+        assert set() == Album(artists=None).artists
 
     def test_num_tracks(self):
         num_tracks = 11
         album = Album(num_tracks=num_tracks)
-        self.assertEqual(album.num_tracks, num_tracks)
+        assert album.num_tracks == num_tracks
         with self.assertRaises(AttributeError):
             album.num_tracks = None
 
     def test_num_discs(self):
         num_discs = 2
         album = Album(num_discs=num_discs)
-        self.assertEqual(album.num_discs, num_discs)
+        assert album.num_discs == num_discs
         with self.assertRaises(AttributeError):
             album.num_discs = None
 
     def test_date(self):
         date = "1977-01-01"
         album = Album(date=date)
-        self.assertEqual(album.date, date)
+        assert album.date == date
         with self.assertRaises(AttributeError):
             album.date = None
 
     def test_musicbrainz_id(self):
         mb_id = "mb-id"
         album = Album(musicbrainz_id=mb_id)
-        self.assertEqual(album.musicbrainz_id, mb_id)
+        assert album.musicbrainz_id == mb_id
         with self.assertRaises(AttributeError):
             album.musicbrainz_id = None
 
@@ -405,15 +403,14 @@ class AlbumTest(unittest.TestCase):
             Album(foo="baz")
 
     def test_repr_without_artists(self):
-        self.assertEqual(
-            "Album(name='name', uri='uri')",
-            repr(Album(uri="uri", name="name")),
+        assert "Album(name='name', uri='uri')" == repr(
+            Album(uri="uri", name="name")
         )
 
     def test_repr_with_artists(self):
-        self.assertEqual(
-            "Album(artists=[Artist(name='foo')], name='name', uri='uri')",
-            repr(Album(uri="uri", name="name", artists=[Artist(name="foo")])),
+        assert (
+            "Album(artists=[Artist(name='foo')], name='name', uri='uri')"
+            == repr(Album(uri="uri", name="name", artists=[Artist(name="foo")]))
         )
 
     def test_serialize_without_artists(self):
@@ -438,53 +435,53 @@ class AlbumTest(unittest.TestCase):
         album1 = Album(uri="uri", name="name", artists=[Artist(name="foo")])
         serialized = json.dumps(album1, cls=ModelJSONEncoder)
         album2 = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(album1, album2)
+        assert album1 == album2
 
     def test_eq_name(self):
         album1 = Album(name="name")
         album2 = Album(name="name")
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq_uri(self):
         album1 = Album(uri="uri")
         album2 = Album(uri="uri")
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq_artists(self):
         artists = [Artist()]
         album1 = Album(artists=artists)
         album2 = Album(artists=artists)
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq_artists_order(self):
         artist1 = Artist(name="name1")
         artist2 = Artist(name="name2")
         album1 = Album(artists=[artist1, artist2])
         album2 = Album(artists=[artist2, artist1])
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq_num_tracks(self):
         album1 = Album(num_tracks=2)
         album2 = Album(num_tracks=2)
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq_date(self):
         date = "1977-01-01"
         album1 = Album(date=date)
         album2 = Album(date=date)
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq_musibrainz_id(self):
         album1 = Album(musicbrainz_id="id")
         album2 = Album(musicbrainz_id="id")
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq(self):
         artists = [Artist()]
@@ -502,50 +499,50 @@ class AlbumTest(unittest.TestCase):
             num_tracks=2,
             musicbrainz_id="id",
         )
-        self.assertEqual(album1, album2)
-        self.assertEqual(hash(album1), hash(album2))
+        assert album1 == album2
+        assert hash(album1) == hash(album2)
 
     def test_eq_none(self):
-        self.assertNotEqual(Album(), None)
+        assert Album() is not None
 
     def test_eq_other(self):
-        self.assertNotEqual(Album(), "other")
+        assert Album() != "other"
 
     def test_ne_name(self):
         album1 = Album(name="name1")
         album2 = Album(name="name2")
-        self.assertNotEqual(album1, album2)
-        self.assertNotEqual(hash(album1), hash(album2))
+        assert album1 != album2
+        assert hash(album1) != hash(album2)
 
     def test_ne_uri(self):
         album1 = Album(uri="uri1")
         album2 = Album(uri="uri2")
-        self.assertNotEqual(album1, album2)
-        self.assertNotEqual(hash(album1), hash(album2))
+        assert album1 != album2
+        assert hash(album1) != hash(album2)
 
     def test_ne_artists(self):
         album1 = Album(artists=[Artist(name="name1")])
         album2 = Album(artists=[Artist(name="name2")])
-        self.assertNotEqual(album1, album2)
-        self.assertNotEqual(hash(album1), hash(album2))
+        assert album1 != album2
+        assert hash(album1) != hash(album2)
 
     def test_ne_num_tracks(self):
         album1 = Album(num_tracks=1)
         album2 = Album(num_tracks=2)
-        self.assertNotEqual(album1, album2)
-        self.assertNotEqual(hash(album1), hash(album2))
+        assert album1 != album2
+        assert hash(album1) != hash(album2)
 
     def test_ne_date(self):
         album1 = Album(date="1977-01-01")
         album2 = Album(date="1977-01-02")
-        self.assertNotEqual(album1, album2)
-        self.assertNotEqual(hash(album1), hash(album2))
+        assert album1 != album2
+        assert hash(album1) != hash(album2)
 
     def test_ne_musicbrainz_id(self):
         album1 = Album(musicbrainz_id="id1")
         album2 = Album(musicbrainz_id="id2")
-        self.assertNotEqual(album1, album2)
-        self.assertNotEqual(hash(album1), hash(album2))
+        assert album1 != album2
+        assert hash(album1) != hash(album2)
 
     def test_ne(self):
         album1 = Album(
@@ -562,101 +559,101 @@ class AlbumTest(unittest.TestCase):
             num_tracks=2,
             musicbrainz_id="id2",
         )
-        self.assertNotEqual(album1, album2)
-        self.assertNotEqual(hash(album1), hash(album2))
+        assert album1 != album2
+        assert hash(album1) != hash(album2)
 
 
 class TrackTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         track = Track(uri=uri)
-        self.assertEqual(track.uri, uri)
+        assert track.uri == uri
         with self.assertRaises(AttributeError):
             track.uri = None
 
     def test_name(self):
         name = "a name"
         track = Track(name=name)
-        self.assertEqual(track.name, name)
+        assert track.name == name
         with self.assertRaises(AttributeError):
             track.name = None
 
     def test_artists(self):
         artists = [Artist(name="name1"), Artist(name="name2")]
         track = Track(artists=artists)
-        self.assertEqual(set(track.artists), set(artists))
+        assert set(track.artists) == set(artists)
         with self.assertRaises(AttributeError):
             track.artists = None
 
     def test_artists_none(self):
-        self.assertEqual(set(), Track(artists=None).artists)
+        assert set() == Track(artists=None).artists
 
     def test_composers(self):
         artists = [Artist(name="name1"), Artist(name="name2")]
         track = Track(composers=artists)
-        self.assertEqual(set(track.composers), set(artists))
+        assert set(track.composers) == set(artists)
         with self.assertRaises(AttributeError):
             track.composers = None
 
     def test_composers_none(self):
-        self.assertEqual(set(), Track(composers=None).composers)
+        assert set() == Track(composers=None).composers
 
     def test_performers(self):
         artists = [Artist(name="name1"), Artist(name="name2")]
         track = Track(performers=artists)
-        self.assertEqual(set(track.performers), set(artists))
+        assert set(track.performers) == set(artists)
         with self.assertRaises(AttributeError):
             track.performers = None
 
     def test_performers_none(self):
-        self.assertEqual(set(), Track(performers=None).performers)
+        assert set() == Track(performers=None).performers
 
     def test_album(self):
         album = Album()
         track = Track(album=album)
-        self.assertEqual(track.album, album)
+        assert track.album == album
         with self.assertRaises(AttributeError):
             track.album = None
 
     def test_track_no(self):
         track_no = 7
         track = Track(track_no=track_no)
-        self.assertEqual(track.track_no, track_no)
+        assert track.track_no == track_no
         with self.assertRaises(AttributeError):
             track.track_no = None
 
     def test_disc_no(self):
         disc_no = 2
         track = Track(disc_no=disc_no)
-        self.assertEqual(track.disc_no, disc_no)
+        assert track.disc_no == disc_no
         with self.assertRaises(AttributeError):
             track.disc_no = None
 
     def test_date(self):
         date = "1977-01-01"
         track = Track(date=date)
-        self.assertEqual(track.date, date)
+        assert track.date == date
         with self.assertRaises(AttributeError):
             track.date = None
 
     def test_length(self):
         length = 137000
         track = Track(length=length)
-        self.assertEqual(track.length, length)
+        assert track.length == length
         with self.assertRaises(AttributeError):
             track.length = None
 
     def test_bitrate(self):
         bitrate = 160
         track = Track(bitrate=bitrate)
-        self.assertEqual(track.bitrate, bitrate)
+        assert track.bitrate == bitrate
         with self.assertRaises(AttributeError):
             track.bitrate = None
 
     def test_musicbrainz_id(self):
         mb_id = "mb-id"
         track = Track(musicbrainz_id=mb_id)
-        self.assertEqual(track.musicbrainz_id, mb_id)
+        assert track.musicbrainz_id == mb_id
         with self.assertRaises(AttributeError):
             track.musicbrainz_id = None
 
@@ -665,15 +662,14 @@ class TrackTest(unittest.TestCase):
             Track(foo="baz")
 
     def test_repr_without_artists(self):
-        self.assertEqual(
-            "Track(name='name', uri='uri')",
-            repr(Track(uri="uri", name="name")),
+        assert "Track(name='name', uri='uri')" == repr(
+            Track(uri="uri", name="name")
         )
 
     def test_repr_with_artists(self):
-        self.assertEqual(
-            "Track(artists=[Artist(name='foo')], name='name', uri='uri')",
-            repr(Track(uri="uri", name="name", artists=[Artist(name="foo")])),
+        assert (
+            "Track(artists=[Artist(name='foo')], name='name', uri='uri')"
+            == repr(Track(uri="uri", name="name", artists=[Artist(name="foo")]))
         )
 
     def test_serialize_without_artists(self):
@@ -715,72 +711,72 @@ class TrackTest(unittest.TestCase):
         )
         serialized = json.dumps(track1, cls=ModelJSONEncoder)
         track2 = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(track1, track2)
+        assert track1 == track2
 
     def test_eq_uri(self):
         track1 = Track(uri="uri1")
         track2 = Track(uri="uri1")
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_name(self):
         track1 = Track(name="name1")
         track2 = Track(name="name1")
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_artists(self):
         artists = [Artist()]
         track1 = Track(artists=artists)
         track2 = Track(artists=artists)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_artists_order(self):
         artist1 = Artist(name="name1")
         artist2 = Artist(name="name2")
         track1 = Track(artists=[artist1, artist2])
         track2 = Track(artists=[artist2, artist1])
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_album(self):
         album = Album()
         track1 = Track(album=album)
         track2 = Track(album=album)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_track_no(self):
         track1 = Track(track_no=1)
         track2 = Track(track_no=1)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_date(self):
         date = "1977-01-01"
         track1 = Track(date=date)
         track2 = Track(date=date)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_length(self):
         track1 = Track(length=100)
         track2 = Track(length=100)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_bitrate(self):
         track1 = Track(bitrate=100)
         track2 = Track(bitrate=100)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_musibrainz_id(self):
         track1 = Track(musicbrainz_id="id")
         track2 = Track(musicbrainz_id="id")
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq(self):
         date = "1977-01-01"
@@ -808,68 +804,68 @@ class TrackTest(unittest.TestCase):
             bitrate=100,
             musicbrainz_id="id",
         )
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_eq_none(self):
-        self.assertNotEqual(Track(), None)
+        assert Track() is not None
 
     def test_eq_other(self):
-        self.assertNotEqual(Track(), "other")
+        assert Track() != "other"
 
     def test_ne_uri(self):
         track1 = Track(uri="uri1")
         track2 = Track(uri="uri2")
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_name(self):
         track1 = Track(name="name1")
         track2 = Track(name="name2")
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_artists(self):
         track1 = Track(artists=[Artist(name="name1")])
         track2 = Track(artists=[Artist(name="name2")])
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_album(self):
         track1 = Track(album=Album(name="name1"))
         track2 = Track(album=Album(name="name2"))
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_track_no(self):
         track1 = Track(track_no=1)
         track2 = Track(track_no=2)
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_date(self):
         track1 = Track(date="1977-01-01")
         track2 = Track(date="1977-01-02")
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_length(self):
         track1 = Track(length=100)
         track2 = Track(length=200)
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_bitrate(self):
         track1 = Track(bitrate=100)
         track2 = Track(bitrate=200)
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne_musicbrainz_id(self):
         track1 = Track(musicbrainz_id="id1")
         track2 = Track(musicbrainz_id="id2")
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ne(self):
         track1 = Track(
@@ -894,34 +890,34 @@ class TrackTest(unittest.TestCase):
             bitrate=200,
             musicbrainz_id="id2",
         )
-        self.assertNotEqual(track1, track2)
-        self.assertNotEqual(hash(track1), hash(track2))
+        assert track1 != track2
+        assert hash(track1) != hash(track2)
 
     def test_ignores_values_with_default_value_none(self):
         track1 = Track(name="name1")
         track2 = Track(name="name1", album=None)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
     def test_replace_can_reset_to_default_value(self):
         track1 = Track(name="name1")
         track2 = Track(name="name1", album=Album()).replace(album=None)
-        self.assertEqual(track1, track2)
-        self.assertEqual(hash(track1), hash(track2))
+        assert track1 == track2
+        assert hash(track1) == hash(track2)
 
 
 class TlTrackTest(unittest.TestCase):
     def test_tlid(self):
         tlid = 123
         tl_track = TlTrack(tlid=tlid)
-        self.assertEqual(tl_track.tlid, tlid)
+        assert tl_track.tlid == tlid
         with self.assertRaises(AttributeError):
             tl_track.tlid = None
 
     def test_track(self):
         track = Track()
         tl_track = TlTrack(track=track)
-        self.assertEqual(tl_track.track, track)
+        assert tl_track.track == track
         with self.assertRaises(AttributeError):
             tl_track.track = None
 
@@ -933,21 +929,20 @@ class TlTrackTest(unittest.TestCase):
         tlid = 123
         track = Track()
         tl_track = TlTrack(tlid, track)
-        self.assertEqual(tl_track.tlid, tlid)
-        self.assertEqual(tl_track.track, track)
+        assert tl_track.tlid == tlid
+        assert tl_track.track == track
 
     def test_iteration(self):
         tlid = 123
         track = Track()
         tl_track = TlTrack(tlid, track)
         (tlid2, track2) = tl_track
-        self.assertEqual(tlid2, tlid)
-        self.assertEqual(track2, track)
+        assert tlid2 == tlid
+        assert track2 == track
 
     def test_repr(self):
-        self.assertEqual(
-            "TlTrack(tlid=123, track=Track(uri='uri'))",
-            repr(TlTrack(tlid=123, track=Track(uri="uri"))),
+        assert "TlTrack(tlid=123, track=Track(uri='uri'))" == repr(
+            TlTrack(tlid=123, track=Track(uri="uri"))
         )
 
     def test_serialize(self):
@@ -961,66 +956,66 @@ class TlTrackTest(unittest.TestCase):
         tl_track1 = TlTrack(tlid=123, track=Track(uri="uri", name="name"))
         serialized = json.dumps(tl_track1, cls=ModelJSONEncoder)
         tl_track2 = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(tl_track1, tl_track2)
+        assert tl_track1 == tl_track2
 
     def test_eq(self):
         tlid = 123
         track = Track()
         tl_track1 = TlTrack(tlid=tlid, track=track)
         tl_track2 = TlTrack(tlid=tlid, track=track)
-        self.assertEqual(tl_track1, tl_track2)
-        self.assertEqual(hash(tl_track1), hash(tl_track2))
+        assert tl_track1 == tl_track2
+        assert hash(tl_track1) == hash(tl_track2)
 
     def test_eq_none(self):
-        self.assertNotEqual(TlTrack(), None)
+        assert TlTrack() is not None
 
     def test_eq_other(self):
-        self.assertNotEqual(TlTrack(), "other")
+        assert TlTrack() != "other"
 
     def test_ne_tlid(self):
         tl_track1 = TlTrack(tlid=123)
         tl_track2 = TlTrack(tlid=321)
-        self.assertNotEqual(tl_track1, tl_track2)
-        self.assertNotEqual(hash(tl_track1), hash(tl_track2))
+        assert tl_track1 != tl_track2
+        assert hash(tl_track1) != hash(tl_track2)
 
     def test_ne_track(self):
         tl_track1 = TlTrack(track=Track(uri="a"))
         tl_track2 = TlTrack(track=Track(uri="b"))
-        self.assertNotEqual(tl_track1, tl_track2)
-        self.assertNotEqual(hash(tl_track1), hash(tl_track2))
+        assert tl_track1 != tl_track2
+        assert hash(tl_track1) != hash(tl_track2)
 
 
 class PlaylistTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         playlist = Playlist(uri=uri)
-        self.assertEqual(playlist.uri, uri)
+        assert playlist.uri == uri
         with self.assertRaises(AttributeError):
             playlist.uri = None
 
     def test_name(self):
         name = "a name"
         playlist = Playlist(name=name)
-        self.assertEqual(playlist.name, name)
+        assert playlist.name == name
         with self.assertRaises(AttributeError):
             playlist.name = None
 
     def test_tracks(self):
         tracks = [Track(), Track(), Track()]
         playlist = Playlist(tracks=tracks)
-        self.assertEqual(list(playlist.tracks), tracks)
+        assert list(playlist.tracks) == tracks
         with self.assertRaises(AttributeError):
             playlist.tracks = None
 
     def test_length(self):
         tracks = [Track(), Track(), Track()]
         playlist = Playlist(tracks=tracks)
-        self.assertEqual(playlist.length, 3)
+        assert playlist.length == 3
 
     def test_last_modified(self):
         last_modified = 1390942873000
         playlist = Playlist(last_modified=last_modified)
-        self.assertEqual(playlist.last_modified, last_modified)
+        assert playlist.last_modified == last_modified
         with self.assertRaises(AttributeError):
             playlist.last_modified = None
 
@@ -1034,10 +1029,10 @@ class PlaylistTest(unittest.TestCase):
             last_modified=last_modified,
         )
         new_playlist = playlist.replace(uri="another uri")
-        self.assertEqual(new_playlist.uri, "another uri")
-        self.assertEqual(new_playlist.name, "a name")
-        self.assertEqual(list(new_playlist.tracks), tracks)
-        self.assertEqual(new_playlist.last_modified, last_modified)
+        assert new_playlist.uri == "another uri"
+        assert new_playlist.name == "a name"
+        assert list(new_playlist.tracks) == tracks
+        assert new_playlist.last_modified == last_modified
 
     def test_with_new_name(self):
         tracks = [Track()]
@@ -1049,10 +1044,10 @@ class PlaylistTest(unittest.TestCase):
             last_modified=last_modified,
         )
         new_playlist = playlist.replace(name="another name")
-        self.assertEqual(new_playlist.uri, "an uri")
-        self.assertEqual(new_playlist.name, "another name")
-        self.assertEqual(list(new_playlist.tracks), tracks)
-        self.assertEqual(new_playlist.last_modified, last_modified)
+        assert new_playlist.uri == "an uri"
+        assert new_playlist.name == "another name"
+        assert list(new_playlist.tracks) == tracks
+        assert new_playlist.last_modified == last_modified
 
     def test_with_new_tracks(self):
         tracks = [Track()]
@@ -1065,10 +1060,10 @@ class PlaylistTest(unittest.TestCase):
         )
         new_tracks = [Track(), Track()]
         new_playlist = playlist.replace(tracks=new_tracks)
-        self.assertEqual(new_playlist.uri, "an uri")
-        self.assertEqual(new_playlist.name, "a name")
-        self.assertEqual(list(new_playlist.tracks), new_tracks)
-        self.assertEqual(new_playlist.last_modified, last_modified)
+        assert new_playlist.uri == "an uri"
+        assert new_playlist.name == "a name"
+        assert list(new_playlist.tracks) == new_tracks
+        assert new_playlist.last_modified == last_modified
 
     def test_with_new_last_modified(self):
         tracks = [Track()]
@@ -1081,25 +1076,26 @@ class PlaylistTest(unittest.TestCase):
             last_modified=last_modified,
         )
         new_playlist = playlist.replace(last_modified=new_last_modified)
-        self.assertEqual(new_playlist.uri, "an uri")
-        self.assertEqual(new_playlist.name, "a name")
-        self.assertEqual(list(new_playlist.tracks), tracks)
-        self.assertEqual(new_playlist.last_modified, new_last_modified)
+        assert new_playlist.uri == "an uri"
+        assert new_playlist.name == "a name"
+        assert list(new_playlist.tracks) == tracks
+        assert new_playlist.last_modified == new_last_modified
 
     def test_invalid_kwarg(self):
         with self.assertRaises(TypeError):
             Playlist(foo="baz")
 
     def test_repr_without_tracks(self):
-        self.assertEqual(
-            "Playlist(name='name', uri='uri')",
-            repr(Playlist(uri="uri", name="name")),
+        assert "Playlist(name='name', uri='uri')" == repr(
+            Playlist(uri="uri", name="name")
         )
 
     def test_repr_with_tracks(self):
-        self.assertEqual(
-            "Playlist(name='name', tracks=[Track(name='foo')], uri='uri')",
-            repr(Playlist(uri="uri", name="name", tracks=[Track(name="foo")])),
+        assert (
+            "Playlist(name='name', tracks=[Track(name='foo')], uri='uri')"
+            == repr(
+                Playlist(uri="uri", name="name", tracks=[Track(name="foo")])
+            )
         )
 
     def test_serialize_without_tracks(self):
@@ -1124,32 +1120,32 @@ class PlaylistTest(unittest.TestCase):
         playlist1 = Playlist(uri="uri", name="name")
         serialized = json.dumps(playlist1, cls=ModelJSONEncoder)
         playlist2 = json.loads(serialized, object_hook=model_json_decoder)
-        self.assertEqual(playlist1, playlist2)
+        assert playlist1 == playlist2
 
     def test_eq_name(self):
         playlist1 = Playlist(name="name")
         playlist2 = Playlist(name="name")
-        self.assertEqual(playlist1, playlist2)
-        self.assertEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 == playlist2
+        assert hash(playlist1) == hash(playlist2)
 
     def test_eq_uri(self):
         playlist1 = Playlist(uri="uri")
         playlist2 = Playlist(uri="uri")
-        self.assertEqual(playlist1, playlist2)
-        self.assertEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 == playlist2
+        assert hash(playlist1) == hash(playlist2)
 
     def test_eq_tracks(self):
         tracks = [Track()]
         playlist1 = Playlist(tracks=tracks)
         playlist2 = Playlist(tracks=tracks)
-        self.assertEqual(playlist1, playlist2)
-        self.assertEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 == playlist2
+        assert hash(playlist1) == hash(playlist2)
 
     def test_eq_last_modified(self):
         playlist1 = Playlist(last_modified=1)
         playlist2 = Playlist(last_modified=1)
-        self.assertEqual(playlist1, playlist2)
-        self.assertEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 == playlist2
+        assert hash(playlist1) == hash(playlist2)
 
     def test_eq(self):
         tracks = [Track()]
@@ -1159,38 +1155,38 @@ class PlaylistTest(unittest.TestCase):
         playlist2 = Playlist(
             uri="uri", name="name", tracks=tracks, last_modified=1
         )
-        self.assertEqual(playlist1, playlist2)
-        self.assertEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 == playlist2
+        assert hash(playlist1) == hash(playlist2)
 
     def test_eq_none(self):
-        self.assertNotEqual(Playlist(), None)
+        assert Playlist() is not None
 
     def test_eq_other(self):
-        self.assertNotEqual(Playlist(), "other")
+        assert Playlist() != "other"
 
     def test_ne_name(self):
         playlist1 = Playlist(name="name1")
         playlist2 = Playlist(name="name2")
-        self.assertNotEqual(playlist1, playlist2)
-        self.assertNotEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 != playlist2
+        assert hash(playlist1) != hash(playlist2)
 
     def test_ne_uri(self):
         playlist1 = Playlist(uri="uri1")
         playlist2 = Playlist(uri="uri2")
-        self.assertNotEqual(playlist1, playlist2)
-        self.assertNotEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 != playlist2
+        assert hash(playlist1) != hash(playlist2)
 
     def test_ne_tracks(self):
         playlist1 = Playlist(tracks=[Track(uri="uri1")])
         playlist2 = Playlist(tracks=[Track(uri="uri2")])
-        self.assertNotEqual(playlist1, playlist2)
-        self.assertNotEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 != playlist2
+        assert hash(playlist1) != hash(playlist2)
 
     def test_ne_last_modified(self):
         playlist1 = Playlist(last_modified=1)
         playlist2 = Playlist(last_modified=2)
-        self.assertNotEqual(playlist1, playlist2)
-        self.assertNotEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 != playlist2
+        assert hash(playlist1) != hash(playlist2)
 
     def test_ne(self):
         playlist1 = Playlist(
@@ -1205,36 +1201,36 @@ class PlaylistTest(unittest.TestCase):
             tracks=[Track(uri="uri2")],
             last_modified=2,
         )
-        self.assertNotEqual(playlist1, playlist2)
-        self.assertNotEqual(hash(playlist1), hash(playlist2))
+        assert playlist1 != playlist2
+        assert hash(playlist1) != hash(playlist2)
 
 
 class SearchResultTest(unittest.TestCase):
     def test_uri(self):
         uri = "an_uri"
         result = SearchResult(uri=uri)
-        self.assertEqual(result.uri, uri)
+        assert result.uri == uri
         with self.assertRaises(AttributeError):
             result.uri = None
 
     def test_tracks(self):
         tracks = [Track(), Track(), Track()]
         result = SearchResult(tracks=tracks)
-        self.assertEqual(list(result.tracks), tracks)
+        assert list(result.tracks) == tracks
         with self.assertRaises(AttributeError):
             result.tracks = None
 
     def test_artists(self):
         artists = [Artist(), Artist(), Artist()]
         result = SearchResult(artists=artists)
-        self.assertEqual(list(result.artists), artists)
+        assert list(result.artists) == artists
         with self.assertRaises(AttributeError):
             result.artists = None
 
     def test_albums(self):
         albums = [Album(), Album(), Album()]
         result = SearchResult(albums=albums)
-        self.assertEqual(list(result.albums), albums)
+        assert list(result.albums) == albums
         with self.assertRaises(AttributeError):
             result.albums = None
 
@@ -1243,9 +1239,7 @@ class SearchResultTest(unittest.TestCase):
             SearchResult(foo="baz")
 
     def test_repr_without_results(self):
-        self.assertEqual(
-            "SearchResult(uri='uri')", repr(SearchResult(uri="uri"))
-        )
+        assert "SearchResult(uri='uri')" == repr(SearchResult(uri="uri"))
 
     def test_serialize_without_results(self):
         self.assertDictEqual(

--- a/tests/mpd/protocol/__init__.py
+++ b/tests/mpd/protocol/__init__.py
@@ -69,30 +69,24 @@ class BaseTestCase(unittest.TestCase):
         return self.connection.response
 
     def assertNoResponse(self):  # noqa: N802
-        self.assertEqual([], self.connection.response)
+        assert [] == self.connection.response
 
     def assertInResponse(self, value):  # noqa: N802
-        self.assertIn(
-            value,
-            self.connection.response,
-            f"Did not find {value!r} in {self.connection.response!r}",
-        )
+        assert (
+            value in self.connection.response
+        ), f"Did not find {value!r} in {self.connection.response!r}"
 
     def assertOnceInResponse(self, value):  # noqa: N802
         matched = len([r for r in self.connection.response if r == value])
-        self.assertEqual(
-            1,
-            matched,
-            f"Expected to find {value!r} once in {self.connection.response!r}",
-        )
+        assert (
+            1 == matched
+        ), f"Expected to find {value!r} once in {self.connection.response!r}"
 
     def assertNotInResponse(self, value):  # noqa: N802
-        self.assertNotIn(
-            value,
-            self.connection.response,
-            f"Found {value!r} in {self.connection.response!r}",
-        )
+        assert (
+            value not in self.connection.response
+        ), f"Found {value!r} in {self.connection.response!r}"
 
     def assertEqualResponse(self, value):  # noqa: N802
-        self.assertEqual(1, len(self.connection.response))
-        self.assertEqual(value, self.connection.response[0])
+        assert 1 == len(self.connection.response)
+        assert value == self.connection.response[0]

--- a/tests/mpd/protocol/test_audio_output.py
+++ b/tests/mpd/protocol/test_audio_output.py
@@ -8,7 +8,7 @@ class AudioOutputHandlerTest(protocol.BaseTestCase):
         self.send_request('enableoutput "0"')
 
         self.assertInResponse("OK")
-        self.assertEqual(self.core.mixer.get_mute().get(), True)
+        assert self.core.mixer.get_mute().get() is True
 
     def test_enableoutput_unknown_outputid(self):
         self.send_request('enableoutput "7"')
@@ -21,7 +21,7 @@ class AudioOutputHandlerTest(protocol.BaseTestCase):
         self.send_request('disableoutput "0"')
 
         self.assertInResponse("OK")
-        self.assertEqual(self.core.mixer.get_mute().get(), False)
+        assert self.core.mixer.get_mute().get() is False
 
     def test_disableoutput_unknown_outputid(self):
         self.send_request('disableoutput "7"')
@@ -85,24 +85,24 @@ class AudioOutputHandlerNoneMixerTest(protocol.BaseTestCase):
     enable_mixer = False
 
     def test_enableoutput(self):
-        self.assertEqual(self.core.mixer.get_mute().get(), None)
+        assert self.core.mixer.get_mute().get() is None
 
         self.send_request('enableoutput "0"')
         self.assertInResponse(
             "ACK [52@0] {enableoutput} problems enabling output"
         )
 
-        self.assertEqual(self.core.mixer.get_mute().get(), None)
+        assert self.core.mixer.get_mute().get() is None
 
     def test_disableoutput(self):
-        self.assertEqual(self.core.mixer.get_mute().get(), None)
+        assert self.core.mixer.get_mute().get() is None
 
         self.send_request('disableoutput "0"')
         self.assertInResponse(
             "ACK [52@0] {disableoutput} problems disabling output"
         )
 
-        self.assertEqual(self.core.mixer.get_mute().get(), None)
+        assert self.core.mixer.get_mute().get() is None
 
     def test_outputs_when_unmuted(self):
         self.core.mixer.set_mute(False)

--- a/tests/mpd/protocol/test_authentication.py
+++ b/tests/mpd/protocol/test_authentication.py
@@ -9,52 +9,52 @@ class AuthenticationActiveTest(protocol.BaseTestCase):
 
     def test_authentication_with_valid_password_is_accepted(self):
         self.send_request('password "topsecret"')
-        self.assertTrue(self.dispatcher.authenticated)
+        assert self.dispatcher.authenticated
         self.assertInResponse("OK")
 
     def test_authentication_with_invalid_password_is_not_accepted(self):
         self.send_request('password "secret"')
-        self.assertFalse(self.dispatcher.authenticated)
+        assert not self.dispatcher.authenticated
         self.assertEqualResponse("ACK [3@0] {password} incorrect password")
 
     def test_authentication_without_password_fails(self):
         self.send_request("password")
-        self.assertFalse(self.dispatcher.authenticated)
+        assert not self.dispatcher.authenticated
         self.assertEqualResponse(
             'ACK [2@0] {password} wrong number of arguments for "password"'
         )
 
     def test_anything_when_not_authenticated_should_fail(self):
         self.send_request("any request at all")
-        self.assertFalse(self.dispatcher.authenticated)
+        assert not self.dispatcher.authenticated
         self.assertEqualResponse(
             'ACK [4@0] {any} you don\'t have permission for "any"'
         )
 
     def test_close_is_allowed_without_authentication(self):
         self.send_request("close")
-        self.assertFalse(self.dispatcher.authenticated)
+        assert not self.dispatcher.authenticated
 
     def test_commands_is_allowed_without_authentication(self):
         self.send_request("commands")
-        self.assertFalse(self.dispatcher.authenticated)
+        assert not self.dispatcher.authenticated
         self.assertInResponse("OK")
 
     def test_notcommands_is_allowed_without_authentication(self):
         self.send_request("notcommands")
-        self.assertFalse(self.dispatcher.authenticated)
+        assert not self.dispatcher.authenticated
         self.assertInResponse("OK")
 
     def test_ping_is_allowed_without_authentication(self):
         self.send_request("ping")
-        self.assertFalse(self.dispatcher.authenticated)
+        assert not self.dispatcher.authenticated
         self.assertInResponse("OK")
 
 
 class AuthenticationInactiveTest(protocol.BaseTestCase):
     def test_authentication_with_anything_when_password_check_turned_off(self):
         self.send_request("any request at all")
-        self.assertTrue(self.dispatcher.authenticated)
+        assert self.dispatcher.authenticated
         self.assertEqualResponse('ACK [5@0] {} unknown command "any"')
 
     def test_any_password_is_not_accepted_when_password_check_turned_off(self):

--- a/tests/mpd/protocol/test_command_list.py
+++ b/tests/mpd/protocol/test_command_list.py
@@ -4,7 +4,7 @@ from tests.mpd import protocol
 class CommandListsTest(protocol.BaseTestCase):
     def test_command_list_begin(self):
         response = self.send_request("command_list_begin")
-        self.assertEqual([], response)
+        assert [] == response
 
     def test_command_list_end(self):
         self.send_request("command_list_begin")
@@ -19,18 +19,18 @@ class CommandListsTest(protocol.BaseTestCase):
 
     def test_command_list_with_ping(self):
         self.send_request("command_list_begin")
-        self.assertTrue(self.dispatcher.command_list_receiving)
-        self.assertFalse(self.dispatcher.command_list_ok)
-        self.assertEqual([], self.dispatcher.command_list)
+        assert self.dispatcher.command_list_receiving
+        assert not self.dispatcher.command_list_ok
+        assert [] == self.dispatcher.command_list
 
         self.send_request("ping")
-        self.assertIn("ping", self.dispatcher.command_list)
+        assert "ping" in self.dispatcher.command_list
 
         self.send_request("command_list_end")
         self.assertInResponse("OK")
-        self.assertFalse(self.dispatcher.command_list_receiving)
-        self.assertFalse(self.dispatcher.command_list_ok)
-        self.assertEqual([], self.dispatcher.command_list)
+        assert not self.dispatcher.command_list_receiving
+        assert not self.dispatcher.command_list_ok
+        assert [] == self.dispatcher.command_list
 
     def test_command_list_with_error_returns_ack_with_correct_index(self):
         self.send_request("command_list_begin")
@@ -41,23 +41,23 @@ class CommandListsTest(protocol.BaseTestCase):
 
     def test_command_list_ok_begin(self):
         response = self.send_request("command_list_ok_begin")
-        self.assertEqual([], response)
+        assert [] == response
 
     def test_command_list_ok_with_ping(self):
         self.send_request("command_list_ok_begin")
-        self.assertTrue(self.dispatcher.command_list_receiving)
-        self.assertTrue(self.dispatcher.command_list_ok)
-        self.assertEqual([], self.dispatcher.command_list)
+        assert self.dispatcher.command_list_receiving
+        assert self.dispatcher.command_list_ok
+        assert [] == self.dispatcher.command_list
 
         self.send_request("ping")
-        self.assertIn("ping", self.dispatcher.command_list)
+        assert "ping" in self.dispatcher.command_list
 
         self.send_request("command_list_end")
         self.assertInResponse("list_OK")
         self.assertInResponse("OK")
-        self.assertFalse(self.dispatcher.command_list_receiving)
-        self.assertFalse(self.dispatcher.command_list_ok)
-        self.assertEqual([], self.dispatcher.command_list)
+        assert not self.dispatcher.command_list_receiving
+        assert not self.dispatcher.command_list_ok
+        assert [] == self.dispatcher.command_list
 
     # FIXME this should also include the special handling of idle within a
     # command list. That is that once a idle/noidle command is found inside a

--- a/tests/mpd/protocol/test_current_playlist.py
+++ b/tests/mpd/protocol/test_current_playlist.py
@@ -27,20 +27,16 @@ class AddCommandsTest(protocol.BaseTestCase):
         for track in [self.tracks[0], self.tracks[0], self.tracks[1]]:
             self.send_request(f'add "{track.uri}"')
 
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 3)
-        self.assertEqual(
-            self.core.tracklist.get_tracks().get()[2], self.tracks[1]
-        )
+        assert len(self.core.tracklist.get_tracks().get()) == 3
+        assert self.core.tracklist.get_tracks().get()[2] == self.tracks[1]
         self.assertEqualResponse("OK")
 
     def test_add_unicode(self):
         for track in [self.tracks[0], self.tracks[1], self.tracks[2]]:
             self.send_request(f'add "{track.uri}"')
 
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 3)
-        self.assertEqual(
-            self.core.tracklist.get_tracks().get()[2], self.tracks[2]
-        )
+        assert len(self.core.tracklist.get_tracks().get()) == 3
+        assert self.core.tracklist.get_tracks().get()[2] == self.tracks[2]
         self.assertEqualResponse("OK")
 
     def test_add_with_uri_not_found_in_library_should_ack(self):
@@ -53,7 +49,7 @@ class AddCommandsTest(protocol.BaseTestCase):
         }
 
         self.send_request('add ""')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 0)
+        assert len(self.core.tracklist.get_tracks().get()) == 0
         self.assertInResponse("OK")
 
     def test_add_with_library_should_recurse(self):
@@ -63,7 +59,7 @@ class AddCommandsTest(protocol.BaseTestCase):
         }
 
         self.send_request('add "/dummy"')
-        self.assertEqual(self.core.tracklist.get_tracks().get(), self.tracks)
+        assert self.core.tracklist.get_tracks().get() == self.tracks
         self.assertInResponse("OK")
 
     def test_add_root_should_not_add_anything_and_ok(self):
@@ -72,7 +68,7 @@ class AddCommandsTest(protocol.BaseTestCase):
         }
 
         self.send_request('add "/"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 0)
+        assert len(self.core.tracklist.get_tracks().get()) == 0
         self.assertInResponse("OK")
 
     def test_addid_without_songpos(self):
@@ -80,8 +76,8 @@ class AddCommandsTest(protocol.BaseTestCase):
             self.send_request(f'addid "{track.uri}"')
         tl_tracks = self.core.tracklist.get_tl_tracks().get()
 
-        self.assertEqual(len(tl_tracks), 3)
-        self.assertEqual(tl_tracks[2].track, self.tracks[1])
+        assert len(tl_tracks) == 3
+        assert tl_tracks[2].track == self.tracks[1]
         self.assertInResponse(f"Id: {tl_tracks[2].tlid:d}")
         self.assertInResponse("OK")
 
@@ -91,8 +87,8 @@ class AddCommandsTest(protocol.BaseTestCase):
         self.send_request(f'addid "{self.tracks[1].uri}" "1"')
         tl_tracks = self.core.tracklist.get_tl_tracks().get()
 
-        self.assertEqual(len(tl_tracks), 3)
-        self.assertEqual(tl_tracks[1].track, self.tracks[1])
+        assert len(tl_tracks) == 3
+        assert tl_tracks[1].track == self.tracks[1]
         self.assertInResponse(f"Id: {tl_tracks[1].tlid:d}")
         self.assertInResponse("OK")
 
@@ -120,24 +116,24 @@ class BasePopulatedTracklistTestCase(protocol.BaseTestCase):
 class DeleteCommandsTest(BasePopulatedTracklistTestCase):
     def test_clear(self):
         self.send_request("clear")
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 0)
-        self.assertEqual(self.core.playback.get_current_track().get(), None)
+        assert len(self.core.tracklist.get_tracks().get()) == 0
+        assert self.core.playback.get_current_track().get() is None
         self.assertInResponse("OK")
 
     def test_delete_songpos(self):
         tl_tracks = self.core.tracklist.get_tl_tracks().get()
         self.send_request(f'delete "{tl_tracks[1].tlid}"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 5)
+        assert len(self.core.tracklist.get_tracks().get()) == 5
         self.assertInResponse("OK")
 
     def test_delete_songpos_out_of_bounds(self):
         self.send_request('delete "8"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 6)
+        assert len(self.core.tracklist.get_tracks().get()) == 6
         self.assertEqualResponse("ACK [2@0] {delete} Bad song index")
 
     def test_delete_open_range(self):
         self.send_request('delete "1:"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 1)
+        assert len(self.core.tracklist.get_tracks().get()) == 1
         self.assertInResponse("OK")
 
     # TODO: check how this should work.
@@ -148,27 +144,27 @@ class DeleteCommandsTest(BasePopulatedTracklistTestCase):
 
     def test_delete_closed_range(self):
         self.send_request('delete "1:3"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 4)
+        assert len(self.core.tracklist.get_tracks().get()) == 4
         self.assertInResponse("OK")
 
     def test_delete_entire_range_out_of_bounds(self):
         self.send_request('delete "8:9"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 6)
+        assert len(self.core.tracklist.get_tracks().get()) == 6
         self.assertEqualResponse("ACK [2@0] {delete} Bad song index")
 
     def test_delete_upper_range_out_of_bounds(self):
         self.send_request('delete "5:9"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 5)
+        assert len(self.core.tracklist.get_tracks().get()) == 5
         self.assertEqualResponse("OK")
 
     def test_deleteid(self):
         self.send_request('deleteid "1"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 5)
+        assert len(self.core.tracklist.get_tracks().get()) == 5
         self.assertInResponse("OK")
 
     def test_deleteid_does_not_exist(self):
         self.send_request('deleteid "12345"')
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 6)
+        assert len(self.core.tracklist.get_tracks().get()) == 6
         self.assertEqualResponse("ACK [50@0] {deleteid} No such song")
 
 
@@ -176,25 +172,25 @@ class MoveCommandsTest(BasePopulatedTracklistTestCase):
     def test_move_songpos(self):
         self.send_request('move "1" "0"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result, ["b", "a", "c", "d", "e", "ǂ"])
+        assert result == ["b", "a", "c", "d", "e", "ǂ"]
         self.assertInResponse("OK")
 
     def test_move_open_range(self):
         self.send_request('move "2:" "0"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result, ["c", "d", "e", "ǂ", "a", "b"])
+        assert result == ["c", "d", "e", "ǂ", "a", "b"]
         self.assertInResponse("OK")
 
     def test_move_closed_range(self):
         self.send_request('move "1:3" "0"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result, ["b", "c", "a", "d", "e", "ǂ"])
+        assert result == ["b", "c", "a", "d", "e", "ǂ"]
         self.assertInResponse("OK")
 
     def test_moveid(self):
         self.send_request('moveid "5" "2"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result, ["a", "b", "e", "c", "d", "ǂ"])
+        assert result == ["a", "b", "e", "c", "d", "ǂ"]
         self.assertInResponse("OK")
 
     def test_moveid_with_tlid_not_found_in_tracklist_should_ack(self):
@@ -253,7 +249,7 @@ class PlaylistInfoCommandTest(BasePopulatedTracklistTestCase):
             playlist_response = self.send_request("playlist")
 
         playlistinfo_response = self.send_request("playlistinfo")
-        self.assertEqual(playlist_response, playlistinfo_response)
+        assert playlist_response == playlistinfo_response
 
     def test_playlistinfo_without_songpos_or_range(self):
         self.send_request("playlistinfo")
@@ -293,7 +289,7 @@ class PlaylistInfoCommandTest(BasePopulatedTracklistTestCase):
     def test_playlistinfo_with_negative_songpos_same_as_playlistinfo(self):
         response1 = self.send_request('playlistinfo "-1"')
         response2 = self.send_request("playlistinfo")
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     def test_playlistinfo_with_open_range(self):
         self.send_request('playlistinfo "2:"')
@@ -353,7 +349,7 @@ class PlChangeCommandTest(BasePopulatedTracklistTestCase):
         self.assertInResponse("OK")
 
     def test_plchanges_with_equal_version_returns_nothing(self):
-        self.assertEqual(self.core.tracklist.get_version().get(), 1)
+        assert self.core.tracklist.get_version().get() == 1
         self.send_request('plchanges "1"')
         self.assertNotInResponse("Title: a")
         self.assertNotInResponse("Title: b")
@@ -361,7 +357,7 @@ class PlChangeCommandTest(BasePopulatedTracklistTestCase):
         self.assertInResponse("OK")
 
     def test_plchanges_with_greater_version_returns_nothing(self):
-        self.assertEqual(self.core.tracklist.get_version().get(), 1)
+        assert self.core.tracklist.get_version().get() == 1
         self.send_request('plchanges "2"')
         self.assertNotInResponse("Title: a")
         self.assertNotInResponse("Title: b")
@@ -416,28 +412,28 @@ class ShuffleCommandTest(BasePopulatedTracklistTestCase):
         version = self.core.tracklist.get_version().get()
 
         self.send_request("shuffle")
-        self.assertLess(version, self.core.tracklist.get_version().get())
+        assert version < self.core.tracklist.get_version().get()
         self.assertInResponse("OK")
 
     def test_shuffle_with_open_range(self):
         version = self.core.tracklist.get_version().get()
 
         self.send_request('shuffle "4:"')
-        self.assertLess(version, self.core.tracklist.get_version().get())
+        assert version < self.core.tracklist.get_version().get()
 
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result[:4], ["a", "b", "c", "d"])
+        assert result[:4] == ["a", "b", "c", "d"]
         self.assertInResponse("OK")
 
     def test_shuffle_with_closed_range(self):
         version = self.core.tracklist.get_version().get()
 
         self.send_request('shuffle "1:3"')
-        self.assertLess(version, self.core.tracklist.get_version().get())
+        assert version < self.core.tracklist.get_version().get()
 
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result[:1], ["a"])
-        self.assertEqual(result[3:], ["d", "e", "ǂ"])
+        assert result[:1] == ["a"]
+        assert result[3:] == ["d", "e", "ǂ"]
         self.assertInResponse("OK")
 
 
@@ -445,19 +441,19 @@ class SwapCommandTest(BasePopulatedTracklistTestCase):
     def test_swap(self):
         self.send_request('swap "1" "4"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result, ["a", "e", "c", "d", "b", "ǂ"])
+        assert result == ["a", "e", "c", "d", "b", "ǂ"]
         self.assertInResponse("OK")
 
     def test_swap_highest_position_first(self):
         self.send_request('swap "4" "1"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result, ["a", "e", "c", "d", "b", "ǂ"])
+        assert result == ["a", "e", "c", "d", "b", "ǂ"]
         self.assertInResponse("OK")
 
     def test_swapid(self):
         self.send_request('swapid "2" "5"')
         result = [t.name for t in self.core.tracklist.get_tracks().get()]
-        self.assertEqual(result, ["a", "e", "c", "d", "b", "ǂ"])
+        assert result == ["a", "e", "c", "d", "b", "ǂ"]
         self.assertInResponse("OK")
 
     def test_swapid_with_first_id_unknown_should_ack(self):

--- a/tests/mpd/protocol/test_idle.py
+++ b/tests/mpd/protocol/test_idle.py
@@ -10,10 +10,10 @@ class IdleHandlerTest(protocol.BaseTestCase):
         self.session.on_event(subsystem)
 
     def assertEqualEvents(self, events):  # noqa: N802
-        self.assertEqual(set(events), self.context.events)
+        assert set(events) == self.context.events
 
     def assertEqualSubscriptions(self, events):  # noqa: N802
-        self.assertEqual(set(events), self.context.subscriptions)
+        assert set(events) == self.context.subscriptions
 
     def assertNoEvents(self):  # noqa: N802
         self.assertEqualEvents([])

--- a/tests/mpd/protocol/test_music_db.py
+++ b/tests/mpd/protocol/test_music_db.py
@@ -14,20 +14,20 @@ class QueryFromMpdSearchFormatTest(unittest.TestCase):
         result = music_db._query_from_mpd_search_parameters(
             ["Date", "1974-01-02", "Date", "1975"], music_db._SEARCH_MAPPING
         )
-        self.assertEqual(result["date"][0], "1974-01-02")
-        self.assertEqual(result["date"][1], "1975")
+        assert result["date"][0] == "1974-01-02"
+        assert result["date"][1] == "1975"
 
     def test_empty_value_is_ignored(self):
         result = music_db._query_from_mpd_search_parameters(
             ["Date", ""], music_db._SEARCH_MAPPING
         )
-        self.assertEqual(result, {})
+        assert result == {}
 
     def test_whitespace_value_is_ignored(self):
         result = music_db._query_from_mpd_search_parameters(
             ["Date", "  "], music_db._SEARCH_MAPPING
         )
-        self.assertEqual(result, {})
+        assert result == {}
 
     # TODO Test more mappings
 
@@ -95,28 +95,24 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         self.backend.library.dummy_find_exact_result = SearchResult(
             tracks=[track]
         )
-        self.assertEqual(self.core.tracklist.get_length().get(), 0)
+        assert self.core.tracklist.get_length().get() == 0
 
         self.send_request('findadd "title" "A"')
 
-        self.assertEqual(self.core.tracklist.get_length().get(), 1)
-        self.assertEqual(
-            self.core.tracklist.get_tracks().get()[0].uri, "dummy:a"
-        )
+        assert self.core.tracklist.get_length().get() == 1
+        assert self.core.tracklist.get_tracks().get()[0].uri == "dummy:a"
         self.assertInResponse("OK")
 
     def test_searchadd(self):
         track = Track(uri="dummy:a", name="A")
         self.backend.library.dummy_library = [track]
         self.backend.library.dummy_search_result = SearchResult(tracks=[track])
-        self.assertEqual(self.core.tracklist.get_length().get(), 0)
+        assert self.core.tracklist.get_length().get() == 0
 
         self.send_request('searchadd "title" "a"')
 
-        self.assertEqual(self.core.tracklist.get_length().get(), 1)
-        self.assertEqual(
-            self.core.tracklist.get_tracks().get()[0].uri, "dummy:a"
-        )
+        assert self.core.tracklist.get_length().get() == 1
+        assert self.core.tracklist.get_tracks().get()[0].uri == "dummy:a"
         self.assertInResponse("OK")
 
     def test_searchaddpl_appends_to_existing_playlist(self):
@@ -133,15 +129,15 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         )
 
         items = self.core.playlists.get_items(playlist.uri).get()
-        self.assertEqual(len(items), 2)
+        assert len(items) == 2
 
         self.send_request('searchaddpl "my favs" "title" "a"')
 
         items = self.core.playlists.get_items(playlist.uri).get()
-        self.assertEqual(len(items), 3)
-        self.assertEqual(items[0].uri, "dummy:x")
-        self.assertEqual(items[1].uri, "dummy:y")
-        self.assertEqual(items[2].uri, "dummy:a")
+        assert len(items) == 3
+        assert items[0].uri == "dummy:x"
+        assert items[1].uri == "dummy:y"
+        assert items[2].uri == "dummy:a"
         self.assertInResponse("OK")
 
     def test_searchaddpl_creates_missing_playlist(self):
@@ -150,7 +146,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         )
 
         playlists = self.core.playlists.as_list().get()
-        self.assertNotIn("my favs", {p.name for p in playlists})
+        assert "my favs" not in {p.name for p in playlists}
 
         self.send_request('searchaddpl "my favs" "title" "a"')
 
@@ -159,8 +155,8 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         items = self.core.playlists.get_items(playlist.uri).get()
 
-        self.assertEqual(len(items), 1)
-        self.assertEqual(items[0].uri, "dummy:a")
+        assert len(items) == 1
+        assert items[0].uri == "dummy:a"
         self.assertInResponse("OK")
 
     def test_listall_without_uri(self):
@@ -226,7 +222,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request('listall "dummy"')
         response2 = self.send_request('listall "/dummy"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     def test_listall_for_dir_with_and_without_trailing_slash_is_the_same(self):
         self.backend.library.dummy_browse_result = {
@@ -238,7 +234,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request('listall "dummy"')
         response2 = self.send_request('listall "dummy/"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     def test_listall_duplicate(self):
         self.backend.library.dummy_browse_result = {
@@ -319,7 +315,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request('listallinfo "dummy"')
         response2 = self.send_request('listallinfo "/dummy"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     def test_listallinfo_for_dir_with_and_without_trailing_slash_is_same(self):
         self.backend.library.dummy_browse_result = {
@@ -331,7 +327,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request('listallinfo "dummy"')
         response2 = self.send_request('listallinfo "dummy/"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     def test_listallinfo_duplicate(self):
         self.backend.library.dummy_browse_result = {
@@ -360,7 +356,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request("lsinfo")
         response2 = self.send_request('lsinfo "/"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     @mock.patch.object(stored_playlists, "_get_last_modified")
     def test_lsinfo_with_empty_path_returns_same_as_for_root(
@@ -373,7 +369,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request('lsinfo ""')
         response2 = self.send_request('lsinfo "/"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     @mock.patch.object(stored_playlists, "_get_last_modified")
     def test_lsinfo_for_root_includes_playlists(self, last_modified_mock):
@@ -413,7 +409,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request('lsinfo "dummy"')
         response2 = self.send_request('lsinfo "/dummy"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     @mock.patch.object(stored_playlists, "_get_last_modified")
     def test_lsinfo_for_dir_with_and_without_trailing_slash_is_the_same(
@@ -429,7 +425,7 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
 
         response1 = self.send_request('lsinfo "dummy"')
         response2 = self.send_request('lsinfo "dummy/"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
     def test_lsinfo_for_dir_includes_tracks(self):
         self.backend.library.dummy_library = [
@@ -494,8 +490,8 @@ class MusicDatabaseHandlerTest(protocol.BaseTestCase):
         )
 
         response = self.send_request('lsinfo "/"')
-        self.assertLess(
-            response.index("directory: dummy"), response.index("playlist: a")
+        assert response.index("directory: dummy") < response.index(
+            "playlist: a"
         )
 
     def test_lsinfo_duplicate(self):

--- a/tests/mpd/protocol/test_playback.py
+++ b/tests/mpd/protocol/test_playback.py
@@ -14,22 +14,22 @@ STOPPED = PlaybackState.STOPPED
 class PlaybackOptionsHandlerTest(protocol.BaseTestCase):
     def test_consume_off(self):
         self.send_request('consume "0"')
-        self.assertFalse(self.core.tracklist.get_consume().get())
+        assert not self.core.tracklist.get_consume().get()
         self.assertInResponse("OK")
 
     def test_consume_off_without_quotes(self):
         self.send_request("consume 0")
-        self.assertFalse(self.core.tracklist.get_consume().get())
+        assert not self.core.tracklist.get_consume().get()
         self.assertInResponse("OK")
 
     def test_consume_on(self):
         self.send_request('consume "1"')
-        self.assertTrue(self.core.tracklist.get_consume().get())
+        assert self.core.tracklist.get_consume().get()
         self.assertInResponse("OK")
 
     def test_consume_on_without_quotes(self):
         self.send_request("consume 1")
-        self.assertTrue(self.core.tracklist.get_consume().get())
+        assert self.core.tracklist.get_consume().get()
         self.assertInResponse("OK")
 
     def test_crossfade(self):
@@ -38,62 +38,62 @@ class PlaybackOptionsHandlerTest(protocol.BaseTestCase):
 
     def test_random_off(self):
         self.send_request('random "0"')
-        self.assertFalse(self.core.tracklist.get_random().get())
+        assert not self.core.tracklist.get_random().get()
         self.assertInResponse("OK")
 
     def test_random_off_without_quotes(self):
         self.send_request("random 0")
-        self.assertFalse(self.core.tracklist.get_random().get())
+        assert not self.core.tracklist.get_random().get()
         self.assertInResponse("OK")
 
     def test_random_on(self):
         self.send_request('random "1"')
-        self.assertTrue(self.core.tracklist.get_random().get())
+        assert self.core.tracklist.get_random().get()
         self.assertInResponse("OK")
 
     def test_random_on_without_quotes(self):
         self.send_request("random 1")
-        self.assertTrue(self.core.tracklist.get_random().get())
+        assert self.core.tracklist.get_random().get()
         self.assertInResponse("OK")
 
     def test_repeat_off(self):
         self.send_request('repeat "0"')
-        self.assertFalse(self.core.tracklist.get_repeat().get())
+        assert not self.core.tracklist.get_repeat().get()
         self.assertInResponse("OK")
 
     def test_repeat_off_without_quotes(self):
         self.send_request("repeat 0")
-        self.assertFalse(self.core.tracklist.get_repeat().get())
+        assert not self.core.tracklist.get_repeat().get()
         self.assertInResponse("OK")
 
     def test_repeat_on(self):
         self.send_request('repeat "1"')
-        self.assertTrue(self.core.tracklist.get_repeat().get())
+        assert self.core.tracklist.get_repeat().get()
         self.assertInResponse("OK")
 
     def test_repeat_on_without_quotes(self):
         self.send_request("repeat 1")
-        self.assertTrue(self.core.tracklist.get_repeat().get())
+        assert self.core.tracklist.get_repeat().get()
         self.assertInResponse("OK")
 
     def test_single_off(self):
         self.send_request('single "0"')
-        self.assertFalse(self.core.tracklist.get_single().get())
+        assert not self.core.tracklist.get_single().get()
         self.assertInResponse("OK")
 
     def test_single_off_without_quotes(self):
         self.send_request("single 0")
-        self.assertFalse(self.core.tracklist.get_single().get())
+        assert not self.core.tracklist.get_single().get()
         self.assertInResponse("OK")
 
     def test_single_on(self):
         self.send_request('single "1"')
-        self.assertTrue(self.core.tracklist.get_single().get())
+        assert self.core.tracklist.get_single().get()
         self.assertInResponse("OK")
 
     def test_single_on_without_quotes(self):
         self.send_request("single 1")
-        self.assertTrue(self.core.tracklist.get_single().get())
+        assert self.core.tracklist.get_single().get()
         self.assertInResponse("OK")
 
     def test_replay_gain_mode_off(self):
@@ -153,186 +153,162 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
         self.send_request('play "0"')
         self.send_request('pause "1"')
         self.send_request('pause "0"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert PLAYING == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
     def test_pause_on(self):
         self.send_request('play "0"')
         self.send_request('pause "1"')
-        self.assertEqual(PAUSED, self.core.playback.get_state().get())
+        assert PAUSED == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
     def test_pause_toggle(self):
         self.send_request('play "0"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert PLAYING == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
         with deprecation.ignore("mpd.protocol.playback.pause:state_arg"):
             self.send_request("pause")
-            self.assertEqual(PAUSED, self.core.playback.get_state().get())
+            assert PAUSED == self.core.playback.get_state().get()
             self.assertInResponse("OK")
 
             self.send_request("pause")
-            self.assertEqual(PLAYING, self.core.playback.get_state().get())
+            assert PLAYING == self.core.playback.get_state().get()
             self.assertInResponse("OK")
 
     def test_play_without_pos(self):
         self.send_request("play")
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert PLAYING == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
     def test_play_with_pos(self):
         self.send_request('play "0"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert PLAYING == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
     def test_play_with_pos_without_quotes(self):
         self.send_request("play 0")
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert PLAYING == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
     def test_play_with_pos_out_of_bounds(self):
         self.core.tracklist.clear().get()
         self.send_request('play "0"')
-        self.assertEqual(STOPPED, self.core.playback.get_state().get())
+        assert STOPPED == self.core.playback.get_state().get()
         self.assertInResponse("ACK [2@0] {play} Bad song index")
 
     def test_play_minus_one_plays_first_in_playlist_if_no_current_track(self):
-        self.assertEqual(self.core.playback.get_current_track().get(), None)
+        assert self.core.playback.get_current_track().get() is None
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertEqual(
-            "dummy:a", self.core.playback.get_current_track().get().uri
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert "dummy:a" == self.core.playback.get_current_track().get().uri
         self.assertInResponse("OK")
 
     def test_play_minus_one_plays_current_track_if_current_track_is_set(self):
-        self.assertEqual(self.core.playback.get_current_track().get(), None)
+        assert self.core.playback.get_current_track().get() is None
         self.core.playback.play()
         self.core.playback.next()
         self.core.playback.stop().get()
-        self.assertNotEqual(self.core.playback.get_current_track().get(), None)
+        assert self.core.playback.get_current_track().get() is not None
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertEqual(
-            "dummy:b", self.core.playback.get_current_track().get().uri
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert "dummy:b" == self.core.playback.get_current_track().get().uri
         self.assertInResponse("OK")
 
     def test_play_minus_one_on_empty_playlist_does_not_ack(self):
         self.core.tracklist.clear()
 
         self.send_request('play "-1"')
-        self.assertEqual(STOPPED, self.core.playback.get_state().get())
-        self.assertEqual(None, self.core.playback.get_current_track().get())
+        assert STOPPED == self.core.playback.get_state().get()
+        assert self.core.playback.get_current_track().get() is None
         self.assertInResponse("OK")
 
     def test_play_minus_is_ignored_if_playing(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert self.core.playback.get_time_position().get() >= 30000
+        assert PLAYING == self.core.playback.get_state().get()
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_play_minus_one_resumes_if_paused(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert self.core.playback.get_time_position().get() >= 30000
+        assert PLAYING == self.core.playback.get_state().get()
         self.core.playback.pause()
-        self.assertEqual(PAUSED, self.core.playback.get_state().get())
+        assert PAUSED == self.core.playback.get_state().get()
 
         self.send_request('play "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_playid(self):
         self.send_request('playid "1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert PLAYING == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
     def test_playid_without_quotes(self):
         self.send_request("playid 1")
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert PLAYING == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
     def test_playid_minus_1_plays_first_in_playlist_if_no_current_track(self):
-        self.assertEqual(self.core.playback.get_current_track().get(), None)
+        assert self.core.playback.get_current_track().get() is None
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertEqual(
-            "dummy:a", self.core.playback.get_current_track().get().uri
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert "dummy:a" == self.core.playback.get_current_track().get().uri
         self.assertInResponse("OK")
 
     def test_playid_minus_1_plays_current_track_if_current_track_is_set(self):
-        self.assertEqual(self.core.playback.get_current_track().get(), None)
+        assert self.core.playback.get_current_track().get() is None
         self.core.playback.play().get()
         self.core.playback.next().get()
         self.core.playback.stop()
-        self.assertNotEqual(None, self.core.playback.get_current_track().get())
+        assert self.core.playback.get_current_track().get() is not None
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertEqual(
-            "dummy:b", self.core.playback.get_current_track().get().uri
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert "dummy:b" == self.core.playback.get_current_track().get().uri
         self.assertInResponse("OK")
 
     def test_playid_minus_one_on_empty_playlist_does_not_ack(self):
         self.core.tracklist.clear()
 
         self.send_request('playid "-1"')
-        self.assertEqual(STOPPED, self.core.playback.get_state().get())
-        self.assertEqual(None, self.core.playback.get_current_track().get())
+        assert STOPPED == self.core.playback.get_state().get()
+        assert self.core.playback.get_current_track().get() is None
         self.assertInResponse("OK")
 
     def test_playid_minus_is_ignored_if_playing(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert self.core.playback.get_time_position().get() >= 30000
+        assert PLAYING == self.core.playback.get_state().get()
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_playid_minus_one_resumes_if_paused(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
+        assert self.core.playback.get_time_position().get() >= 30000
+        assert PLAYING == self.core.playback.get_state().get()
         self.core.playback.pause()
-        self.assertEqual(PAUSED, self.core.playback.get_state().get())
+        assert PAUSED == self.core.playback.get_state().get()
 
         self.send_request('playid "-1"')
-        self.assertEqual(PLAYING, self.core.playback.get_state().get())
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert PLAYING == self.core.playback.get_state().get()
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_playid_which_does_not_exist(self):
@@ -350,39 +326,33 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
         self.send_request('seek "0" "30"')
 
         current_track = self.core.playback.get_current_track().get()
-        self.assertEqual(current_track, self.tracks[0])
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert current_track == self.tracks[0]
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_seek_in_another_track(self):
         self.core.playback.play()
         current_track = self.core.playback.get_current_track().get()
-        self.assertNotEqual(current_track, self.tracks[1])
+        assert current_track != self.tracks[1]
 
         self.send_request('seek "1" "30"')
 
         current_track = self.core.playback.get_current_track().get()
-        self.assertEqual(current_track, self.tracks[1])
+        assert current_track == self.tracks[1]
         self.assertInResponse("OK")
 
     def test_seek_without_quotes(self):
         self.core.playback.play()
 
         self.send_request("seek 0 30")
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_seek_with_float(self):
         self.core.playback.play()
 
         self.send_request('seek "0" "30.1"')
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30100
-        )
+        assert self.core.playback.get_time_position().get() >= 30100
         self.assertInResponse("OK")
 
     def test_seekid_in_current_track(self):
@@ -391,10 +361,8 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
         self.send_request('seekid "1" "30"')
 
         current_track = self.core.playback.get_current_track().get()
-        self.assertEqual(current_track, self.tracks[0])
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert current_track == self.tracks[0]
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_seekid_in_another_track(self):
@@ -403,8 +371,8 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
         self.send_request('seekid "2" "30"')
 
         current_tl_track = self.core.playback.get_current_tl_track().get()
-        self.assertEqual(current_tl_track.tlid, 2)
-        self.assertEqual(current_tl_track.track, self.tracks[1])
+        assert current_tl_track.tlid == 2
+        assert current_tl_track.track == self.tracks[1]
         self.assertInResponse("OK")
 
     def test_seekid_with_float(self):
@@ -413,10 +381,8 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
         self.send_request('seekid "1" "30.1"')
 
         current_track = self.core.playback.get_current_track().get()
-        self.assertEqual(current_track, self.tracks[0])
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30100
-        )
+        assert current_track == self.tracks[0]
+        assert self.core.playback.get_time_position().get() >= 30100
         self.assertInResponse("OK")
 
     def test_seekcur_absolute_value(self):
@@ -424,37 +390,27 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         self.send_request('seekcur "30"')
 
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_seekcur_positive_diff(self):
         self.core.playback.play().get()
         self.core.playback.seek(10000)
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 10000
-        )
+        assert self.core.playback.get_time_position().get() >= 10000
 
         self.send_request('seekcur "+20"')
 
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert self.core.playback.get_time_position().get() >= 30000
         self.assertInResponse("OK")
 
     def test_seekcur_negative_diff(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert self.core.playback.get_time_position().get() >= 30000
 
         self.send_request('seekcur "-20"')
 
-        self.assertLessEqual(
-            self.core.playback.get_time_position().get(), 15000
-        )
+        assert self.core.playback.get_time_position().get() <= 15000
         self.assertInResponse("OK")
 
     def test_seekcur_absolute_float(self):
@@ -462,66 +418,60 @@ class PlaybackControlHandlerTest(protocol.BaseTestCase):
 
         self.send_request('seekcur "30.1"')
 
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30100
-        )
+        assert self.core.playback.get_time_position().get() >= 30100
         self.assertInResponse("OK")
 
     def test_seekcur_negative_float(self):
         self.core.playback.play().get()
         self.core.playback.seek(30000)
-        self.assertGreaterEqual(
-            self.core.playback.get_time_position().get(), 30000
-        )
+        assert self.core.playback.get_time_position().get() >= 30000
 
         self.send_request('seekcur "-20.1"')
 
-        self.assertLessEqual(
-            self.core.playback.get_time_position().get(), 10000
-        )
+        assert self.core.playback.get_time_position().get() <= 10000
         self.assertInResponse("OK")
 
     def test_stop(self):
         self.core.tracklist.clear().get()
         self.send_request("stop")
-        self.assertEqual(STOPPED, self.core.playback.get_state().get())
+        assert STOPPED == self.core.playback.get_state().get()
         self.assertInResponse("OK")
 
 
 class VolumeTest(protocol.BaseTestCase):
     def test_setvol_below_min(self):
         self.send_request('setvol "-10"')
-        self.assertEqual(0, self.core.mixer.get_volume().get())
+        assert 0 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_setvol_min(self):
         self.send_request('setvol "0"')
-        self.assertEqual(0, self.core.mixer.get_volume().get())
+        assert 0 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_setvol_middle(self):
         self.send_request('setvol "50"')
-        self.assertEqual(50, self.core.mixer.get_volume().get())
+        assert 50 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_setvol_max(self):
         self.send_request('setvol "100"')
-        self.assertEqual(100, self.core.mixer.get_volume().get())
+        assert 100 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_setvol_above_max(self):
         self.send_request('setvol "110"')
-        self.assertEqual(100, self.core.mixer.get_volume().get())
+        assert 100 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_setvol_plus_is_ignored(self):
         self.send_request('setvol "+10"')
-        self.assertEqual(10, self.core.mixer.get_volume().get())
+        assert 10 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_setvol_without_quotes(self):
         self.send_request("setvol 50")
-        self.assertEqual(50, self.core.mixer.get_volume().get())
+        assert 50 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_volume_plus(self):
@@ -529,7 +479,7 @@ class VolumeTest(protocol.BaseTestCase):
 
         self.send_request("volume +20")
 
-        self.assertEqual(70, self.core.mixer.get_volume().get())
+        assert 70 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_volume_minus(self):
@@ -537,7 +487,7 @@ class VolumeTest(protocol.BaseTestCase):
 
         self.send_request("volume -20")
 
-        self.assertEqual(30, self.core.mixer.get_volume().get())
+        assert 30 == self.core.mixer.get_volume().get()
         self.assertInResponse("OK")
 
     def test_volume_less_than_minus_100(self):
@@ -545,7 +495,7 @@ class VolumeTest(protocol.BaseTestCase):
 
         self.send_request("volume -110")
 
-        self.assertEqual(50, self.core.mixer.get_volume().get())
+        assert 50 == self.core.mixer.get_volume().get()
         self.assertInResponse("ACK [2@0] {volume} Invalid volume value")
 
     def test_volume_more_than_plus_100(self):
@@ -553,7 +503,7 @@ class VolumeTest(protocol.BaseTestCase):
 
         self.send_request("volume +110")
 
-        self.assertEqual(50, self.core.mixer.get_volume().get())
+        assert 50 == self.core.mixer.get_volume().get()
         self.assertInResponse("ACK [2@0] {volume} Invalid volume value")
 
 

--- a/tests/mpd/protocol/test_reflection.py
+++ b/tests/mpd/protocol/test_reflection.py
@@ -32,7 +32,7 @@ class ReflectionHandlerTest(protocol.BaseTestCase):
 
     def test_notcommands_returns_only_config_and_kill_and_ok(self):
         response = self.send_request("notcommands")
-        self.assertEqual(3, len(response))
+        assert 3 == len(response)
         self.assertInResponse("command: config")
         self.assertInResponse("command: kill")
         self.assertInResponse("OK")

--- a/tests/mpd/protocol/test_regression.py
+++ b/tests/mpd/protocol/test_regression.py
@@ -40,27 +40,17 @@ class IssueGH17RegressionTest(protocol.BaseTestCase):
         # Playlist order: abcfde
 
         self.send_request("play")
-        self.assertEqual(
-            "dummy:a", self.core.playback.get_current_track().get().uri
-        )
+        assert "dummy:a" == self.core.playback.get_current_track().get().uri
         self.send_request('random "1"')
         self.send_request("next")
-        self.assertEqual(
-            "dummy:b", self.core.playback.get_current_track().get().uri
-        )
+        assert "dummy:b" == self.core.playback.get_current_track().get().uri
         self.send_request("next")
         # Should now be at track 'c', but playback fails and it skips ahead
-        self.assertEqual(
-            "dummy:f", self.core.playback.get_current_track().get().uri
-        )
+        assert "dummy:f" == self.core.playback.get_current_track().get().uri
         self.send_request("next")
-        self.assertEqual(
-            "dummy:d", self.core.playback.get_current_track().get().uri
-        )
+        assert "dummy:d" == self.core.playback.get_current_track().get().uri
         self.send_request("next")
-        self.assertEqual(
-            "dummy:e", self.core.playback.get_current_track().get().uri
-        )
+        assert "dummy:e" == self.core.playback.get_current_track().get().uri
 
 
 class IssueGH18RegressionTest(protocol.BaseTestCase):
@@ -102,8 +92,8 @@ class IssueGH18RegressionTest(protocol.BaseTestCase):
         self.send_request("next")
         tl_track_3 = self.core.playback.get_current_tl_track().get()
 
-        self.assertNotEqual(tl_track_1, tl_track_2)
-        self.assertNotEqual(tl_track_2, tl_track_3)
+        assert tl_track_1 != tl_track_2
+        assert tl_track_2 != tl_track_3
 
 
 class IssueGH22RegressionTest(protocol.BaseTestCase):
@@ -253,7 +243,7 @@ class IssueGH1120RegressionTest(protocol.BaseTestCase):
         self.send_request('lsinfo "/dummy"')
 
         response2 = self.send_request('lsinfo "/"')
-        self.assertEqual(response1, response2)
+        assert response1 == response2
 
 
 class IssueGH1348RegressionTest(protocol.BaseTestCase):
@@ -271,7 +261,7 @@ class IssueGH1348RegressionTest(protocol.BaseTestCase):
 
         # Create an other playlist which isn't in the map
         self.send_request('playlistadd "testing2" "dummy:a"')
-        self.assertEqual(["OK"], self.send_request('rm "testing2"'))
+        assert ["OK"] == self.send_request('rm "testing2"')
 
         playlists = self.backend.playlists.as_list().get()
-        self.assertEqual(["testing1"], [ref.name for ref in playlists])
+        assert ["testing1"] == [ref.name for ref in playlists]

--- a/tests/mpd/protocol/test_stored_playlists.py
+++ b/tests/mpd/protocol/test_stored_playlists.py
@@ -209,7 +209,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.backend.library.dummy_library = tracks
         self.core.tracklist.add(uris=["dummy:a", "dummy:b"]).get()
 
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 2)
+        assert len(self.core.tracklist.get_tracks().get()) == 2
         self.backend.playlists.set_dummy_playlists(
             [Playlist(name="A-list", uri="dummy:A-list", tracks=tracks[2:])]
         )
@@ -217,12 +217,12 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('load "A-list"')
 
         tracks = self.core.tracklist.get_tracks().get()
-        self.assertEqual(5, len(tracks))
-        self.assertEqual("dummy:a", tracks[0].uri)
-        self.assertEqual("dummy:b", tracks[1].uri)
-        self.assertEqual("dummy:c", tracks[2].uri)
-        self.assertEqual("dummy:d", tracks[3].uri)
-        self.assertEqual("dummy:ǫ", tracks[4].uri)
+        assert 5 == len(tracks)
+        assert "dummy:a" == tracks[0].uri
+        assert "dummy:b" == tracks[1].uri
+        assert "dummy:c" == tracks[2].uri
+        assert "dummy:d" == tracks[3].uri
+        assert "dummy:ǫ" == tracks[4].uri
         self.assertInResponse("OK")
 
     def test_load_with_range_loads_part_of_playlist(self):
@@ -236,7 +236,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.backend.library.dummy_library = tracks
         self.core.tracklist.add(uris=["dummy:a", "dummy:b"]).get()
 
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 2)
+        assert len(self.core.tracklist.get_tracks().get()) == 2
         self.backend.playlists.set_dummy_playlists(
             [Playlist(name="A-list", uri="dummy:A-list", tracks=tracks[2:])]
         )
@@ -244,10 +244,10 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('load "A-list" "1:2"')
 
         tracks = self.core.tracklist.get_tracks().get()
-        self.assertEqual(3, len(tracks))
-        self.assertEqual("dummy:a", tracks[0].uri)
-        self.assertEqual("dummy:b", tracks[1].uri)
-        self.assertEqual("dummy:d", tracks[2].uri)
+        assert 3 == len(tracks)
+        assert "dummy:a" == tracks[0].uri
+        assert "dummy:b" == tracks[1].uri
+        assert "dummy:d" == tracks[2].uri
         self.assertInResponse("OK")
 
     def test_load_with_range_without_end_loads_rest_of_playlist(self):
@@ -261,7 +261,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.backend.library.dummy_library = tracks
         self.core.tracklist.add(uris=["dummy:a", "dummy:b"]).get()
 
-        self.assertEqual(len(self.core.tracklist.get_tracks().get()), 2)
+        assert len(self.core.tracklist.get_tracks().get()) == 2
         self.backend.playlists.set_dummy_playlists(
             [Playlist(name="A-list", uri="dummy:A-list", tracks=tracks[2:])]
         )
@@ -269,17 +269,17 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('load "A-list" "1:"')
 
         tracks = self.core.tracklist.get_tracks().get()
-        self.assertEqual(4, len(tracks))
-        self.assertEqual("dummy:a", tracks[0].uri)
-        self.assertEqual("dummy:b", tracks[1].uri)
-        self.assertEqual("dummy:d", tracks[2].uri)
-        self.assertEqual("dummy:e", tracks[3].uri)
+        assert 4 == len(tracks)
+        assert "dummy:a" == tracks[0].uri
+        assert "dummy:b" == tracks[1].uri
+        assert "dummy:d" == tracks[2].uri
+        assert "dummy:e" == tracks[3].uri
         self.assertInResponse("OK")
 
     def test_load_unknown_playlist_acks(self):
         self.send_request('load "unknown playlist"')
 
-        self.assertEqual(0, len(self.core.tracklist.get_tracks().get()))
+        assert 0 == len(self.core.tracklist.get_tracks().get())
         self.assertEqualResponse("ACK [50@0] {load} No such playlist")
 
         # No invalid name check for load.
@@ -302,10 +302,10 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('load "A-list"')
 
         tracks = self.core.tracklist.get_tracks().get()
-        self.assertEqual(len(tracks), 1)
-        self.assertEqual(tracks[0].uri, "dummy:a")
-        self.assertEqual(tracks[0].name, "Track A")
-        self.assertEqual(tracks[0].length, 5000)
+        assert len(tracks) == 1
+        assert tracks[0].uri == "dummy:a"
+        assert tracks[0].name == "Track A"
+        assert tracks[0].length == 5000
 
         self.assertInResponse("OK")
 
@@ -322,9 +322,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('playlistadd "name" "dummy:b"')
 
         self.assertInResponse("OK")
-        self.assertEqual(
-            2, len(self.backend.playlists.get_items("dummy:a1").get())
-        )
+        assert 2 == len(self.backend.playlists.get_items("dummy:a1").get())
 
     def test_playlistadd_creates_playlist(self):
         tracks = [
@@ -335,7 +333,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('playlistadd "namé" "dummy:é"')
 
         self.assertInResponse("OK")
-        self.assertIsNotNone(self.backend.playlists.lookup("dummy:namé").get())
+        assert self.backend.playlists.lookup("dummy:namé").get() is not None
 
     def test_playlistadd_invalid_name_acks(self):
         self.send_request('playlistadd "foo/bar" "dummy:a"')
@@ -353,15 +351,13 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('playlistclear "namé"')
 
         self.assertInResponse("OK")
-        self.assertEqual(
-            0, len(self.backend.playlists.get_items("dummy:a1").get())
-        )
+        assert 0 == len(self.backend.playlists.get_items("dummy:a1").get())
 
     def test_playlistclear_creates_playlist(self):
         self.send_request('playlistclear "name"')
 
         self.assertInResponse("OK")
-        self.assertIsNotNone(self.backend.playlists.lookup("dummy:name").get())
+        assert self.backend.playlists.lookup("dummy:name").get() is not None
 
     def test_playlistclear_creates_playlist_save_fails(self):
         self.backend.playlists.set_allow_save(False)
@@ -393,9 +389,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('playlistdelete "namé" "2"')
 
         self.assertInResponse("OK")
-        self.assertEqual(
-            2, len(self.backend.playlists.get_items("dummy:a1").get())
-        )
+        assert 2 == len(self.backend.playlists.get_items("dummy:a1").get())
 
     def test_playlistdelete_save_fails(self):
         tracks = [
@@ -445,8 +439,9 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('playlistmove "namé" "2" "0"')
 
         self.assertInResponse("OK")
-        self.assertEqual(
-            "dummy:c", self.backend.playlists.get_items("dummy:a1").get()[0].uri
+        assert (
+            "dummy:c"
+            == self.backend.playlists.get_items("dummy:a1").get()[0].uri
         )
 
     def test_playlistmove_save_fails(self):
@@ -513,9 +508,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('rename "old_name" "new_namé"')
 
         self.assertInResponse("OK")
-        self.assertIsNotNone(
-            self.backend.playlists.lookup("dummy:new_namé").get()
-        )
+        assert self.backend.playlists.lookup("dummy:new_namé").get() is not None
 
     def test_rename_save_fails(self):
         self.backend.playlists.set_dummy_playlists(
@@ -565,7 +558,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('rm "namé"')
 
         self.assertInResponse("OK")
-        self.assertIsNone(self.backend.playlists.lookup("dummy:à1").get())
+        assert self.backend.playlists.lookup("dummy:à1").get() is None
 
     def test_rm_unknown_playlist_acks(self):
         self.send_request('rm "name"')
@@ -583,7 +576,7 @@ class PlaylistsHandlerTest(protocol.BaseTestCase):
         self.send_request('save "namé"')
 
         self.assertInResponse("OK")
-        self.assertIsNotNone(self.backend.playlists.lookup("dummy:namé").get())
+        assert self.backend.playlists.lookup("dummy:namé").get() is not None
 
     def test_save_fails(self):
         self.backend.playlists.set_allow_save(False)

--- a/tests/mpd/test_commands.py
+++ b/tests/mpd/test_commands.py
@@ -5,16 +5,16 @@ from mopidy.mpd import exceptions, protocol
 
 class TestConverts(unittest.TestCase):
     def test_integer(self):
-        self.assertEqual(123, protocol.INT("123"))
-        self.assertEqual(-123, protocol.INT("-123"))
-        self.assertEqual(123, protocol.INT("+123"))
+        assert 123 == protocol.INT("123")
+        assert (-123) == protocol.INT("-123")
+        assert 123 == protocol.INT("+123")
         self.assertRaises(ValueError, protocol.INT, "3.14")
         self.assertRaises(ValueError, protocol.INT, "")
         self.assertRaises(ValueError, protocol.INT, "abc")
         self.assertRaises(ValueError, protocol.INT, "12 34")
 
     def test_unsigned_integer(self):
-        self.assertEqual(123, protocol.UINT("123"))
+        assert 123 == protocol.UINT("123")
         self.assertRaises(ValueError, protocol.UINT, "-123")
         self.assertRaises(ValueError, protocol.UINT, "+123")
         self.assertRaises(ValueError, protocol.UINT, "3.14")
@@ -23,8 +23,8 @@ class TestConverts(unittest.TestCase):
         self.assertRaises(ValueError, protocol.UINT, "12 34")
 
     def test_boolean(self):
-        self.assertEqual(True, protocol.BOOL("1"))
-        self.assertEqual(False, protocol.BOOL("0"))
+        assert protocol.BOOL("1") is True
+        assert protocol.BOOL("0") is False
         self.assertRaises(ValueError, protocol.BOOL, "3.14")
         self.assertRaises(ValueError, protocol.BOOL, "")
         self.assertRaises(ValueError, protocol.BOOL, "true")
@@ -33,10 +33,10 @@ class TestConverts(unittest.TestCase):
         self.assertRaises(ValueError, protocol.BOOL, "12 34")
 
     def test_range(self):
-        self.assertEqual(slice(1, 2), protocol.RANGE("1"))
-        self.assertEqual(slice(0, 1), protocol.RANGE("0"))
-        self.assertEqual(slice(0, None), protocol.RANGE("0:"))
-        self.assertEqual(slice(1, 3), protocol.RANGE("1:3"))
+        assert slice(1, 2) == protocol.RANGE("1")
+        assert slice(0, 1) == protocol.RANGE("0")
+        assert slice(0, None) == protocol.RANGE("0:")
+        assert slice(1, 3) == protocol.RANGE("1:3")
         self.assertRaises(ValueError, protocol.RANGE, "3.14")
         self.assertRaises(ValueError, protocol.RANGE, "1:abc")
         self.assertRaises(ValueError, protocol.RANGE, "abc:1")
@@ -70,18 +70,18 @@ class TestCommands(unittest.TestCase):
     def test_function_only_takes_context_succeeds(self):
         sentinel = object()
         self.commands.add("bar")(lambda context: sentinel)
-        self.assertEqual(sentinel, self.commands.call(["bar"]))
+        assert sentinel == self.commands.call(["bar"])
 
     def test_function_has_required_arg_succeeds(self):
         sentinel = object()
         self.commands.add("bar")(lambda context, required: sentinel)
-        self.assertEqual(sentinel, self.commands.call(["bar", "arg"]))
+        assert sentinel == self.commands.call(["bar", "arg"])
 
     def test_function_has_optional_args_succeeds(self):
         sentinel = object()
         self.commands.add("bar")(lambda context, optional=None: sentinel)
-        self.assertEqual(sentinel, self.commands.call(["bar"]))
-        self.assertEqual(sentinel, self.commands.call(["bar", "arg"]))
+        assert sentinel == self.commands.call(["bar"])
+        assert sentinel == self.commands.call(["bar", "arg"])
 
     def test_function_has_required_and_optional_args_succeeds(self):
         sentinel = object()
@@ -90,20 +90,20 @@ class TestCommands(unittest.TestCase):
             return sentinel
 
         self.commands.add("bar")(func)
-        self.assertEqual(sentinel, self.commands.call(["bar", "arg"]))
-        self.assertEqual(sentinel, self.commands.call(["bar", "arg", "arg"]))
+        assert sentinel == self.commands.call(["bar", "arg"])
+        assert sentinel == self.commands.call(["bar", "arg", "arg"])
 
     def test_function_has_varargs_succeeds(self):
         sentinel, args = object(), []
         self.commands.add("bar")(lambda context, *args: sentinel)
         for _ in range(10):
-            self.assertEqual(sentinel, self.commands.call(["bar"] + args))
+            assert sentinel == self.commands.call((["bar"] + args))
             args.append("test")
 
     def test_function_has_only_varags_succeeds(self):
         sentinel = object()
         self.commands.add("baz")(lambda *args: sentinel)
-        self.assertEqual(sentinel, self.commands.call(["baz"]))
+        assert sentinel == self.commands.call(["baz"])
 
     def test_function_has_no_arguments_fails(self):
         with self.assertRaises(TypeError):
@@ -135,9 +135,9 @@ class TestCommands(unittest.TestCase):
         self.commands.add("bar")(lambda context: sentinel2)
         self.commands.add("baz")(lambda context: sentinel3)
 
-        self.assertEqual(sentinel1, self.commands.call(["foo"]))
-        self.assertEqual(sentinel2, self.commands.call(["bar"]))
-        self.assertEqual(sentinel3, self.commands.call(["baz"]))
+        assert sentinel1 == self.commands.call(["foo"])
+        assert sentinel2 == self.commands.call(["bar"])
+        assert sentinel3 == self.commands.call(["baz"])
 
     def test_call_with_nonexistent_handler(self):
         with self.assertRaises(exceptions.MpdUnknownCommand):
@@ -146,9 +146,7 @@ class TestCommands(unittest.TestCase):
     def test_call_passes_context(self):
         sentinel = object()
         self.commands.add("foo")(lambda context: context)
-        self.assertEqual(
-            sentinel, self.commands.call(["foo"], context=sentinel)
-        )
+        assert sentinel == self.commands.call(["foo"], context=sentinel)
 
     def test_call_without_args_fails(self):
         with self.assertRaises(exceptions.MpdNoCommand):
@@ -156,23 +154,21 @@ class TestCommands(unittest.TestCase):
 
     def test_call_passes_required_argument(self):
         self.commands.add("foo")(lambda context, required: required)
-        self.assertEqual("test123", self.commands.call(["foo", "test123"]))
+        assert "test123" == self.commands.call(["foo", "test123"])
 
     def test_call_passes_optional_argument(self):
         sentinel = object()
         self.commands.add("foo")(lambda context, optional=sentinel: optional)
-        self.assertEqual(sentinel, self.commands.call(["foo"]))
-        self.assertEqual("test", self.commands.call(["foo", "test"]))
+        assert sentinel == self.commands.call(["foo"])
+        assert "test" == self.commands.call(["foo", "test"])
 
     def test_call_passes_required_and_optional_argument(self):
         def func(context, required, optional=None):
             return (required, optional)
 
         self.commands.add("foo")(func)
-        self.assertEqual(("arg", None), self.commands.call(["foo", "arg"]))
-        self.assertEqual(
-            ("arg", "kwarg"), self.commands.call(["foo", "arg", "kwarg"])
-        )
+        assert ("arg", None) == self.commands.call(["foo", "arg"])
+        assert ("arg", "kwarg") == self.commands.call(["foo", "arg", "kwarg"])
 
     def test_call_passes_varargs(self):
         self.commands.add("foo")(lambda context, *args: args)
@@ -197,7 +193,7 @@ class TestCommands(unittest.TestCase):
             return required
 
         self.commands.add("test", required=lambda v: sentinel)(func)
-        self.assertEqual(sentinel, self.commands.call(["test", "foo"]))
+        assert sentinel == self.commands.call(["test", "foo"])
 
     def test_validator_gets_applied_to_optional_arg(self):
         sentinel = object()
@@ -207,7 +203,7 @@ class TestCommands(unittest.TestCase):
 
         self.commands.add("foo", optional=lambda v: sentinel)(func)
 
-        self.assertEqual(sentinel, self.commands.call(["foo", "123"]))
+        assert sentinel == self.commands.call(["foo", "123"])
 
     def test_validator_skips_optional_default(self):
         sentinel = object()
@@ -217,7 +213,7 @@ class TestCommands(unittest.TestCase):
 
         self.commands.add("foo", optional=lambda v: None)(func)
 
-        self.assertEqual(sentinel, self.commands.call(["foo"]))
+        assert sentinel == self.commands.call(["foo"])
 
     def test_validator_applied_to_non_existent_arg_fails(self):
         self.commands.add("foo")(lambda context, arg: arg)
@@ -259,8 +255,8 @@ class TestCommands(unittest.TestCase):
         self.commands.add("foo")(func1)
         self.commands.add("bar", auth_required=False)(func2)
 
-        self.assertTrue(self.commands.handlers["foo"].auth_required)
-        self.assertFalse(self.commands.handlers["bar"].auth_required)
+        assert self.commands.handlers["foo"].auth_required
+        assert not self.commands.handlers["bar"].auth_required
 
     def test_list_command_gets_stored(self):
         def func1(context):
@@ -272,5 +268,5 @@ class TestCommands(unittest.TestCase):
         self.commands.add("foo")(func1)
         self.commands.add("bar", list_command=False)(func2)
 
-        self.assertTrue(self.commands.handlers["foo"].list_command)
-        self.assertFalse(self.commands.handlers["bar"].list_command)
+        assert self.commands.handlers["foo"].list_command
+        assert not self.commands.handlers["bar"].list_command

--- a/tests/mpd/test_dispatcher.py
+++ b/tests/mpd/test_dispatcher.py
@@ -26,19 +26,18 @@ class MpdDispatcherTest(unittest.TestCase):
         with self.assertRaises(MpdAckError) as cm:
             self.dispatcher._call_handler("an_unknown_command with args")
 
-        self.assertEqual(
-            cm.exception.get_mpd_ack(),
-            'ACK [5@0] {} unknown command "an_unknown_command"',
+        assert (
+            cm.exception.get_mpd_ack()
+            == 'ACK [5@0] {} unknown command "an_unknown_command"'
         )
 
     def test_handling_unknown_request_yields_error(self):
         result = self.dispatcher.handle_request("an unhandled request")
-        self.assertEqual(result[0], 'ACK [5@0] {} unknown command "an"')
+        assert result[0] == 'ACK [5@0] {} unknown command "an"'
 
     def test_handling_blacklisted_command(self):
         result = self.dispatcher.handle_request("disabled")
-        self.assertEqual(
-            result[0],
-            'ACK [0@0] {disabled} "disabled" has been '
-            "disabled in the server",
+        assert (
+            result[0]
+            == 'ACK [0@0] {disabled} "disabled" has been disabled in the server'
         )

--- a/tests/mpd/test_exceptions.py
+++ b/tests/mpd/test_exceptions.py
@@ -16,51 +16,50 @@ class MpdExceptionsTest(unittest.TestCase):
         try:
             raise MpdNotImplemented
         except MpdAckError as exc:
-            self.assertEqual(
-                exc.message, "Not implemented"  # noqa B306: Our own exception
+            assert (
+                exc.message  # noqa: B306: Our own exception
+                == "Not implemented"
             )
 
     def test_get_mpd_ack_with_default_values(self):
         e = MpdAckError("A description")
-        self.assertEqual(e.get_mpd_ack(), "ACK [0@0] {None} A description")
+        assert e.get_mpd_ack() == "ACK [0@0] {None} A description"
 
     def test_get_mpd_ack_with_values(self):
         try:
             raise MpdAckError("A description", index=7, command="foo")
         except MpdAckError as e:
-            self.assertEqual(e.get_mpd_ack(), "ACK [0@7] {foo} A description")
+            assert e.get_mpd_ack() == "ACK [0@7] {foo} A description"
 
     def test_mpd_unknown_command(self):
         try:
             raise MpdUnknownCommand(command="play")
         except MpdAckError as e:
-            self.assertEqual(
-                e.get_mpd_ack(), 'ACK [5@0] {} unknown command "play"'
-            )
+            assert e.get_mpd_ack() == 'ACK [5@0] {} unknown command "play"'
 
     def test_mpd_no_command(self):
         try:
             raise MpdNoCommand
         except MpdAckError as e:
-            self.assertEqual(e.get_mpd_ack(), "ACK [5@0] {} No command given")
+            assert e.get_mpd_ack() == "ACK [5@0] {} No command given"
 
     def test_mpd_system_error(self):
         try:
             raise MpdSystemError("foo")
         except MpdSystemError as e:
-            self.assertEqual(e.get_mpd_ack(), "ACK [52@0] {None} foo")
+            assert e.get_mpd_ack() == "ACK [52@0] {None} foo"
 
     def test_mpd_permission_error(self):
         try:
             raise MpdPermissionError(command="foo")
         except MpdPermissionError as e:
-            self.assertEqual(
-                e.get_mpd_ack(),
-                'ACK [4@0] {foo} you don\'t have permission for "foo"',
+            assert (
+                e.get_mpd_ack()
+                == 'ACK [4@0] {foo} you don\'t have permission for "foo"'
             )
 
     def test_mpd_noexist_error(self):
         try:
             raise MpdNoExistError(command="foo")
         except MpdNoExistError as e:
-            self.assertEqual(e.get_mpd_ack(), "ACK [50@0] {foo} ")
+            assert e.get_mpd_ack() == "ACK [50@0] {foo} "

--- a/tests/mpd/test_status.py
+++ b/tests/mpd/test_status.py
@@ -47,152 +47,152 @@ class StatusHandlerTest(unittest.TestCase):
 
     def test_stats_method(self):
         result = status.stats(self.context)
-        self.assertIn("artists", result)
-        self.assertGreaterEqual(int(result["artists"]), 0)
-        self.assertIn("albums", result)
-        self.assertGreaterEqual(int(result["albums"]), 0)
-        self.assertIn("songs", result)
-        self.assertGreaterEqual(int(result["songs"]), 0)
-        self.assertIn("uptime", result)
-        self.assertGreaterEqual(int(result["uptime"]), 0)
-        self.assertIn("db_playtime", result)
-        self.assertGreaterEqual(int(result["db_playtime"]), 0)
-        self.assertIn("db_update", result)
-        self.assertGreaterEqual(int(result["db_update"]), 0)
-        self.assertIn("playtime", result)
-        self.assertGreaterEqual(int(result["playtime"]), 0)
+        assert "artists" in result
+        assert int(result["artists"]) >= 0
+        assert "albums" in result
+        assert int(result["albums"]) >= 0
+        assert "songs" in result
+        assert int(result["songs"]) >= 0
+        assert "uptime" in result
+        assert int(result["uptime"]) >= 0
+        assert "db_playtime" in result
+        assert int(result["db_playtime"]) >= 0
+        assert "db_update" in result
+        assert int(result["db_update"]) >= 0
+        assert "playtime" in result
+        assert int(result["playtime"]) >= 0
 
     def test_status_method_contains_volume_with_na_value(self):
         result = dict(status.status(self.context))
-        self.assertIn("volume", result)
-        self.assertEqual(int(result["volume"]), -1)
+        assert "volume" in result
+        assert int(result["volume"]) == (-1)
 
     def test_status_method_contains_volume(self):
         self.core.mixer.set_volume(17)
         result = dict(status.status(self.context))
-        self.assertIn("volume", result)
-        self.assertEqual(int(result["volume"]), 17)
+        assert "volume" in result
+        assert int(result["volume"]) == 17
 
     def test_status_method_contains_repeat_is_0(self):
         result = dict(status.status(self.context))
-        self.assertIn("repeat", result)
-        self.assertEqual(int(result["repeat"]), 0)
+        assert "repeat" in result
+        assert int(result["repeat"]) == 0
 
     def test_status_method_contains_repeat_is_1(self):
         self.core.tracklist.set_repeat(True)
         result = dict(status.status(self.context))
-        self.assertIn("repeat", result)
-        self.assertEqual(int(result["repeat"]), 1)
+        assert "repeat" in result
+        assert int(result["repeat"]) == 1
 
     def test_status_method_contains_random_is_0(self):
         result = dict(status.status(self.context))
-        self.assertIn("random", result)
-        self.assertEqual(int(result["random"]), 0)
+        assert "random" in result
+        assert int(result["random"]) == 0
 
     def test_status_method_contains_random_is_1(self):
         self.core.tracklist.set_random(True)
         result = dict(status.status(self.context))
-        self.assertIn("random", result)
-        self.assertEqual(int(result["random"]), 1)
+        assert "random" in result
+        assert int(result["random"]) == 1
 
     def test_status_method_contains_single(self):
         result = dict(status.status(self.context))
-        self.assertIn("single", result)
-        self.assertIn(int(result["single"]), (0, 1))
+        assert "single" in result
+        assert int(result["single"]) in (0, 1)
 
     def test_status_method_contains_consume_is_0(self):
         result = dict(status.status(self.context))
-        self.assertIn("consume", result)
-        self.assertEqual(int(result["consume"]), 0)
+        assert "consume" in result
+        assert int(result["consume"]) == 0
 
     def test_status_method_contains_consume_is_1(self):
         self.core.tracklist.set_consume(True)
         result = dict(status.status(self.context))
-        self.assertIn("consume", result)
-        self.assertEqual(int(result["consume"]), 1)
+        assert "consume" in result
+        assert int(result["consume"]) == 1
 
     def test_status_method_contains_playlist(self):
         result = dict(status.status(self.context))
-        self.assertIn("playlist", result)
-        self.assertGreaterEqual(int(result["playlist"]), 0)
-        self.assertLessEqual(int(result["playlist"]), 2 ** 31 - 1)
+        assert "playlist" in result
+        assert int(result["playlist"]) >= 0
+        assert int(result["playlist"]) <= ((2 ** 31) - 1)
 
     def test_status_method_contains_playlistlength(self):
         result = dict(status.status(self.context))
-        self.assertIn("playlistlength", result)
-        self.assertGreaterEqual(int(result["playlistlength"]), 0)
+        assert "playlistlength" in result
+        assert int(result["playlistlength"]) >= 0
 
     def test_status_method_contains_xfade(self):
         result = dict(status.status(self.context))
-        self.assertIn("xfade", result)
-        self.assertGreaterEqual(int(result["xfade"]), 0)
+        assert "xfade" in result
+        assert int(result["xfade"]) >= 0
 
     def test_status_method_contains_state_is_play(self):
         self.core.playback.set_state(PLAYING)
         result = dict(status.status(self.context))
-        self.assertIn("state", result)
-        self.assertEqual(result["state"], "play")
+        assert "state" in result
+        assert result["state"] == "play"
 
     def test_status_method_contains_state_is_stop(self):
         self.core.playback.set_state(STOPPED)
         result = dict(status.status(self.context))
-        self.assertIn("state", result)
-        self.assertEqual(result["state"], "stop")
+        assert "state" in result
+        assert result["state"] == "stop"
 
     def test_status_method_contains_state_is_pause(self):
         self.core.playback.set_state(PLAYING)
         self.core.playback.set_state(PAUSED)
         result = dict(status.status(self.context))
-        self.assertIn("state", result)
-        self.assertEqual(result["state"], "pause")
+        assert "state" in result
+        assert result["state"] == "pause"
 
     def test_status_method_when_playlist_loaded_contains_song(self):
         self.set_tracklist([Track(uri="dummy:/a")])
         self.core.playback.play().get()
         result = dict(status.status(self.context))
-        self.assertIn("song", result)
-        self.assertGreaterEqual(int(result["song"]), 0)
+        assert "song" in result
+        assert int(result["song"]) >= 0
 
     def test_status_method_when_playlist_loaded_contains_tlid_as_songid(self):
         self.set_tracklist([Track(uri="dummy:/a")])
         self.core.playback.play().get()
         result = dict(status.status(self.context))
-        self.assertIn("songid", result)
-        self.assertEqual(int(result["songid"]), 1)
+        assert "songid" in result
+        assert int(result["songid"]) == 1
 
     def test_status_method_when_playlist_loaded_contains_nextsong(self):
         self.set_tracklist([Track(uri="dummy:/a"), Track(uri="dummy:/b")])
         self.core.playback.play().get()
         result = dict(status.status(self.context))
-        self.assertIn("nextsong", result)
-        self.assertGreaterEqual(int(result["nextsong"]), 0)
+        assert "nextsong" in result
+        assert int(result["nextsong"]) >= 0
 
     def test_status_method_when_playlist_loaded_contains_nextsongid(self):
         self.set_tracklist([Track(uri="dummy:/a"), Track(uri="dummy:/b")])
         self.core.playback.play().get()
         result = dict(status.status(self.context))
-        self.assertIn("nextsongid", result)
-        self.assertEqual(int(result["nextsongid"]), 2)
+        assert "nextsongid" in result
+        assert int(result["nextsongid"]) == 2
 
     def test_status_method_when_playing_contains_time_with_no_length(self):
         self.set_tracklist([Track(uri="dummy:/a", length=None)])
         self.core.playback.play().get()
         result = dict(status.status(self.context))
-        self.assertIn("time", result)
+        assert "time" in result
         (position, total) = result["time"].split(":")
         position = int(position)
         total = int(total)
-        self.assertLessEqual(position, total)
+        assert position <= total
 
     def test_status_method_when_playing_contains_time_with_length(self):
         self.set_tracklist([Track(uri="dummy:/a", length=10000)])
         self.core.playback.play().get()
         result = dict(status.status(self.context))
-        self.assertIn("time", result)
+        assert "time" in result
         (position, total) = result["time"].split(":")
         position = int(position)
         total = int(total)
-        self.assertLessEqual(position, total)
+        assert position <= total
 
     def test_status_method_when_playing_contains_elapsed(self):
         self.set_tracklist([Track(uri="dummy:/a", length=60000)])
@@ -200,20 +200,20 @@ class StatusHandlerTest(unittest.TestCase):
         self.core.playback.pause()
         self.core.playback.seek(59123)
         result = dict(status.status(self.context))
-        self.assertIn("elapsed", result)
-        self.assertEqual(result["elapsed"], "59.123")
+        assert "elapsed" in result
+        assert result["elapsed"] == "59.123"
 
     def test_status_method_when_starting_playing_contains_elapsed_zero(self):
         self.set_tracklist([Track(uri="dummy:/a", length=10000)])
         self.core.playback.play().get()
         self.core.playback.pause()
         result = dict(status.status(self.context))
-        self.assertIn("elapsed", result)
-        self.assertEqual(result["elapsed"], "0.000")
+        assert "elapsed" in result
+        assert result["elapsed"] == "0.000"
 
     def test_status_method_when_playing_contains_bitrate(self):
         self.set_tracklist([Track(uri="dummy:/a", bitrate=3200)])
         self.core.playback.play().get()
         result = dict(status.status(self.context))
-        self.assertIn("bitrate", result)
-        self.assertEqual(int(result["bitrate"]), 3200)
+        assert "bitrate" in result
+        assert int(result["bitrate"]) == 3200

--- a/tests/mpd/test_tokenizer.py
+++ b/tests/mpd/test_tokenizer.py
@@ -5,12 +5,12 @@ from mopidy.mpd import exceptions, tokenize
 
 class TestTokenizer(unittest.TestCase):
     def assertTokenizeEquals(self, expected, line):  # noqa: N802
-        self.assertEqual(expected, tokenize.split(line))
+        assert expected == tokenize.split(line)
 
     def assertTokenizeRaises(self, exception, message, line):  # noqa: N802
         with self.assertRaises(exception) as cm:
             tokenize.split(line)
-        self.assertEqual(cm.exception.message, message)
+        assert cm.exception.message == message
 
     def test_empty_string(self):
         ex = exceptions.MpdNoCommand

--- a/tests/mpd/test_translator.py
+++ b/tests/mpd/test_translator.py
@@ -38,117 +38,117 @@ class TrackMpdFormatTest(unittest.TestCase):
         result = translator.track_to_mpd_format(
             Track(uri="a uri", length=137000)
         )
-        self.assertIn(("file", "a uri"), result)
-        self.assertIn(("Time", 137), result)
-        self.assertNotIn(("Artist", ""), result)
-        self.assertNotIn(("Title", ""), result)
-        self.assertNotIn(("Album", ""), result)
-        self.assertNotIn(("Track", 0), result)
-        self.assertNotIn(("Date", ""), result)
-        self.assertEqual(len(result), 2)
+        assert ("file", "a uri") in result
+        assert ("Time", 137) in result
+        assert ("Artist", "") not in result
+        assert ("Title", "") not in result
+        assert ("Album", "") not in result
+        assert ("Track", 0) not in result
+        assert ("Date", "") not in result
+        assert len(result) == 2
 
     def test_track_to_mpd_format_with_position(self):
         result = translator.track_to_mpd_format(Track(), position=1)
-        self.assertNotIn(("Pos", 1), result)
+        assert ("Pos", 1) not in result
 
     def test_track_to_mpd_format_with_tlid(self):
         result = translator.track_to_mpd_format(TlTrack(1, Track()))
-        self.assertNotIn(("Id", 1), result)
+        assert ("Id", 1) not in result
 
     def test_track_to_mpd_format_with_position_and_tlid(self):
         result = translator.track_to_mpd_format(
             TlTrack(2, Track(uri="a uri")), position=1
         )
-        self.assertIn(("Pos", 1), result)
-        self.assertIn(("Id", 2), result)
+        assert ("Pos", 1) in result
+        assert ("Id", 2) in result
 
     def test_track_to_mpd_format_for_nonempty_track(self):
         result = translator.track_to_mpd_format(
             TlTrack(122, self.track), position=9
         )
-        self.assertIn(("file", "à uri"), result)
-        self.assertIn(("Time", 137), result)
-        self.assertIn(("Artist", "an artist"), result)
-        self.assertIn(("Title", "a nàme"), result)
-        self.assertIn(("Album", "an album"), result)
-        self.assertIn(("AlbumArtist", "an other artist"), result)
-        self.assertIn(("Composer", "a composer"), result)
-        self.assertIn(("Performer", "a performer"), result)
-        self.assertIn(("Genre", "a genre"), result)
-        self.assertIn(("Track", "7/13"), result)
-        self.assertIn(("Date", "1977-01-01"), result)
-        self.assertIn(("Disc", 1), result)
-        self.assertIn(("Pos", 9), result)
-        self.assertIn(("Id", 122), result)
-        self.assertIn(("X-AlbumUri", "urischeme:àlbum:12345"), result)
-        self.assertNotIn(("Comment", "a comment"), result)
-        self.assertEqual(len(result), 15)
+        assert ("file", "à uri") in result
+        assert ("Time", 137) in result
+        assert ("Artist", "an artist") in result
+        assert ("Title", "a nàme") in result
+        assert ("Album", "an album") in result
+        assert ("AlbumArtist", "an other artist") in result
+        assert ("Composer", "a composer") in result
+        assert ("Performer", "a performer") in result
+        assert ("Genre", "a genre") in result
+        assert ("Track", "7/13") in result
+        assert ("Date", "1977-01-01") in result
+        assert ("Disc", 1) in result
+        assert ("Pos", 9) in result
+        assert ("Id", 122) in result
+        assert ("X-AlbumUri", "urischeme:àlbum:12345") in result
+        assert ("Comment", "a comment") not in result
+        assert len(result) == 15
 
     def test_track_to_mpd_format_with_last_modified(self):
         track = self.track.replace(last_modified=995303899000)
         result = translator.track_to_mpd_format(track)
-        self.assertIn(("Last-Modified", "2001-07-16T17:18:19Z"), result)
+        assert ("Last-Modified", "2001-07-16T17:18:19Z") in result
 
     def test_track_to_mpd_format_with_last_modified_of_zero(self):
         track = self.track.replace(last_modified=0)
         result = translator.track_to_mpd_format(track)
         keys = [k for k, v in result]
-        self.assertNotIn("Last-Modified", keys)
+        assert "Last-Modified" not in keys
 
     def test_track_to_mpd_format_musicbrainz_trackid(self):
         track = self.track.replace(musicbrainz_id="foo")
         result = translator.track_to_mpd_format(track)
-        self.assertIn(("MUSICBRAINZ_TRACKID", "foo"), result)
+        assert ("MUSICBRAINZ_TRACKID", "foo") in result
 
     def test_track_to_mpd_format_musicbrainz_albumid(self):
         album = self.track.album.replace(musicbrainz_id="foo")
         track = self.track.replace(album=album)
         result = translator.track_to_mpd_format(track)
-        self.assertIn(("MUSICBRAINZ_ALBUMID", "foo"), result)
+        assert ("MUSICBRAINZ_ALBUMID", "foo") in result
 
     def test_track_to_mpd_format_musicbrainz_albumartistid(self):
         artist = list(self.track.artists)[0].replace(musicbrainz_id="foo")
         album = self.track.album.replace(artists=[artist])
         track = self.track.replace(album=album)
         result = translator.track_to_mpd_format(track)
-        self.assertIn(("MUSICBRAINZ_ALBUMARTISTID", "foo"), result)
+        assert ("MUSICBRAINZ_ALBUMARTISTID", "foo") in result
 
     def test_track_to_mpd_format_musicbrainz_artistid(self):
         artist = list(self.track.artists)[0].replace(musicbrainz_id="foo")
         track = self.track.replace(artists=[artist])
         result = translator.track_to_mpd_format(track)
-        self.assertIn(("MUSICBRAINZ_ARTISTID", "foo"), result)
+        assert ("MUSICBRAINZ_ARTISTID", "foo") in result
 
     def test_concat_multi_values(self):
         artists = [Artist(name="ABBA"), Artist(name="Beatles")]
         translated = translator.concat_multi_values(artists, "name")
-        self.assertEqual(translated, "ABBA;Beatles")
+        assert translated == "ABBA;Beatles"
 
     def test_concat_multi_values_artist_with_no_name(self):
         artists = [Artist(name=None)]
         translated = translator.concat_multi_values(artists, "name")
-        self.assertEqual(translated, "")
+        assert translated == ""
 
     def test_concat_multi_values_artist_with_no_musicbrainz_id(self):
         artists = [Artist(name="Jah Wobble")]
         translated = translator.concat_multi_values(artists, "musicbrainz_id")
-        self.assertEqual(translated, "")
+        assert translated == ""
 
     def test_track_to_mpd_format_with_stream_title(self):
         result = translator.track_to_mpd_format(self.track, stream_title="foo")
-        self.assertIn(("Name", "a nàme"), result)
-        self.assertIn(("Title", "foo"), result)
+        assert ("Name", "a nàme") in result
+        assert ("Title", "foo") in result
 
     def test_track_to_mpd_format_with_empty_stream_title(self):
         result = translator.track_to_mpd_format(self.track, stream_title="")
-        self.assertIn(("Name", "a nàme"), result)
-        self.assertNotIn(("Title", ""), result)
+        assert ("Name", "a nàme") in result
+        assert ("Title", "") not in result
 
     def test_track_to_mpd_format_with_stream_and_no_track_name(self):
         track = self.track.replace(name=None)
         result = translator.track_to_mpd_format(track, stream_title="foo")
-        self.assertNotIn(("Name", ""), result)
-        self.assertIn(("Title", "foo"), result)
+        assert ("Name", "") not in result
+        assert ("Title", "foo") in result
 
 
 class PlaylistMpdFormatTest(unittest.TestCase):
@@ -161,7 +161,7 @@ class PlaylistMpdFormatTest(unittest.TestCase):
             ]
         )
         result = translator.playlist_to_mpd_format(playlist)
-        self.assertEqual(len(result), 3)
+        assert len(result) == 3
 
     def test_mpd_format_with_range(self):
         playlist = Playlist(
@@ -172,5 +172,5 @@ class PlaylistMpdFormatTest(unittest.TestCase):
             ]
         )
         result = translator.playlist_to_mpd_format(playlist, 1, 2)
-        self.assertEqual(len(result), 1)
-        self.assertEqual(dict(result[0])["Track"], 2)
+        assert len(result) == 1
+        assert dict(result[0])["Track"] == 2

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -8,35 +8,23 @@ from mopidy import commands
 class ConfigOverrideTypeTest(unittest.TestCase):
     def test_valid_override(self):
         expected = (b"section", b"key", b"value")
-        self.assertEqual(
-            expected, commands.config_override_type(b"section/key=value")
-        )
-        self.assertEqual(
-            expected, commands.config_override_type(b"section/key=value ")
-        )
-        self.assertEqual(
-            expected, commands.config_override_type(b"section/key =value")
-        )
-        self.assertEqual(
-            expected, commands.config_override_type(b"section /key=value")
-        )
+        assert expected == commands.config_override_type(b"section/key=value")
+        assert expected == commands.config_override_type(b"section/key=value ")
+        assert expected == commands.config_override_type(b"section/key =value")
+        assert expected == commands.config_override_type(b"section /key=value")
 
     def test_valid_override_is_bytes(self):
         section, key, value = commands.config_override_type(
             b"section/key=value"
         )
-        self.assertIsInstance(section, bytes)
-        self.assertIsInstance(key, bytes)
-        self.assertIsInstance(value, bytes)
+        assert isinstance(section, bytes)
+        assert isinstance(key, bytes)
+        assert isinstance(value, bytes)
 
     def test_empty_override(self):
         expected = (b"section", b"key", b"")
-        self.assertEqual(
-            expected, commands.config_override_type(b"section/key=")
-        )
-        self.assertEqual(
-            expected, commands.config_override_type(b"section/key=  ")
-        )
+        assert expected == commands.config_override_type(b"section/key=")
+        assert expected == commands.config_override_type(b"section/key=  ")
 
     def test_invalid_override(self):
         with self.assertRaises(argparse.ArgumentTypeError):
@@ -58,12 +46,12 @@ class CommandParsingTest(unittest.TestCase):
 
     def test_command_parsing_returns_namespace(self):
         cmd = commands.Command()
-        self.assertIsInstance(cmd.parse([]), argparse.Namespace)
+        assert isinstance(cmd.parse([]), argparse.Namespace)
 
     def test_command_parsing_does_not_contain_args(self):
         cmd = commands.Command()
         result = cmd.parse([])
-        self.assertFalse(hasattr(result, "_args"))
+        assert not hasattr(result, "_args")
 
     def test_unknown_options_bails(self):
         cmd = commands.Command()
@@ -80,7 +68,7 @@ class CommandParsingTest(unittest.TestCase):
         cmd.add_argument("--bar")
 
         result = cmd.parse(["--bar", "baz"])
-        self.assertEqual(result.bar, "baz")
+        assert result.bar == "baz"
 
     def test_command_arguments_and_sub_command(self):
         child = commands.Command()
@@ -91,8 +79,8 @@ class CommandParsingTest(unittest.TestCase):
         cmd.add_child("foo", child)
 
         result = cmd.parse(["--bar", "baz", "foo"])
-        self.assertEqual(result.bar, "baz")
-        self.assertEqual(result.baz, None)
+        assert result.bar == "baz"
+        assert result.baz is None
 
     def test_subcommand_may_have_positional(self):
         child = commands.Command()
@@ -102,7 +90,7 @@ class CommandParsingTest(unittest.TestCase):
         cmd.add_child("foo", child)
 
         result = cmd.parse(["foo", "baz"])
-        self.assertEqual(result.bar, "baz")
+        assert result.bar == "baz"
 
     def test_subcommand_may_have_remainder(self):
         child = commands.Command()
@@ -112,7 +100,7 @@ class CommandParsingTest(unittest.TestCase):
         cmd.add_child("foo", child)
 
         result = cmd.parse(["foo", "baz", "bep", "bop"])
-        self.assertEqual(result.bar, ["baz", "bep", "bop"])
+        assert result.bar == ["baz", "bep", "bop"]
 
     def test_result_stores_choosen_command(self):
         child = commands.Command()
@@ -121,10 +109,10 @@ class CommandParsingTest(unittest.TestCase):
         cmd.add_child("foo", child)
 
         result = cmd.parse(["foo"])
-        self.assertEqual(result.command, child)
+        assert result.command == child
 
         result = cmd.parse([])
-        self.assertEqual(result.command, cmd)
+        assert result.command == cmd
 
         child2 = commands.Command()
         cmd.add_child("bar", child2)
@@ -133,10 +121,10 @@ class CommandParsingTest(unittest.TestCase):
         child.add_child("baz", subchild)
 
         result = cmd.parse(["bar"])
-        self.assertEqual(result.command, child2)
+        assert result.command == child2
 
         result = cmd.parse(["foo", "baz"])
-        self.assertEqual(result.command, subchild)
+        assert result.command == subchild
 
     def test_invalid_type(self):
         cmd = commands.Command()
@@ -240,7 +228,7 @@ class CommandParsingTest(unittest.TestCase):
         cmd.set(foo="bar")
 
         result = cmd.parse([])
-        self.assertEqual(result.foo, "bar")
+        assert result.foo == "bar"
 
     def test_set_propegate(self):
         child = commands.Command()
@@ -250,7 +238,7 @@ class CommandParsingTest(unittest.TestCase):
         cmd.add_child("command", child)
 
         result = cmd.parse(["command"])
-        self.assertEqual(result.foo, "bar")
+        assert result.foo == "bar"
 
     def test_innermost_set_wins(self):
         child = commands.Command()
@@ -261,8 +249,8 @@ class CommandParsingTest(unittest.TestCase):
         cmd.add_child("command", child)
 
         result = cmd.parse(["command"])
-        self.assertEqual(result.foo, "bar")
-        self.assertEqual(result.baz, 1)
+        assert result.foo == "bar"
+        assert result.baz == 1
 
     def test_help_action_works(self):
         cmd = commands.Command()
@@ -281,36 +269,32 @@ class UsageTest(unittest.TestCase):
     def test_prog_name_default_and_override(self, argv_mock):
         argv_mock.__getitem__.return_value = "/usr/bin/foo"
         cmd = commands.Command()
-        self.assertEqual("usage: foo", cmd.format_usage().strip())
-        self.assertEqual("usage: baz", cmd.format_usage("baz").strip())
+        assert "usage: foo" == cmd.format_usage().strip()
+        assert "usage: baz" == cmd.format_usage("baz").strip()
 
     def test_basic_usage(self):
         cmd = commands.Command()
-        self.assertEqual("usage: foo", cmd.format_usage("foo").strip())
+        assert "usage: foo" == cmd.format_usage("foo").strip()
 
         cmd.add_argument("-h", "--help", action="store_true")
-        self.assertEqual("usage: foo [-h]", cmd.format_usage("foo").strip())
+        assert "usage: foo [-h]" == cmd.format_usage("foo").strip()
 
         cmd.add_argument("bar")
-        self.assertEqual("usage: foo [-h] bar", cmd.format_usage("foo").strip())
+        assert "usage: foo [-h] bar" == cmd.format_usage("foo").strip()
 
     def test_nested_usage(self):
         child = commands.Command()
         cmd = commands.Command()
         cmd.add_child("bar", child)
 
-        self.assertEqual("usage: foo", cmd.format_usage("foo").strip())
-        self.assertEqual("usage: foo bar", cmd.format_usage("foo bar").strip())
+        assert "usage: foo" == cmd.format_usage("foo").strip()
+        assert "usage: foo bar" == cmd.format_usage("foo bar").strip()
 
         cmd.add_argument("-h", "--help", action="store_true")
-        self.assertEqual(
-            "usage: foo bar", child.format_usage("foo bar").strip()
-        )
+        assert "usage: foo bar" == child.format_usage("foo bar").strip()
 
         child.add_argument("-h", "--help", action="store_true")
-        self.assertEqual(
-            "usage: foo bar [-h]", child.format_usage("foo bar").strip()
-        )
+        assert "usage: foo bar [-h]" == child.format_usage("foo bar").strip()
 
 
 class HelpTest(unittest.TestCase):
@@ -318,12 +302,12 @@ class HelpTest(unittest.TestCase):
     def test_prog_name_default_and_override(self, argv_mock):
         argv_mock.__getitem__.return_value = "/usr/bin/foo"
         cmd = commands.Command()
-        self.assertEqual("usage: foo", cmd.format_help().strip())
-        self.assertEqual("usage: bar", cmd.format_help("bar").strip())
+        assert "usage: foo" == cmd.format_help().strip()
+        assert "usage: bar" == cmd.format_help("bar").strip()
 
     def test_command_without_documenation_or_options(self):
         cmd = commands.Command()
-        self.assertEqual("usage: bar", cmd.format_help("bar").strip())
+        assert "usage: bar" == cmd.format_help("bar").strip()
 
     def test_command_with_option(self):
         cmd = commands.Command()
@@ -336,7 +320,7 @@ class HelpTest(unittest.TestCase):
             "OPTIONS:\n\n"
             "  -h, --help  show this message"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_command_with_option_and_positional(self):
         cmd = commands.Command()
@@ -351,7 +335,7 @@ class HelpTest(unittest.TestCase):
             "  -h, --help  show this message\n"
             "  bar         some help text"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_command_with_documentation(self):
         cmd = commands.Command()
@@ -360,7 +344,7 @@ class HelpTest(unittest.TestCase):
         expected = (
             "usage: foo\n\n" "some text about everything this command does."
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_command_with_documentation_and_option(self):
         cmd = commands.Command()
@@ -375,14 +359,14 @@ class HelpTest(unittest.TestCase):
             "OPTIONS:\n\n"
             "  -h, --help  show this message"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_subcommand_without_documentation_or_options(self):
         child = commands.Command()
         cmd = commands.Command()
         cmd.add_child("bar", child)
 
-        self.assertEqual("usage: foo", cmd.format_help("foo").strip())
+        assert "usage: foo" == cmd.format_help("foo").strip()
 
     def test_subcommand_with_documentation_shown(self):
         child = commands.Command()
@@ -396,7 +380,7 @@ class HelpTest(unittest.TestCase):
             "bar\n\n"
             "  some text about everything this command does."
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_subcommand_with_options_shown(self):
         child = commands.Command()
@@ -413,7 +397,7 @@ class HelpTest(unittest.TestCase):
             "bar [-h]\n\n"
             "    -h, --help  show this message"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_subcommand_with_positional_shown(self):
         child = commands.Command()
@@ -428,7 +412,7 @@ class HelpTest(unittest.TestCase):
             "bar baz\n\n"
             "    baz  the great and wonderful"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_subcommand_with_options_and_documentation(self):
         child = commands.Command()
@@ -447,7 +431,7 @@ class HelpTest(unittest.TestCase):
             "  some text about everything this command does.\n\n"
             "    -h, --help  show this message"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_nested_subcommands_with_options(self):
         subchild = commands.Command()
@@ -470,7 +454,7 @@ class HelpTest(unittest.TestCase):
             "bar baz [--test TEST]\n\n"
             "    --test TEST  the great and wonderful"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_nested_subcommands_skipped_intermediate(self):
         subchild = commands.Command()
@@ -488,7 +472,7 @@ class HelpTest(unittest.TestCase):
             "bar baz [--test TEST]\n\n"
             "    --test TEST  the great and wonderful"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_command_with_option_and_subcommand_with_option(self):
         child = commands.Command()
@@ -508,7 +492,7 @@ class HelpTest(unittest.TestCase):
             "bar [--test TEST]\n\n"
             "    --test TEST  the great and wonderful"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
     def test_command_with_options_doc_and_subcommand_with_option_and_doc(self):
         child = commands.Command()
@@ -532,7 +516,7 @@ class HelpTest(unittest.TestCase):
             "  some text about this sub-command.\n\n"
             "    --test TEST  the great and wonderful"
         )
-        self.assertEqual(expected, cmd.format_help("foo").strip())
+        assert expected == cmd.format_help("foo").strip()
 
 
 class RunTest(unittest.TestCase):

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -7,46 +7,32 @@ class ExceptionsTest(unittest.TestCase):
     def test_exception_can_include_message_string(self):
         exc = exceptions.MopidyException("foo")
 
-        self.assertEqual(exc.message, "foo")
-        self.assertEqual(str(exc), "foo")
+        assert exc.message == "foo"
+        assert str(exc) == "foo"
 
     def test_backend_error_is_a_mopidy_exception(self):
-        self.assertTrue(
-            issubclass(exceptions.BackendError, exceptions.MopidyException)
-        )
+        assert issubclass(exceptions.BackendError, exceptions.MopidyException)
 
     def test_extension_error_is_a_mopidy_exception(self):
-        self.assertTrue(
-            issubclass(exceptions.ExtensionError, exceptions.MopidyException)
-        )
+        assert issubclass(exceptions.ExtensionError, exceptions.MopidyException)
 
     def test_find_error_is_a_mopidy_exception(self):
-        self.assertTrue(
-            issubclass(exceptions.FindError, exceptions.MopidyException)
-        )
+        assert issubclass(exceptions.FindError, exceptions.MopidyException)
 
     def test_find_error_can_store_an_errno(self):
         exc = exceptions.FindError("msg", errno=1234)
 
-        self.assertEqual(exc.message, "msg")
-        self.assertEqual(exc.errno, 1234)
+        assert exc.message == "msg"
+        assert exc.errno == 1234
 
     def test_frontend_error_is_a_mopidy_exception(self):
-        self.assertTrue(
-            issubclass(exceptions.FrontendError, exceptions.MopidyException)
-        )
+        assert issubclass(exceptions.FrontendError, exceptions.MopidyException)
 
     def test_mixer_error_is_a_mopidy_exception(self):
-        self.assertTrue(
-            issubclass(exceptions.MixerError, exceptions.MopidyException)
-        )
+        assert issubclass(exceptions.MixerError, exceptions.MopidyException)
 
     def test_scanner_error_is_a_mopidy_exception(self):
-        self.assertTrue(
-            issubclass(exceptions.ScannerError, exceptions.MopidyException)
-        )
+        assert issubclass(exceptions.ScannerError, exceptions.MopidyException)
 
     def test_audio_error_is_a_mopidy_exception(self):
-        self.assertTrue(
-            issubclass(exceptions.AudioException, exceptions.MopidyException)
-        )
+        assert issubclass(exceptions.AudioException, exceptions.MopidyException)

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -23,9 +23,9 @@ class HelpTest(unittest.TestCase):
             stdout=subprocess.PIPE,
         )
         output = process.communicate()[0]
-        self.assertIn(b"--version", output)
-        self.assertIn(b"--help", output)
-        self.assertIn(b"--quiet", output)
-        self.assertIn(b"--verbose", output)
-        self.assertIn(b"--config", output)
-        self.assertIn(b"--option", output)
+        assert b"--version" in output
+        assert b"--help" in output
+        assert b"--quiet" in output
+        assert b"--verbose" in output
+        assert b"--config" in output
+        assert b"--option" in output

--- a/tests/test_path_utils.py
+++ b/tests/test_path_utils.py
@@ -11,8 +11,8 @@ class MtimeTest(unittest.TestCase):
 
     def test_mtime_of_current_dir(self):
         mtime_dir = int(os.stat(".").st_mtime)
-        self.assertEqual(mtime_dir, path_utils.mtime("."))
+        assert mtime_dir == path_utils.mtime(".")
 
     def test_fake_time_is_returned(self):
         path_utils.mtime.set_fake_time(123456)
-        self.assertEqual(path_utils.mtime("."), 123456)
+        assert path_utils.mtime(".") == 123456


### PR DESCRIPTION
pytest assertions are easier to read and give better error messages when the tests fails.

Though, we still have quite a bit of flipping of LHS and RHS to do before this feels proper.