### PR TITLE
core: Reset stream title after all ``title`` tag changes.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,15 @@ This changelog is used to track all major changes to Mopidy.
 For older releases, see :ref:`history`.
 
 
+v3.0.2 (UNRELEASED)
+===================
+
+Bugfix release.
+
+- Core: Reset stream title on receipt of any ``title`` audio tag change.
+  Fixes: :issue:`1871`, PR: :issue:`1875`)
+
+
 v3.0.1 (2019-12-22)
 ===================
 

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -125,9 +125,9 @@ class Core(
         if not tags:
             return
 
-        # TODO: this is a hack to make sure we don't emit stream title changes
-        # for plain tracks. We need a better way to decide if something is a
-        # stream.
+        self.playback._stream_title = None
+        # TODO: Do not emit stream title changes for plain tracks. We need a
+        # better way to decide if something is a stream.
         if "title" in tags and tags["title"]:
             title = tags["title"][0]
             current_track = self.playback.get_current_track()

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -1009,6 +1009,26 @@ class TestStream(BaseTest):
         assert self.playback.get_stream_title() is None
 
 
+class TestBug1871Regression(BaseTest):
+    def test(self):
+        track = Track(uri="dummy:d", length=1234, name="baz")
+        with deprecation.ignore():
+            self.core.tracklist.add(tracks=[track], at_position=1)
+
+        self.core.playback.play()
+        self.replay_events()
+
+        self.trigger_about_to_finish(replay_until="stream_changed")
+        self.audio.trigger_fake_tags_changed({"title": ["foo"]}).get()
+        self.replay_events()
+
+        self.audio.trigger_fake_tags_changed({"title": ["baz"]}).get()
+        self.replay_events()
+
+        assert self.playback.get_current_track().uri == "dummy:d"
+        assert self.playback.get_stream_title() is None
+
+
 class TestBackendSelection:
     def setup_method(self, method):
         config = {"core": {"max_tracklist_length": 10000}}


### PR DESCRIPTION
Fixes #1871

PR #1751 introduced a regression where, following a normal gapless
track change, the stream_title was incorrectly set to the previous
track's title.

This still isn't very good as we are still emitting the bogus `stream_title_changed` event for the previous track's title. That is because we keep any tags we get after `about_to_finish` fires in `pending_tags`, and then emit them when the track change completes (`on_stream_start` fires), even if they were old tags for the previous track. 