### PR TITLE
backend: should_download takes a uri parameter.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,14 @@ This changelog is used to track all major changes to Mopidy.
 For older releases, see :ref:`history`.
 
 
+v3.1.0 (UNRELEASED)
+===================
+
+- Add :meth:`mopidy.backend.PlaybackProvider.should_download` which can be
+  implemented by playback providers that want to use GStreamer's download
+  buffering strategy for their URIs. (PR: :issue:`1888`)
+
+
 v3.0.2 (2020-04-02)
 ===================
 

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -228,15 +228,17 @@ class PlaybackProvider:
         """
         return False
 
-    def should_download(self):
+    def should_download(self, uri):
         """
-        Attempt progressive download buffering.
+        Attempt progressive download buffering for the URI or not.
 
         *MAY be reimplemented by subclass.*
 
         When streaming a fixed length file, the entire file can be buffered
         to improve playback performance.
 
+        :param uri: the URI
+        :type uri: string
         :rtype: bool
         """
         return False
@@ -264,7 +266,9 @@ class PlaybackProvider:
         if not uri:
             return False
         self.audio.set_uri(
-            uri, live_stream=self.is_live(uri), download=self.should_download(),
+            uri,
+            live_stream=self.is_live(uri),
+            download=self.should_download(uri),
         ).get()
         return True
 

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -177,7 +177,9 @@ class TestPlayHandling(BaseTest):
         assert not self.backend.playback.is_live(self.tracks[0].uri).get()
 
     def test_download_buffering_is_not_enabled_by_default(self):
-        assert not self.backend.playback.should_download().get()
+        assert not self.backend.playback.should_download(
+            self.tracks[0].uri
+        ).get()
 
 
 class TestNextHandling(BaseTest):


### PR DESCRIPTION
Related to #1888
The decision to use "download" buffering may depend on the uri, similar to `is_live`.

e.g. some backends that can provide very long tracks might not want to use this buffering strategy for those tracks. 

Also added a changelog entry for #1888 