### PR TITLE
stream: add the possibility to mark streams as live

### DIFF
--- a/docs/ext/stream.rst
+++ b/docs/ext/stream.rst
@@ -49,3 +49,9 @@ See :ref:`config` for general help on configuring Mopidy.
     is typically needed for play once URIs provided by certain streaming
     providers. Regular POSIX glob semantics apply, so ``http://*.example.com/*``
     would match all example.com sub-domains.
+
+.. confval:: stream/force_live
+
+    Treat all stream URLs as live.
+    Playing a source as a live stream disables buffering, which reduces
+    latency before playback starts, and discards data when paused.

--- a/mopidy/stream/__init__.py
+++ b/mopidy/stream/__init__.py
@@ -19,6 +19,7 @@ class Extension(ext.Extension):
         schema["protocols"] = config.List()
         schema["metadata_blacklist"] = config.List(optional=True)
         schema["timeout"] = config.Integer(minimum=1000, maximum=1000 * 60 * 60)
+        schema["force_live"] = config.Boolean(optional=True)
         return schema
 
     def validate_environment(self):

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -53,6 +53,8 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
             )
             self.uri_schemes -= {"file"}
 
+        self._force_live = config["stream"]["force_live"]
+
 
 class StreamLibraryProvider(backend.LibraryProvider):
     def lookup(self, uri):
@@ -97,6 +99,19 @@ class StreamPlaybackProvider(backend.PlaybackProvider):
             requests_session=self.backend._session,
         )
         return unwrapped_uri
+
+    def is_live(self, uri):
+        """
+        Decide if the URI should be treated as a live stream or not.
+
+        Playing a source as a live stream disables buffering, which reduces
+        latency before playback starts, and discards data when paused.
+
+        :param uri: the URI
+        :type uri: string
+        :rtype: bool
+        """
+        return self.backend._force_live
 
 
 # TODO: cleanup the return value of this.

--- a/mopidy/stream/ext.conf
+++ b/mopidy/stream/ext.conf
@@ -9,3 +9,4 @@ protocols =
     rtsp
 timeout = 5000
 metadata_blacklist =
+force_live = false

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -17,6 +17,7 @@ def config():
             "timeout": 1000,
             "metadata_blacklist": [],
             "protocols": ["file"],
+            "force_live": False,
         },
         "file": {"enabled": False},
     }

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -28,6 +28,7 @@ def config():
             "timeout": TIMEOUT,
             "metadata_blacklist": [],
             "protocols": ["http"],
+            "force_live": False,
         },
         "file": {"enabled": False},
     }


### PR DESCRIPTION
This significantly reduces startup latency. Defaults to old
(non-live) behaviour, new behaviour can be set in config file.