### PR TITLE
Add a configuration  to periodically save the state of mopidy

### DIFF
--- a/docs/config.rst
+++ b/docs/config.rst
@@ -127,6 +127,15 @@ Core section
 
     Default is ``false``.
 
+.. confval:: core/save_state_period
+
+    When set, indicate the period (in seconds) that mopidy will save the
+    state. That way, even when mopidy is badly killed (with a power outage for
+    instance), mopidy will still be able to restore a previous state with
+    core/restore_state.
+
+    Default is nothing, meaning don't save periodically.
+
 
 .. _audio-config:
 

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -324,6 +324,12 @@ class RootCommand(Command):
             core = self.start_core(config, mixer, backends, audio)
             self.start_frontends(config, frontend_classes, core)
             logger.info("Starting GLib mainloop")
+            if "save_state_period" in config["core"]:
+                def periodic_save_state():
+                    call = ProxyCall(attr_path=["_save_state"], args=[], kwargs={})
+                    core.actor_ref.ask(call, block=True)
+                    GLib.timeout_add_seconds(config["core"]["save_state_period"], periodic_save_state)
+                GLib.timeout_add_seconds(config["core"]["save_state_period"], periodic_save_state)
             loop.run()
         except (
             exceptions.BackendError,

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -40,6 +40,7 @@ _core_schema["data_dir"] = Path()
 # MPD supports at most 10k tracks, some clients segfault when this is exceeded.
 _core_schema["max_tracklist_length"] = Integer(minimum=1)
 _core_schema["restore_state"] = Boolean(optional=True)
+_core_schema["save_state_period"] = Integer(minimum=1)
 
 _logging_schema = ConfigSchema("logging")
 _logging_schema["verbosity"] = Integer(minimum=-1, maximum=4)


### PR DESCRIPTION
This is useful in case the server suffers power outages from time
to time and you don't want to lose all the state but restart from
a previous state.