### PR TITLE
Add isort to code formatting and CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -13,6 +13,7 @@ workflows:
       - check-manifest
       - docs
       - flake8
+      - isort
 
 jobs:
   py38: &test-template

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -52,3 +52,5 @@ jobs:
   docs: *test-template
 
   flake8: *test-template
+
+  isort: *test-template

--- a/docs/codestyle.rst
+++ b/docs/codestyle.rst
@@ -10,6 +10,8 @@ All projects in the Mopidy organization follows the following code style:
   Use Black's string normalization, which prefers ``"`` quotes over ``'``,
   unless the string contains ``"``.
 
+- Automatically sort imports using `isort <https://timothycrosley.github.io/isort>`_.
+  
 - Follow :pep:`8`.
   Run `flake8 <https://pypi.org/project/flake8>`_  to check your code
   against the guidelines.

--- a/mopidy/internal/playlists.py
+++ b/mopidy/internal/playlists.py
@@ -1,9 +1,8 @@
 import configparser
 import io
+import xml.etree.ElementTree as elementtree  # noqa: N813
 
 from mopidy.internal import validation
-
-import xml.etree.ElementTree as elementtree  # noqa: N813
 
 
 def parse(data):

--- a/mopidy/internal/process.py
+++ b/mopidy/internal/process.py
@@ -1,9 +1,8 @@
+import _thread
 import logging
 import threading
 
 import pykka
-
-import _thread
 
 logger = logging.getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,6 +12,6 @@ multi_line_output = 3
 include_trailing_comma = true
 force_grid_wrap = 0
 use_parentheses = true
-line_length = 88
+line_length = 80
 known_tests = "tests"
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ lint =
     check-manifest
     flake8
     flake8-bugbear
-    flake8-import-order
+    flake8-isort
     isort[pyproject]
     pep8-naming
 release =

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,7 +102,7 @@ select =
     B
     # B950: line too long (soft speed limit)
     B950
-    # flake8-import-order
+    # flake8-isort
     I
     # pep8-naming rules
     N

--- a/setup.cfg
+++ b/setup.cfg
@@ -102,6 +102,8 @@ select =
     B
     # B950: line too long (soft speed limit)
     B950
+    # flake8-import-order
+    I
     # pep8-naming rules
     N
 ignore =

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -1,7 +1,7 @@
 import os
-import urllib
-import tempfile
 import shutil
+import tempfile
+import urllib
 from unittest import mock
 
 import tornado.testing

--- a/tox.ini
+++ b/tox.ini
@@ -14,6 +14,10 @@ commands =
 deps = .[lint]
 commands = python -m black --check .
 
+[testenv:isort]
+deps = .[lint]
+commands = python -m isort --check-only .
+
 [testenv:check-manifest]
 deps = .[lint]
 commands = python -m check_manifest

--- a/tox.ini
+++ b/tox.ini
@@ -14,10 +14,6 @@ commands =
 deps = .[lint]
 commands = python -m black --check .
 
-[testenv:isort]
-deps = .[lint]
-commands = python -m isort --check-only .
-
 [testenv:check-manifest]
 deps = .[lint]
 commands = python -m check_manifest
@@ -30,6 +26,10 @@ commands = python -m sphinx -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 [testenv:flake8]
 deps = .[lint]
 commands = python -m flake8 --show-source --statistics
+
+[testenv:isort]
+deps = .[lint]
+commands = python -m isort --check-only .
 
 [testenv:linkcheck]
 deps = .[docs]


### PR DESCRIPTION
Fixes #1919 

I'm starting this PR with adding CI for isort, which is already installed in the lint environment and already has some configuration in the repository.

Made the line length 80 to match the black setting.

Once it is confirmed that the CI works as expected, i.e. fails, I will push the next commit with the isort changes.