### PR TITLE
Added tox to dev requirements. (Fixes #1908)

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -64,6 +64,7 @@ dev =
     %(lint)s
     %(release)s
     %(test)s
+    tox
 
 
 [options.packages.find]


### PR DESCRIPTION
We somehow lost this during our 2to3 transition.