### PR TITLE
Increase logging level for invalid config

### DIFF
--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -224,7 +224,9 @@ def _validate(raw_config, schemas):
             config[schema.name] = result
 
     for section in sections:
-        logger.warning(f"Ignoring config section {section!r}: A matching extension was not found")
+        logger.warning(
+            f"Ignoring config section {section!r}: A matching extension was not found"
+        )
 
     return config, errors
 

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -224,7 +224,7 @@ def _validate(raw_config, schemas):
             config[schema.name] = result
 
     for section in sections:
-        logger.debug(f"Ignoring unknown config section: {section}")
+        logger.warning(f"Ignoring config section {section!r}: A matching extension was not found")
 
     return config, errors
 

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -225,7 +225,7 @@ def _validate(raw_config, schemas):
 
     for section in sections:
         logger.warning(
-            f"Ignoring config section {section!r}: A matching extension was not found"
+            f"Ignoring config section {section!r} because no matching extension was found"
         )
 
     return config, errors


### PR DESCRIPTION
Closes #1878 

I added an `unknownsection` to my config and an `unknownvalue` to `scrobbler` to see how it looks. Turns out I already config set for 2 extensions that I don't have installed.
```
INFO     2020-03-17 23:08:11,518 [1:MainThread] mopidy.config
  Loading config from command line options
WARNING  2020-03-17 23:08:11,522 [1:MainThread] mopidy.config
  Ignoring config section 'local': A matching extension was not found
WARNING  2020-03-17 23:08:11,522 [1:MainThread] mopidy.config
  Ignoring config section 'soundcloud': A matching extension was not found
WARNING  2020-03-17 23:08:11,522 [1:MainThread] mopidy.config
  Ignoring config section 'unknownsection': A matching extension was not found
INFO     2020-03-17 23:08:12,261 [1:MainThread] mopidy.__main__
  Enabled extensions: gmusic, podcast, softwaremixer, mpd, http
INFO     2020-03-17 23:08:12,261 [1:MainThread] mopidy.__main__
  Disabled extensions: iris, spotify, stream, m3u, file, scrobbler
WARNING  2020-03-17 23:08:12,262 [1:MainThread] mopidy.__main__
  Found scrobbler configuration errors. The extension has been automatically disabled:
WARNING  2020-03-17 23:08:12,262 [1:MainThread] mopidy.__main__
    scrobbler/unknownvalue unknown config key.
WARNING  2020-03-17 23:08:12,262 [1:MainThread] mopidy.__main__
  Please fix the extension configuration errors or disable the extensions to silence these messages.
```