### PR TITLE
audio: Fix logging of GStreamer warning/error

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -323,21 +323,18 @@ class _Handler:
         AudioListener.send("reached_end_of_stream")
 
     def on_error(self, error, debug):
-        error_msg = str(error).decode()
-        debug_msg = debug.decode()
+        gst_logger.error(f"GStreamer error: {error.message}")
         gst_logger.debug(
-            "Got ERROR bus message: error=%r debug=%r", error_msg, debug_msg
+            f"Got ERROR bus message: error={error!r} debug={debug!r}"
         )
-        gst_logger.error("GStreamer error: %s", error_msg)
+
         # TODO: is this needed?
         self._audio.stop_playback()
 
     def on_warning(self, error, debug):
-        error_msg = str(error).decode()
-        debug_msg = debug.decode()
-        gst_logger.warning("GStreamer warning: %s", error_msg)
+        gst_logger.warning(f"GStreamer warning: {error.message}")
         gst_logger.debug(
-            "Got WARNING bus message: error=%r debug=%r", error_msg, debug_msg
+            f"Got WARNING bus message: error={error!r} debug={debug!r}"
         )
 
     def on_async_done(self):


### PR DESCRIPTION
On Python 2, we used `str(error)` to get a native string representation, aka bytes, and then used `.decode()` on that to get a Unicode string.

On Python 3, the `str(error)` call returns Unicode, which doesn't have a `.decode()` method, so the error/warning handler crashes.

I added `ipdb` tracing, provoked an error, and investigated the objects we get from GStreamer:

- `error` is a `GLib.GError` which has a good `str()`/`repr()`, as well as `.message`, `.domain`, and `.code` attributes.
- `debug` is a string

There were no traces of bytes that needed decoding in the objects.

Fixes #1851