### PR TITLE
Turn off strict parsing for pls playlist files

### DIFF
--- a/mopidy/internal/playlists.py
+++ b/mopidy/internal/playlists.py
@@ -78,7 +78,7 @@ def parse_extm3u(data):
 def parse_pls(data):
     # TODO: convert non URIs to file URIs.
     try:
-        cp = configparser.RawConfigParser()
+        cp = configparser.RawConfigParser(strict=False)
         cp.read_string(data.decode())
     except configparser.Error:
         return


### PR DESCRIPTION
Some PLS files contain one 'Version' key for each file in the playlist. This ultimately has no impact on how mopidy parses files in the playlist, and therefore it should be as tolerant as possible of real-world playlist files.

Note that it isn't enough to simply catch `configparser.DuplicateSectionError` or `configparser.DuplicateOptionError` and keep moving, as the config object ends up in a weird half-finished state that doesn't match its state when it has finished parsing without throwing.

Consideration should also be given switching away from `configparser.RawConfigParser`, as the official python documentation recommends moving to `configparser.ConfigParser`. I'd be happy to update this PR to switch this at the same time.