### PR TITLE
Fix memory leak when converting GST `sample` tags

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,9 @@ v3.1.0 (UNRELEASED)
   implemented by playback providers that want to use GStreamer's download
   buffering strategy for their URIs. (PR: :issue:`1888`)
 
+- Audio: Fix memory leak when converting GStreamer `sample` type tags. (Fixes:
+  :issue:`1827`, PR: :issue:`1929`)
+
 
 v3.0.2 (2020-04-02)
 ===================


### PR DESCRIPTION
Embedded cover art, and other tags exposed to us as type `Gst.Sample`, were
causing memory leaks when converted to plain Python types using
`GstBuffer.extract_dup()`. `extract_dup()` expects the caller to free the
memory it allocates but older versions of the python3-gi don't seem to do
this. The workaround is to access samples using `GstMemory` methods instead.

This issue was present on Buster 10 systems (python-gi 3.30.4) but not on
Ubuntu 20.04 (python-gi 3.36.0).

Fixes #1827
[Zulip Topic](https://mopidy.zulipchat.com/#narrow/stream/207265-mopidy-dev/topic/Memory.20Leaks)