### PR TITLE
deps: Require GStreamer >= 1.14.0

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -25,6 +25,8 @@ Dependencies
 
 - Python >= 3.7 is now required. Python 2.7 is no longer supported.
 
+- GStreamer >= 1.14.0 is now required.
+
 - Pykka >= 2.0.1 is now required.
 
 - Tornado >= 4.4 is now required. The upper boundary (< 6) has been removed.

--- a/docs/installation/source.rst
+++ b/docs/installation/source.rst
@@ -32,7 +32,7 @@ please follow the directions :ref:`here <contributing>`.
 
        sudo yum install -y gcc python3-devel python3-pip
 
-#. Then you'll need to install GStreamer >= 1.2.3, with Python bindings.
+#. Then you'll need to install GStreamer >= 1.14.0, with Python bindings.
    GStreamer is packaged for most popular Linux distributions. Search for
    GStreamer in your package manager, and make sure to install the Python
    bindings, and the "good" and "ugly" plugin sets.

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -30,7 +30,7 @@ else:
 GLib.set_prgname("mopidy")
 GLib.set_application_name("Mopidy")
 
-REQUIRED_GST_VERSION = (1, 2, 3)
+REQUIRED_GST_VERSION = (1, 14, 0)
 REQUIRED_GST_VERSION_DISPLAY = ".".join(map(str, REQUIRED_GST_VERSION))
 
 if Gst.version() < REQUIRED_GST_VERSION:


### PR DESCRIPTION
This is available in:

- [Debian stable (buster) and newer](https://packages.debian.org/search?keywords=gstreamer1.0-plugins-base)
- [Ubuntu 18.04 (LTS) and newer](https://packages.ubuntu.com/search?keywords=gstreamer1.0-plugins-base)

Fixes #1739