### PR TITLE
deps: Don't repeat Mopidy's deps for each extension

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -206,6 +206,10 @@ Extension support
 
   This makes it easier to support arbitrary encoding in file names.
 
+- The command :command:`mopidy deps` no longer repeats the dependencies of
+  Mopidy itself for every installed extension. This reduces the length of the
+  command's output drastically. (PR: :issue:`1846`)
+
 HTTP frontend
 -------------
 

--- a/mopidy/internal/deps.py
+++ b/mopidy/internal/deps.py
@@ -81,13 +81,24 @@ def python_info():
     }
 
 
-def pkg_info(project_name=None, include_extras=False):
+def pkg_info(
+    project_name=None, include_transitive_deps=True, include_extras=False
+):
     if project_name is None:
         project_name = "Mopidy"
     try:
         distribution = pkg_resources.get_distribution(project_name)
         extras = include_extras and distribution.extras or []
-        dependencies = [pkg_info(d) for d in distribution.requires(extras)]
+        if include_transitive_deps:
+            dependencies = [
+                pkg_info(
+                    d.project_name,
+                    include_transitive_deps=d.project_name != "Mopidy",
+                )
+                for d in distribution.requires(extras)
+            ]
+        else:
+            dependencies = []
         return {
             "name": project_name,
             "version": distribution.version,

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -81,23 +81,23 @@ class DepsTest(unittest.TestCase):
 
     @mock.patch("pkg_resources.get_distribution")
     def test_pkg_info(self, get_distribution_mock):
-        dist_mopidy = mock.Mock()
-        dist_mopidy.project_name = "Mopidy"
-        dist_mopidy.version = "0.13"
-        dist_mopidy.location = "/tmp/example/mopidy"
-        dist_mopidy.requires.return_value = ["Pykka"]
-
-        dist_pykka = mock.Mock()
-        dist_pykka.project_name = "Pykka"
-        dist_pykka.version = "1.1"
-        dist_pykka.location = "/tmp/example/pykka"
-        dist_pykka.requires.return_value = ["setuptools"]
-
         dist_setuptools = mock.Mock()
         dist_setuptools.project_name = "setuptools"
         dist_setuptools.version = "0.6"
         dist_setuptools.location = "/tmp/example/setuptools"
         dist_setuptools.requires.return_value = []
+
+        dist_pykka = mock.Mock()
+        dist_pykka.project_name = "Pykka"
+        dist_pykka.version = "1.1"
+        dist_pykka.location = "/tmp/example/pykka"
+        dist_pykka.requires.return_value = [dist_setuptools]
+
+        dist_mopidy = mock.Mock()
+        dist_mopidy.project_name = "Mopidy"
+        dist_mopidy.version = "0.13"
+        dist_mopidy.location = "/tmp/example/mopidy"
+        dist_mopidy.requires.return_value = [dist_pykka]
 
         get_distribution_mock.side_effect = [
             dist_mopidy,


### PR DESCRIPTION
On one example setup, this reduces the output of `mopidy deps` from 499 to 137 lines. No data is lost, we just don't repeat the ~8 lines of dependencies of Mopidy itself for every extension that also depends on Mopidy.