### PR TITLE
Promote APIs from "pending deprecation" to "deprecated"

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -136,6 +136,11 @@ Playback controller
     Use :meth:`~mopidy.core.MixerController.get_volume`
     and :meth:`~mopidy.core.MixerController.set_volume`.
 
+- Deprecated the ``tl_track`` argument to
+  :meth:`mopidy.core.PlaybackController.play`, with the goal of removing it in
+  the next major release. Use the ``tlid`` argument instead.
+  (Fixes: #1773, PR: #1786, #1854)
+
 Playlist controller
 ^^^^^^^^^^^^^^^^^^^
 
@@ -177,6 +182,22 @@ Tracklist controller
 - Removed the support for passing filter criterias as keyword arguments to
   :meth:`mopidy.core.TracklistController.remove`.
   Use the ``criteria`` argument instead.
+
+- Deprecated methods, with the goal of removing them in the next major release:
+  (Fixes: #1773, PR: #1786, #1854)
+
+  - :meth:`mopidy.core.TracklistController.eot_track`.
+    Use :meth:`~mopidy.core.TracklistController.get_eot_tlid` instead.
+
+  - :meth:`mopidy.core.TracklistController.next_track`.
+    Use :meth:`~mopidy.core.TracklistController.get_next_tlid` instead.
+
+  - :meth:`mopidy.core.TracklistController.previous_track`.
+    Use :meth:`~mopidy.core.TracklistController.get_previous_tlid` instead.
+
+- The ``tracks`` argument to :meth:`mopidy.core.TracklistController.add` has
+  been deprecated since Mopidy 1.0. It is still deprecated, with the goal of
+  removing it in the next major release. Use the ``uris`` argument instead.
 
 Backend API
 -----------

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -275,6 +275,9 @@ class PlaybackController:
 
         Note that the track **must** already be in the tracklist.
 
+        .. deprecated:: 3.0
+            The ``tl_track`` argument. Use ``tlid`` instead.
+
         :param tl_track: track to play
         :type tl_track: :class:`mopidy.models.TlTrack` or :class:`None`
         :param tlid: TLID of the track to play

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -287,7 +287,7 @@ class PlaybackController:
         tlid is None or validation.check_integer(tlid, min=1)
 
         if tl_track:
-            deprecation.warn("core.playback.play:tl_track_kwarg", pending=True)
+            deprecation.warn("core.playback.play:tl_track_kwarg")
 
         if tl_track is None and tlid is not None:
             for tl_track in self.core.tracklist.get_tl_tracks():

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -195,7 +195,11 @@ class TracklistController:
         """
 
         current_tl_track = self.core.playback.get_current_tl_track()
-        return getattr(self.eot_track(current_tl_track), "tlid", None)
+
+        with deprecation.ignore("core.tracklist.eot_track"):
+            eot_tl_track = self.eot_track(current_tl_track)
+
+        return getattr(eot_tl_track, "tlid", None)
 
     def eot_track(self, tl_track):
         """
@@ -237,7 +241,11 @@ class TracklistController:
         .. versionadded:: 1.1
         """
         current_tl_track = self.core.playback.get_current_tl_track()
-        return getattr(self.next_track(current_tl_track), "tlid", None)
+
+        with deprecation.ignore("core.tracklist.next_track"):
+            next_tl_track = self.next_track(current_tl_track)
+
+        return getattr(next_tl_track, "tlid", None)
 
     def next_track(self, tl_track):
         """
@@ -303,7 +311,11 @@ class TracklistController:
         .. versionadded:: 1.1
         """
         current_tl_track = self.core.playback.get_current_tl_track()
-        return getattr(self.previous_track(current_tl_track), "tlid", None)
+
+        with deprecation.ignore("core.tracklist.previous_track"):
+            previous_tl_track = self.previous_track(current_tl_track)
+
+        return getattr(previous_tl_track, "tlid", None)
 
     def previous_track(self, tl_track):
         """

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -207,7 +207,7 @@ class TracklistController:
         :type tl_track: :class:`mopidy.models.TlTrack` or :class:`None`
         :rtype: :class:`mopidy.models.TlTrack` or :class:`None`
         """
-        deprecation.warn("core.tracklist.eot_track", pending=True)
+        deprecation.warn("core.tracklist.eot_track")
         tl_track is None or validation.check_instance(tl_track, TlTrack)
         if self.get_single() and self.get_repeat():
             return tl_track
@@ -250,7 +250,7 @@ class TracklistController:
         :type tl_track: :class:`mopidy.models.TlTrack` or :class:`None`
         :rtype: :class:`mopidy.models.TlTrack` or :class:`None`
         """
-        deprecation.warn("core.tracklist.next_track", pending=True)
+        deprecation.warn("core.tracklist.next_track")
         tl_track is None or validation.check_instance(tl_track, TlTrack)
 
         if not self._tl_tracks:
@@ -312,7 +312,7 @@ class TracklistController:
         :type tl_track: :class:`mopidy.models.TlTrack` or :class:`None`
         :rtype: :class:`mopidy.models.TlTrack` or :class:`None`
         """
-        deprecation.warn("core.tracklist.previous_track", pending=True)
+        deprecation.warn("core.tracklist.previous_track")
         tl_track is None or validation.check_instance(tl_track, TlTrack)
 
         if self.get_repeat() or self.get_consume() or self.get_random():

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -203,6 +203,9 @@ class TracklistController:
 
         Not necessarily the same track as :meth:`next_track`.
 
+        .. deprecated:: 3.0
+            Use :meth:`get_eot_tlid` instead.
+
         :param tl_track: the reference track
         :type tl_track: :class:`mopidy.models.TlTrack` or :class:`None`
         :rtype: :class:`mopidy.models.TlTrack` or :class:`None`
@@ -245,6 +248,9 @@ class TracklistController:
         is enabled the next track can loop around the tracklist. When random is
         enabled this should be a random track, all tracks should be played once
         before the tracklist repeats.
+
+        .. deprecated:: 3.0
+            Use :meth:`get_next_tlid` instead.
 
         :param tl_track: the reference track
         :type tl_track: :class:`mopidy.models.TlTrack` or :class:`None`
@@ -307,6 +313,9 @@ class TracklistController:
         For normal playback this is the previous track in the tracklist. If
         random and/or consume is enabled it should return the current track
         instead.
+
+        .. deprecated:: 3.0
+            Use :meth:`get_previous_tlid` instead.
 
         :param tl_track: the reference track
         :type tl_track: :class:`mopidy.models.TlTrack` or :class:`None`

--- a/setup.cfg
+++ b/setup.cfg
@@ -92,6 +92,7 @@ universal = 1
 filterwarnings =
     error::DeprecationWarning:mopidy[.*]
     ignore::PendingDeprecationWarning:mopidy[.*]
+    ignore::DeprecationWarning:mopidy[.*]
 
 
 [flake8]


### PR DESCRIPTION
This PR builds upon #1786 by @hugovk, and takes the easy way out: We postpone the replacement of our usage of the deprecated APIs until after Mopidy 3.0 has been released. The important thing is to deprecate them, so that they can be removed in the next major, not to immediately stop using them ourselves.