### PR TITLE
File: Implemented get_images for file library

### DIFF
--- a/mopidy/file/__init__.py
+++ b/mopidy/file/__init__.py
@@ -24,6 +24,7 @@ class Extension(ext.Extension):
         schema["show_dotfiles"] = config.Boolean(optional=True)
         schema["follow_symlinks"] = config.Boolean(optional=True)
         schema["metadata_timeout"] = config.Integer(optional=True)
+        schema["folder_image_names"] = config.List(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy/file/ext.conf
+++ b/mopidy/file/ext.conf
@@ -17,3 +17,7 @@ excluded_file_extensions =
   .zip
 follow_symlinks = false
 metadata_timeout = 1000
+folder_image_names =
+  folder.jpeg
+  folder.png
+  folder.jpg

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -1,3 +1,4 @@
+import base64
 import imghdr
 import logging
 import os
@@ -156,58 +157,61 @@ class FileLibraryProvider(backend.LibraryProvider):
             result = self._scanner.scan(uri)
             if "image" in result.tags and len(result.tags["image"]) > 0:
                 image = result.tags["image"][0]
-                filename = os.path.join(self._cache_dir, path.uri_to_path(uri))
                 extension = imghdr.what("", h=image)
-                with open(f"{filename}.{extension}", "wb+") as f:
-                    f.write(image)
                 images[uri] = (
-                    Image(uri=path.path_to_uri(f"{filename}.{extension}")),
+                    Image(
+                        uri=f'data:image/{extension};base64, {base64.b64encode(image).decode("utf-8")}'
+                    ),
                 )
             elif os.path.exists(
                 os.path.join(
                     os.path.dirname(path.uri_to_path(uri)), "folder.png"
                 )
             ):
-                images[uri] = (
-                    Image(
-                        uri=path.path_to_uri(
-                            os.path.join(
-                                os.path.dirname(path.uri_to_path(uri)),
-                                "folder.png",
-                            )
-                        )
+                with open(
+                    os.path.join(
+                        os.path.dirname(path.uri_to_path(uri)), "folder.png"
                     ),
-                )
+                    "rb",
+                ) as f:
+                    images[uri] = (
+                        Image(
+                            uri=f'data:image/png;base64, {base64.b64encode(f.read()).decode("utf-8")}'
+                        ),
+                    )
             elif os.path.exists(
                 os.path.join(
                     os.path.dirname(path.uri_to_path(uri)), "folder.jpg"
                 )
             ):
-                images[uri] = (
-                    Image(
-                        uri=path.path_to_uri(
-                            os.path.join(
-                                os.path.dirname(path.uri_to_path(uri)),
-                                "folder.jpg",
-                            )
-                        )
+                with open(
+                    os.path.join(
+                        os.path.dirname(path.uri_to_path(uri)), "folder.jpg"
                     ),
-                )
+                    "rb",
+                ) as f:
+                    images[uri] = (
+                        Image(
+                            uri=f'data:image/jpg;base64, {base64.b64encode(f.read()).decode("utf-8")}'
+                        ),
+                    )
             elif os.path.exists(
                 os.path.join(
                     os.path.dirname(path.uri_to_path(uri)), "folder.jpeg"
                 )
             ):
-                images[uri] = (
-                    Image(
-                        uri=path.path_to_uri(
-                            os.path.join(
-                                os.path.dirname(path.uri_to_path(uri)),
-                                "folder.jpeg",
-                            )
-                        )
+                with open(
+                    os.path.join(
+                        os.path.dirname(path.uri_to_path(uri)), "folder.jpeg"
                     ),
-                )
+                    "rb",
+                ) as f:
+                    images[uri] = (
+                        Image(
+                            uri=f'data:image/jpeg;base64, {base64.b64encode(f.read()).decode("utf-8")}'
+                        ),
+                    )
+
             else:
                 images[uri] = ()
         return images

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -160,7 +160,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 extension = imghdr.what("", h=image)
                 images[uri] = (
                     Image(
-                        uri=f'data:image/{extension};base64, {base64.b64encode(image).decode("utf-8")}'
+                        uri=f'data:image/{extension};base64, '
+                            f'{base64.b64encode(image).decode("utf-8")}'
                     ),
                 )
             elif os.path.exists(
@@ -176,7 +177,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 ) as f:
                     images[uri] = (
                         Image(
-                            uri=f'data:image/png;base64, {base64.b64encode(f.read()).decode("utf-8")}'
+                            uri=f'data:image/png;base64, '
+                                f'{base64.b64encode(f.read()).decode("utf-8")}'
                         ),
                     )
             elif os.path.exists(
@@ -192,7 +194,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 ) as f:
                     images[uri] = (
                         Image(
-                            uri=f'data:image/jpg;base64, {base64.b64encode(f.read()).decode("utf-8")}'
+                            uri=f'data:image/jpg;base64, '
+                                f'{base64.b64encode(f.read()).decode("utf-8")}'
                         ),
                     )
             elif os.path.exists(
@@ -208,7 +211,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 ) as f:
                     images[uri] = (
                         Image(
-                            uri=f'data:image/jpeg;base64, {base64.b64encode(f.read()).decode("utf-8")}'
+                            uri=f'data:image/jpeg;base64, '
+                                f'{base64.b64encode(f.read()).decode("utf-8")}'
                         ),
                     )
 

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -160,8 +160,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 extension = imghdr.what("", h=image)
                 images[uri] = (
                     Image(
-                        uri=f'data:image/{extension};base64, '
-                            f'{base64.b64encode(image).decode("utf-8")}'
+                        uri=f"data:image/{extension};base64, "
+                        f'{base64.b64encode(image).decode("utf-8")}'
                     ),
                 )
             elif os.path.exists(
@@ -177,8 +177,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 ) as f:
                     images[uri] = (
                         Image(
-                            uri=f'data:image/png;base64, '
-                                f'{base64.b64encode(f.read()).decode("utf-8")}'
+                            uri=f"data:image/png;base64, "
+                            f'{base64.b64encode(f.read()).decode("utf-8")}'
                         ),
                     )
             elif os.path.exists(
@@ -194,8 +194,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 ) as f:
                     images[uri] = (
                         Image(
-                            uri=f'data:image/jpg;base64, '
-                                f'{base64.b64encode(f.read()).decode("utf-8")}'
+                            uri=f"data:image/jpg;base64, "
+                            f'{base64.b64encode(f.read()).decode("utf-8")}'
                         ),
                     )
             elif os.path.exists(
@@ -211,8 +211,8 @@ class FileLibraryProvider(backend.LibraryProvider):
                 ) as f:
                     images[uri] = (
                         Image(
-                            uri=f'data:image/jpeg;base64, '
-                                f'{base64.b64encode(f.read()).decode("utf-8")}'
+                            uri=f"data:image/jpeg;base64, "
+                            f'{base64.b64encode(f.read()).decode("utf-8")}'
                         ),
                     )
 

--- a/tests/file/test_lookup.py
+++ b/tests/file/test_lookup.py
@@ -19,6 +19,7 @@ def config():
             "follow_symlinks": False,
             "metadata_timeout": 1000,
         },
+        "core": {"cache_dir": ""},
     }
 
 


### PR DESCRIPTION
* Fetches image from track metadata if available.

* Introduced new extension variable `folder_image_names` to configure the image names for folder-based cover arts.

* Fetches folder based image if present and name matches one of the names in `folder_image_names`.

* Returns a tuple of Image for each uri.

* The image uri is base64 encoded so that it is accessible to clients other than localhost.

* Added error handling incase _scanner.scan fails