### PR TITLE
Initial type annotations and mypy setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
           - name: "Lint: flake8"
             python: "3.9"
             tox: flake8
+          - name: "Lint: mypy"
+            python: "3.9"
+            tox: mypy
           - name: "Docs"
             python: "3.9"
             tox: docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -7,6 +7,7 @@ include AUTHORS
 include AUTHORS.update
 include LICENSE
 include MANIFEST.in
+include mopidy/py.typed
 include pyproject.toml
 include tox.ini
 

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import argparse
 import collections
 import contextlib
@@ -6,6 +8,7 @@ import os
 import pathlib
 import signal
 import sys
+from typing import TYPE_CHECKING
 
 import pykka
 from pykka.messages import ProxyCall
@@ -16,6 +19,10 @@ from mopidy.audio import Audio
 from mopidy.core import Core
 from mopidy.internal import deps, process, timer, versioning
 from mopidy.internal.gi import GLib
+
+if TYPE_CHECKING:
+    from typing import Optional
+
 
 logger = logging.getLogger(__name__)
 
@@ -78,7 +85,7 @@ class Command:
     argprases own sub-parser handling.
     """
 
-    help = None
+    help: Optional[str] = None
     #: Help text to display in help output.
 
     def __init__(self):

--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import json
 import logging
 import secrets
 import threading
+from typing import TYPE_CHECKING
 
 import pykka
 import tornado.httpserver
@@ -15,18 +18,21 @@ from mopidy.core import CoreListener
 from mopidy.http import Extension, handlers
 from mopidy.internal import formatting, network
 
+if TYPE_CHECKING:
+    from typing import Any, ClassVar, List, Type
+
 try:
     import asyncio
 except ImportError:
-    asyncio = None
+    asyncio = None  # type: ignore
 
 
 logger = logging.getLogger(__name__)
 
 
 class HttpFrontend(pykka.ThreadingActor, CoreListener):
-    apps = []
-    statics = []
+    apps: ClassVar[List[Type[Any]]] = []
+    statics: ClassVar[List[Type[Any]]] = []
 
     def __init__(self, config, core):
         super().__init__()

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -1,7 +1,10 @@
+from __future__ import annotations
+
 import functools
 import logging
 import os
 import urllib
+from typing import TYPE_CHECKING
 
 import tornado.escape
 import tornado.ioloop
@@ -11,6 +14,10 @@ import tornado.websocket
 import mopidy
 from mopidy import core, models
 from mopidy.internal import jsonrpc
+
+if TYPE_CHECKING:
+    from typing import ClassVar, Set
+
 
 logger = logging.getLogger(__name__)
 
@@ -103,7 +110,7 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
     # XXX This set is shared by all WebSocketHandler objects. This isn't
     # optimal, but there's currently no use case for having more than one of
     # these anyway.
-    clients = set()
+    clients: ClassVar[Set[WebSocketHandler]] = set()
 
     @classmethod
     def broadcast(cls, msg, io_loop):

--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -1,7 +1,15 @@
+from __future__ import annotations
+
 import logging
 import logging.config
 import logging.handlers
 import platform
+from typing import TYPE_CHECKING
+
+
+if TYPE_CHECKING:
+    from typing import Dict
+
 
 LOG_LEVELS = {
     -1: dict(root=logging.ERROR, mopidy=logging.WARNING),
@@ -147,7 +155,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
         logging.CRITICAL: ("red", "white", True),
     }
     # Map logger name to foreground colors
-    logger_map = {}
+    logger_map: Dict[str, str] = {}
 
     csi = "\x1b["
     reset = "\x1b[0m"

--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -6,12 +6,38 @@ import logging.handlers
 import platform
 from typing import TYPE_CHECKING
 
-
 if TYPE_CHECKING:
-    from typing import Dict
+    from logging import LogRecord
+    from typing import Dict, List, Optional, Tuple
+
+    from typing_extensions import Literal, TypedDict
+
+    LogColor = Literal[
+        "black",
+        "red",
+        "green",
+        "yellow",
+        "blue",
+        "magenta",
+        "cyan",
+        "white",
+    ]
+
+    # TODO Move config types into `mopidy.config`
+
+    class Config(TypedDict):
+        logging: LoggingConfig
+        loglevels: Dict[str, int]
+        logcolors: Dict[str, LogColor]
+
+    class LoggingConfig(TypedDict):
+        verbosity: int
+        format: str
+        color: bool
+        config_file: str
 
 
-LOG_LEVELS = {
+LOG_LEVELS: Dict[int, Dict[str, int]] = {
     -1: dict(root=logging.ERROR, mopidy=logging.WARNING),
     0: dict(root=logging.ERROR, mopidy=logging.INFO),
     1: dict(root=logging.WARNING, mopidy=logging.DEBUG),
@@ -28,16 +54,16 @@ logger = logging.getLogger(__name__)
 
 
 class DelayedHandler(logging.Handler):
-    def __init__(self):
+    def __init__(self) -> None:
         logging.Handler.__init__(self)
         self._released = False
-        self._buffer = []
+        self._buffer: List[LogRecord] = []
 
-    def handle(self, record):
+    def handle(self, record: LogRecord) -> None:
         if not self._released:
             self._buffer.append(record)
 
-    def release_delayed_logs(self):
+    def release_delayed_logs(self) -> None:
         self._released = True
         root = logging.getLogger("")
         while self._buffer:
@@ -47,20 +73,22 @@ class DelayedHandler(logging.Handler):
 _delayed_handler = DelayedHandler()
 
 
-def bootstrap_delayed_logging():
+def bootstrap_delayed_logging() -> None:
     root = logging.getLogger("")
     root.setLevel(logging.NOTSET)
     root.addHandler(_delayed_handler)
 
 
-def setup_logging(config, base_verbosity_level, args_verbosity_level):
+def setup_logging(
+    config: Config, base_verbosity_level: int, args_verbosity_level: int
+) -> None:
     logging.captureWarnings(True)
 
     if config["logging"]["config_file"]:
         # Logging config from file must be read before other handlers are
         # added. If not, the other handlers will have no effect.
+        path = config["logging"]["config_file"]
         try:
-            path = config["logging"]["config_file"]
             logging.config.fileConfig(path, disable_existing_loggers=False)
         except Exception as e:
             # Catch everything as logging does not specify what can go wrong.
@@ -69,12 +97,13 @@ def setup_logging(config, base_verbosity_level, args_verbosity_level):
     loglevels = config.get("loglevels", {})
 
     verbosity_level = get_verbosity_level(
-        config, base_verbosity_level, args_verbosity_level
+        config["logging"], base_verbosity_level, args_verbosity_level
     )
     verbosity_filter = VerbosityFilter(verbosity_level, loglevels)
 
     formatter = logging.Formatter(config["logging"]["format"])
 
+    handler: logging.StreamHandler
     if config["logging"]["color"]:
         handler = ColorizingStreamHandler(config.get("logcolors", {}))
     else:
@@ -87,11 +116,15 @@ def setup_logging(config, base_verbosity_level, args_verbosity_level):
     _delayed_handler.release_delayed_logs()
 
 
-def get_verbosity_level(config, base_verbosity_level, args_verbosity_level):
+def get_verbosity_level(
+    logging_config: LoggingConfig,
+    base_verbosity_level: int,
+    args_verbosity_level: int,
+) -> int:
     if args_verbosity_level:
         result = base_verbosity_level + args_verbosity_level
     else:
-        result = base_verbosity_level + config["logging"]["verbosity"]
+        result = base_verbosity_level + logging_config["verbosity"]
 
     if result < min(LOG_LEVELS.keys()):
         result = min(LOG_LEVELS.keys())
@@ -102,11 +135,11 @@ def get_verbosity_level(config, base_verbosity_level, args_verbosity_level):
 
 
 class VerbosityFilter(logging.Filter):
-    def __init__(self, verbosity_level, loglevels):
+    def __init__(self, verbosity_level: int, loglevels: Dict[str, int]):
         self.verbosity_level = verbosity_level
         self.loglevels = loglevels
 
-    def filter(self, record):
+    def filter(self, record: LogRecord) -> bool:
         for name, required_log_level in self.loglevels.items():
             if record.name == name or record.name.startswith(name + "."):
                 return record.levelno >= required_log_level
@@ -119,7 +152,7 @@ class VerbosityFilter(logging.Filter):
 
 
 #: Available log colors.
-COLORS = [
+COLORS: List[LogColor] = [
     "black",
     "red",
     "green",
@@ -146,7 +179,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
     """
 
     # Map logging levels to (background, foreground, bold/intense)
