### PR TITLE
Support Python 3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,7 @@ workflows:
   version: 2
   test:
     jobs:
+      - py39
       - py38
       - py37
       - black
@@ -16,9 +17,9 @@ workflows:
       - isort
 
 jobs:
-  py38: &test-template
+  py39: &test-template
     docker:
-      - image: mopidy/ci-python:3.8
+      - image: mopidy/ci-python:3.9
     steps:
       - checkout
       - restore_cache:
@@ -40,6 +41,11 @@ jobs:
           file: coverage.xml
       - store_test_results:
           path: test-results
+
+  py38:
+    <<: *test-template
+    docker:
+      - image: mopidy/ci-python:3.8
 
   py37:
     <<: *test-template

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,6 +12,8 @@ For older releases, see :ref:`history`.
 v3.1.0 (UNRELEASED)
 ===================
 
+- Add Python 3.9 to our test matrix.
+
 - Add :meth:`mopidy.backend.PlaybackProvider.should_download` which can be
   implemented by playback providers that want to use GStreamer's download
   buffering strategy for their URIs. (PR: :issue:`1888`)

--- a/setup.cfg
+++ b/setup.cfg
@@ -24,6 +24,7 @@ classifiers =
     Programming Language :: Python :: 3
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
     Topic :: Multimedia :: Sound/Audio :: Players
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, black, check-manifest, docs, flake8
+envlist = py37, py38, py39, black, check-manifest, docs, flake8
 
 [testenv]
 sitepackages = true


### PR DESCRIPTION
This updates our test and CI setup to also run the test suite on Python 3.9.
