### PR TITLE
Fix return type for get_images()

### DIFF
--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -161,7 +161,7 @@ class LibraryController:
 
         :param uris: list of URIs to find images for
         :type uris: list of string
-        :rtype: {uri: tuple of :class:`mopidy.models.Image`}
+        :rtype: {uri: list of :class:`mopidy.models.Image`}
 
         .. versionadded:: 1.0
         """


### PR DESCRIPTION
It seems to be a dictionary of lists, not tuples.