### PR TITLE
flake8: Moved return outside of finally block

### DIFF
--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -345,7 +345,7 @@ class RootCommand(Command):
             if mixer_class is not None:
                 self.stop_mixer(mixer_class)
             process.stop_remaining_actors()
-            return exit_status_code
+        return exit_status_code
 
     def get_mixer_class(self, config, mixer_classes):
         logger.debug(


### PR DESCRIPTION
I think this came in with the latest flake8-bugbear.

In related news, the following command from [our docs](https://docs.mopidy.com/en/latest/devenv/#install-development-tools) doesn't *update* the development dependencies like I assumed it would:
```
(mopidy3) nick@xps:~/Dev/mopidy-dev/mopidy$ pip install --upgrade --editable ".[dev]"
Obtaining file:///home/nick/Dev/mopidy-dev/mopidy
  Installing build dependencies ... done
  Getting requirements to build wheel ... done
    Preparing wheel metadata ... done
Requirement already satisfied, skipping upgrade: tornado>=4.4 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (6.0.3)
Requirement already satisfied, skipping upgrade: Pykka>=2.0.1 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (2.0.1)
Requirement already satisfied, skipping upgrade: setuptools in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (41.6.0)
Requirement already satisfied, skipping upgrade: requests>=2.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (2.22.0)
Requirement already satisfied, skipping upgrade: pytest; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (5.2.2)
Requirement already satisfied, skipping upgrade: flake8-import-order; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (0.18.1)
Requirement already satisfied, skipping upgrade: twine; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (3.1.1)
Requirement already satisfied, skipping upgrade: sphinx; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (2.2.0)
Requirement already satisfied, skipping upgrade: pygraphviz; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (1.5)
Requirement already satisfied, skipping upgrade: flake8; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (3.7.8)
Requirement already satisfied, skipping upgrade: pep8-naming; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (0.9.1)
Requirement already satisfied, skipping upgrade: wheel; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (0.33.6)
Requirement already satisfied, skipping upgrade: responses; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (0.10.6)
Requirement already satisfied, skipping upgrade: check-manifest; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (0.40)
Requirement already satisfied, skipping upgrade: pytest-cov; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (2.8.1)
Requirement already satisfied, skipping upgrade: flake8-bugbear; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (19.8.0)
Requirement already satisfied, skipping upgrade: sphinx-rtd-theme; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (0.4.3)
Requirement already satisfied, skipping upgrade: black; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (19.10b0)
Requirement already satisfied, skipping upgrade: isort[pyproject]; extra == "dev" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from Mopidy==3.0.1) (4.3.21)
Requirement already satisfied, skipping upgrade: chardet<3.1.0,>=3.0.2 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from requests>=2.0->Mopidy==3.0.1) (3.0.4)
Requirement already satisfied, skipping upgrade: certifi>=2017.4.17 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from requests>=2.0->Mopidy==3.0.1) (2019.9.11)
Requirement already satisfied, skipping upgrade: urllib3!=1.25.0,!=1.25.1,<1.26,>=1.21.1 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from requests>=2.0->Mopidy==3.0.1) (1.25.7)
Requirement already satisfied, skipping upgrade: idna<2.9,>=2.5 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from requests>=2.0->Mopidy==3.0.1) (2.8)
Requirement already satisfied, skipping upgrade: more-itertools>=4.0.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (7.2.0)
Requirement already satisfied, skipping upgrade: py>=1.5.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (1.8.0)
Requirement already satisfied, skipping upgrade: pluggy<1.0,>=0.12 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (0.13.0)
Requirement already satisfied, skipping upgrade: importlib-metadata>=0.12; python_version < "3.8" in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (0.23)
Requirement already satisfied, skipping upgrade: wcwidth in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (0.1.7)
Requirement already satisfied, skipping upgrade: attrs>=17.4.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (19.3.0)
Requirement already satisfied, skipping upgrade: atomicwrites>=1.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (1.3.0)
Requirement already satisfied, skipping upgrade: packaging in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest; extra == "dev"->Mopidy==3.0.1) (19.2)
Requirement already satisfied, skipping upgrade: pycodestyle in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from flake8-import-order; extra == "dev"->Mopidy==3.0.1) (2.5.0)
Requirement already satisfied, skipping upgrade: readme-renderer>=21.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from twine; extra == "dev"->Mopidy==3.0.1) (24.0)
Requirement already satisfied, skipping upgrade: requests-toolbelt!=0.9.0,>=0.8.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from twine; extra == "dev"->Mopidy==3.0.1) (0.9.1)
Requirement already satisfied, skipping upgrade: keyring>=15.1 in /usr/lib/python3/dist-packages (from twine; extra == "dev"->Mopidy==3.0.1) (18.0.1)
Requirement already satisfied, skipping upgrade: pkginfo>=1.4.2 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from twine; extra == "dev"->Mopidy==3.0.1) (1.5.0.1)
Requirement already satisfied, skipping upgrade: tqdm>=4.14 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from twine; extra == "dev"->Mopidy==3.0.1) (4.36.1)
Requirement already satisfied, skipping upgrade: babel!=2.0,>=1.3 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (2.7.0)
Requirement already satisfied, skipping upgrade: sphinxcontrib-applehelp in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (1.0.1)
Requirement already satisfied, skipping upgrade: sphinxcontrib-serializinghtml in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (1.1.3)
Requirement already satisfied, skipping upgrade: sphinxcontrib-jsmath in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (1.0.1)
Requirement already satisfied, skipping upgrade: snowballstemmer>=1.1 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (2.0.0)
Requirement already satisfied, skipping upgrade: imagesize in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (1.1.0)
Requirement already satisfied, skipping upgrade: sphinxcontrib-htmlhelp in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (1.0.2)
Requirement already satisfied, skipping upgrade: sphinxcontrib-qthelp in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (1.0.2)
Requirement already satisfied, skipping upgrade: Jinja2>=2.3 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (2.10.3)
Requirement already satisfied, skipping upgrade: docutils>=0.12 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (0.15.2)
Requirement already satisfied, skipping upgrade: alabaster<0.8,>=0.7 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (0.7.12)
Requirement already satisfied, skipping upgrade: sphinxcontrib-devhelp in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (1.0.1)
Requirement already satisfied, skipping upgrade: Pygments>=2.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from sphinx; extra == "dev"->Mopidy==3.0.1) (2.4.2)
Requirement already satisfied, skipping upgrade: mccabe<0.7.0,>=0.6.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from flake8; extra == "dev"->Mopidy==3.0.1) (0.6.1)
Requirement already satisfied, skipping upgrade: entrypoints<0.4.0,>=0.3.0 in /usr/lib/python3/dist-packages (from flake8; extra == "dev"->Mopidy==3.0.1) (0.3)
Requirement already satisfied, skipping upgrade: pyflakes<2.2.0,>=2.1.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from flake8; extra == "dev"->Mopidy==3.0.1) (2.1.1)
Requirement already satisfied, skipping upgrade: flake8-polyfill<2,>=1.0.2 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pep8-naming; extra == "dev"->Mopidy==3.0.1) (1.0.2)
Requirement already satisfied, skipping upgrade: six in /usr/lib/python3/dist-packages (from responses; extra == "dev"->Mopidy==3.0.1) (1.12.0)
Requirement already satisfied, skipping upgrade: toml in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from check-manifest; extra == "dev"->Mopidy==3.0.1) (0.10.0)
Requirement already satisfied, skipping upgrade: coverage>=4.4 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from pytest-cov; extra == "dev"->Mopidy==3.0.1) (4.5.4)
Requirement already satisfied, skipping upgrade: appdirs in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from black; extra == "dev"->Mopidy==3.0.1) (1.4.3)
Requirement already satisfied, skipping upgrade: regex in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from black; extra == "dev"->Mopidy==3.0.1) (2019.11.1)
Requirement already satisfied, skipping upgrade: click>=6.5 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from black; extra == "dev"->Mopidy==3.0.1) (7.0)
Requirement already satisfied, skipping upgrade: typed-ast>=1.4.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from black; extra == "dev"->Mopidy==3.0.1) (1.4.0)
Requirement already satisfied, skipping upgrade: pathspec<1,>=0.6 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from black; extra == "dev"->Mopidy==3.0.1) (0.6.0)
Requirement already satisfied, skipping upgrade: zipp>=0.5 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from importlib-metadata>=0.12; python_version < "3.8"->pytest; extra == "dev"->Mopidy==3.0.1) (0.6.0)
Requirement already satisfied, skipping upgrade: pyparsing>=2.0.2 in /usr/lib/python3/dist-packages (from packaging->pytest; extra == "dev"->Mopidy==3.0.1) (2.2.0)
Requirement already satisfied, skipping upgrade: bleach>=2.1.0 in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from readme-renderer>=21.0->twine; extra == "dev"->Mopidy==3.0.1) (3.1.0)
Requirement already satisfied, skipping upgrade: secretstorage in /usr/lib/python3/dist-packages (from keyring>=15.1->twine; extra == "dev"->Mopidy==3.0.1) (2.3.1)
Requirement already satisfied, skipping upgrade: pytz>=2015.7 in /usr/lib/python3/dist-packages (from babel!=2.0,>=1.3->sphinx; extra == "dev"->Mopidy==3.0.1) (2019.2)
Requirement already satisfied, skipping upgrade: MarkupSafe>=0.23 in /usr/lib/python3/dist-packages (from Jinja2>=2.3->sphinx; extra == "dev"->Mopidy==3.0.1) (1.1.0)
Requirement already satisfied, skipping upgrade: webencodings in /home/nick/.virtualenvs/mopidy3/lib/python3.7/site-packages (from bleach>=2.1.0->readme-renderer>=21.0->twine; extra == "dev"->Mopidy==3.0.1) (0.5.1)
Installing collected packages: Mopidy
  Found existing installation: Mopidy 3.0.1
    Uninstalling Mopidy-3.0.1:
      Successfully uninstalled Mopidy-3.0.1
  Running setup.py develop for Mopidy
Successfully installed Mopidy
``` 