### PR TITLE
include fedora.rst in installation toctree

### DIFF
--- a/docs/installation/index.rst
+++ b/docs/installation/index.rst
@@ -11,6 +11,7 @@ operating system and/or distribution:
 
     debian
     arch
+    fedora
     macos
     pypi
     raspberrypi


### PR DESCRIPTION
makes the new fedora installation instructions visible under installation/. follow-up for #1881. 