-    level_map = {
+    level_map: Dict[int, Tuple[Optional[LogColor], LogColor, bool]] = {
         TRACE_LOG_LEVEL: (None, "blue", False),
         logging.DEBUG: (None, "blue", False),
         logging.INFO: (None, "white", False),
@@ -155,23 +188,23 @@ class ColorizingStreamHandler(logging.StreamHandler):
         logging.CRITICAL: ("red", "white", True),
     }
     # Map logger name to foreground colors
-    logger_map: Dict[str, str] = {}
+    logger_map: Dict[str, LogColor] = {}
 
     csi = "\x1b["
     reset = "\x1b[0m"
 
     is_windows = platform.system() == "Windows"
 
-    def __init__(self, logger_colors):
+    def __init__(self, logger_colors: Dict[str, LogColor]) -> None:
         super().__init__()
         self.logger_map = logger_colors
 
     @property
-    def is_tty(self):
+    def is_tty(self) -> bool:
         isatty = getattr(self.stream, "isatty", None)
         return isatty and isatty()
 
-    def emit(self, record):
+    def emit(self, record: LogRecord) -> None:
         try:
             message = self.format(record)
             self.stream.write(message)
@@ -180,7 +213,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
         except Exception:
             self.handleError(record)
 
-    def format(self, record):
+    def format(self, record: LogRecord) -> str:
         message = logging.StreamHandler.format(self, record)
         if not self.is_tty or self.is_windows:
             return message
@@ -192,7 +225,13 @@ class ColorizingStreamHandler(logging.StreamHandler):
             return self.colorize(message, bg=bg, fg=fg, bold=bold)
         return message
 
-    def colorize(self, message, bg=None, fg=None, bold=False):
+    def colorize(
+        self,
+        message: str,
+        bg: Optional[LogColor] = None,
+        fg: Optional[LogColor] = None,
+        bold: bool = False,
+    ) -> str:
         params = []
         if bg in COLORS:
             params.append(str(COLORS.index(bg) + 40))

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -5,7 +5,7 @@ import socket
 logger = logging.getLogger(__name__)
 
 
-def try_ipv6_socket():
+def try_ipv6_socket() -> bool:
     """Determine if system really supports IPv6"""
     if not socket.has_ipv6:
         return False
@@ -24,7 +24,7 @@ def try_ipv6_socket():
 has_ipv6 = try_ipv6_socket()
 
 
-def format_hostname(hostname):
+def format_hostname(hostname: str) -> str:
     """Format hostname for display."""
     if has_ipv6 and re.match(r"\d+.\d+.\d+.\d+", hostname) is not None:
         hostname = f"::ffff:{hostname}"

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -1,6 +1,17 @@
+from __future__ import annotations
+
 import logging
+from typing import TYPE_CHECKING
 
 from mopidy import listener
+
+if TYPE_CHECKING:
+    from typing import Any, Dict, Optional
+
+    from typing_extensions import Literal
+
+    MixerEvent = Literal["mute_changed", "volume_changed"]
+
 
 logger = logging.getLogger(__name__)
 
@@ -19,7 +30,7 @@ class Mixer:
     :type config: dict
     """
 
-    name = None
+    name: str
     """
     Name of the mixer.
 
@@ -28,10 +39,10 @@ class Mixer:
     mixer.
     """
 
-    def __init__(self, config):
+    def __init__(self, config: Dict) -> None:
         pass
 
-    def get_volume(self):
+    def get_volume(self) -> Optional[int]:
         """
         Get volume level of the mixer on a linear scale from 0 to 100.
 
@@ -50,7 +61,7 @@ class Mixer:
         """
         return None
 
-    def set_volume(self, volume):
+    def set_volume(self, volume: int) -> bool:
         """
         Set volume level of the mixer.
 
@@ -62,7 +73,7 @@ class Mixer:
         """
         return False
 
-    def trigger_volume_changed(self, volume):
+    def trigger_volume_changed(self, volume: int) -> None:
         """
         Send ``volume_changed`` event to all mixer listeners.
 
@@ -73,7 +84,7 @@ class Mixer:
         logger.debug("Mixer event: volume_changed(volume=%d)", volume)
         MixerListener.send("volume_changed", volume=volume)
 
-    def get_mute(self):
+    def get_mute(self) -> Optional[bool]:
         """
         Get mute state of the mixer.
 
@@ -84,7 +95,7 @@ class Mixer:
         """
         return None
 
-    def set_mute(self, mute):
+    def set_mute(self, mute: bool) -> bool:
         """
         Mute or unmute the mixer.
 
@@ -96,7 +107,7 @@ class Mixer:
         """
         return False
 
-    def trigger_mute_changed(self, mute):
+    def trigger_mute_changed(self, mute: bool) -> None:
         """
         Send ``mute_changed`` event to all mixer listeners.
 
@@ -107,7 +118,7 @@ class Mixer:
         logger.debug("Mixer event: mute_changed(mute=%s)", mute)
         MixerListener.send("mute_changed", mute=mute)
 
-    def ping(self):
+    def ping(self) -> bool:
         """Called to check if the actor is still alive."""
         return True
 
@@ -125,11 +136,11 @@ class MixerListener(listener.Listener):
     """
 
     @staticmethod
-    def send(event, **kwargs):
+    def send(event: MixerEvent, **kwargs: Any) -> None:
         """Helper to allow calling of mixer listener events"""
         listener.send(MixerListener, event, **kwargs)
 
-    def volume_changed(self, volume):
+    def volume_changed(self, volume: int) -> None:
         """
         Called after the volume has changed.
 
@@ -140,7 +151,7 @@ class MixerListener(listener.Listener):
         """
         pass
 
-    def mute_changed(self, mute):
+    def mute_changed(self, mute: bool) -> None:
         """
         Called after the mute state has changed.
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -127,3 +127,6 @@ ignore_missing_imports = True
 
 [mypy-pykka.*]
 ignore_missing_imports = True
+
+[mypy-mopidy.internal.log.*]
+disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -137,5 +137,8 @@ disallow_untyped_defs = True
 [mypy-mopidy.internal.log.*]
 disallow_untyped_defs = True
 
+[mypy-mopidy.internal.network.*]
+disallow_untyped_defs = True
+
 [mypy-mopidy.mixer.*]
 disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -128,5 +128,8 @@ ignore_missing_imports = True
 [mypy-pykka.*]
 ignore_missing_imports = True
 
+[mypy-mopidy.backend.*]
+disallow_untyped_defs = True
+
 [mypy-mopidy.internal.log.*]
 disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ lint =
     flake8-bugbear
     flake8-isort
     isort
+    mypy
     pep8-naming
 test =
     pytest
@@ -113,3 +114,16 @@ ignore =
     W503
     # B305: .next() is not a thing on Python 3 (used by playback controller)
     B305
+
+
+[mypy]
+warn_unused_configs = True
+
+[mypy-dbus.*]
+ignore_missing_imports = True
+
+[mypy-gi.*]
+ignore_missing_imports = True
+
+[mypy-pykka.*]
+ignore_missing_imports = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -133,3 +133,6 @@ disallow_untyped_defs = True
 
 [mypy-mopidy.internal.log.*]
 disallow_untyped_defs = True
+
+[mypy-mopidy.mixer.*]
+disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -131,6 +131,9 @@ ignore_missing_imports = True
 [mypy-mopidy.backend.*]
 disallow_untyped_defs = True
 
+[mypy-mopidy.ext.*]
+disallow_untyped_defs = True
+
 [mypy-mopidy.internal.log.*]
 disallow_untyped_defs = True
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -279,7 +279,9 @@ class PostProcessorTest(unittest.TestCase):
 
 def test_format_initial():
     extension = ext.Extension()
+    extension.dist_name = "Mopidy-Foo"
     extension.ext_name = "foo"
+    extension.version = "0.1"
     extension.get_default_config = lambda: None
     extensions_data = [
         ext.ExtensionData(

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -24,16 +24,21 @@ any_testextension = IsA(DummyExtension)
 class TestExtension:
     @pytest.fixture
     def extension(self):
-        return ext.Extension()
+        class MyExtension(ext.Extension):
+            dist_name = "Mopidy-Foo"
+            ext_name = "foo"
+            version = "0.1"
 
-    def test_dist_name_is_none(self, extension):
-        assert extension.dist_name is None
+        return MyExtension()
 
-    def test_ext_name_is_none(self, extension):
-        assert extension.ext_name is None
+    def test_dist_name(self, extension):
+        assert extension.dist_name == "Mopidy-Foo"
 
-    def test_version_is_none(self, extension):
-        assert extension.version is None
+    def test_ext_name(self, extension):
+        assert extension.ext_name == "foo"
+
+    def test_version(self, extension):
+        assert extension.version == "0.1"
 
     def test_get_default_config_raises_not_implemented(self, extension):
         with pytest.raises(NotImplementedError):
@@ -50,19 +55,19 @@ class TestExtension:
         with pytest.raises(NotImplementedError):
             extension.setup(None)
 
-    def test_get_cache_dir_raises_assertion_error(self, extension):
+    def test_get_cache_dir_raises_error(self, extension):
         config = {"core": {"cache_dir": "/tmp"}}
-        with pytest.raises(AssertionError):  # ext_name not set
+        with pytest.raises(AttributeError):  # ext_name not set
             ext.Extension.get_cache_dir(config)
 
-    def test_get_config_dir_raises_assertion_error(self, extension):
+    def test_get_config_dir_raises_error(self, extension):
         config = {"core": {"config_dir": "/tmp"}}
-        with pytest.raises(AssertionError):  # ext_name not set
+        with pytest.raises(AttributeError):  # ext_name not set
             ext.Extension.get_config_dir(config)
 
-    def test_get_data_dir_raises_assertion_error(self, extension):
+    def test_get_data_dir_raises_error(self, extension):
         config = {"core": {"data_dir": "/tmp"}}
-        with pytest.raises(AssertionError):  # ext_name not set
+        with pytest.raises(AttributeError):  # ext_name not set
             ext.Extension.get_data_dir(config)
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, check-manifest, docs, flake8
+envlist = py37, py38, py39, check-manifest, docs, flake8, mypy
 
 [testenv]
 sitepackages = true
@@ -27,3 +27,9 @@ commands = python -m flake8 --show-source --statistics
 deps = .[docs]
 changedir = docs
 commands = python -m sphinx -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/html
+
+[testenv:mypy]
+deps =
+    .[lint]
+    tornado >= 6  # First version to ship type information
+commands = python -m mypy mopidy


### PR DESCRIPTION
This adds a mypy lint task in tox and CI and adds typing to a number of modules.

One use-before-definition bug in an exception handler has already been caught thanks to mypy. Bonus points for finding it in the diff ;-)

Modules that have type annotations are, until we're fully typed, explicitly added to `setup.cfg`. This way, we can gradually type more and more of Mopidy, similarly to how we gradually made more and more of the test suite pass on Python 3 in late 2019.

I've made extensive use of `from __future__ import annotations` in combination with keeping typing-only imports inside `if TYPE_CHECKING`. This ensures that the runtime performance hit from the type annotations is minimal.