### PR TITLE
Convert `dbus.String` into python strings when importing config from keyring

### DIFF
--- a/mopidy/config/keyring.py
+++ b/mopidy/config/keyring.py
@@ -169,7 +169,7 @@ def _prompt(bus, path):
 def _item_attributes(bus, path):
     item = _interface(bus, path, "org.freedesktop.DBus.Properties")
     result = item.Get("org.freedesktop.Secret.Item", "Attributes")
-    return {bytes(k): bytes(v) for k, v in result.items()}
+    return {str(k): str(v) for k, v in result.items()}
 
 
 def _interface(bus, path, interface):


### PR DESCRIPTION
Hello,

Current keyring configuration source doesn't really work - it fails with `TypeError: string argument without an encoding` whenever there is something mopidy-related in the keyring.

`dbus` package returns strings as [`dbus.String`](https://dbus.freedesktop.org/doc/dbus-python/dbus.html#dbus.String) types that can't be byte-encoded without passing `encoding` explicitly. Moreover, the rest of the code doesn't really expect bytes there - [it wants strings](https://github.com/mopidy/mopidy/blob/develop/mopidy/config/keyring.py#L63) (otherwise it will not find the key in dictionary, since `b'section' != 'section'`). This PR converts the DBus attribute name/value pairs to `string`s explicitly and therefore fixes the `TypeError: string argument without an encoding` error.