### PR TITLE
core: implement optional pagination for search API

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -8,6 +8,10 @@ This changelog is used to track all major changes to Mopidy.
 
 For older releases, see :ref:`history`.
 
+v3.1.0 (unreleased)
+===================
+
+- Add (optional) pagination support to library search API
 
 v3.0.1 (2019-12-22)
 ===================

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -85,6 +85,14 @@ class LibraryProvider:
     *MUST be set by any class that implements* :meth:`LibraryProvider.browse`.
     """
 
+    supports_pagination = False
+    """
+    :bool: that indicates whether the library supports paginated search.
+    If so, the search method must have kwargs for `limit` and `offset`.
+
+    *MUST be set by any class that implemtns* :meth:`LibraryProvider.search`.
+    """
+
     def __init__(self, backend):
         self.backend = backend
 


### PR DESCRIPTION
This enables library providers to optionally implement pagination when
using the search API. The motivation for this is the fact that currently
`Mopidy-Local` only returns 100 results per search query, which means
that large parts of my local library are inaccessible by search. This PR
adds `limit` and `offset` keyword arguments to the search API that are
then passed to each backend when searching. However, in order to
preserve backwards compatibility, this is only done if the library
provider has the attribute `supports_pagination` and the value is
`True`. This partially addresses issue #733 but only for search.

If this PR is accepted, I will open a related PR in `Mopidy-Local` to implement pagination support in the library provider.