### PR TITLE
Return on timeout if duration workaround applied

### DIFF
--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -270,7 +270,7 @@ def _process(pipeline, timeout_ms):
             tags.update(tags_lib.convert_taglist(taglist))
 
         timeout = timeout_ms - (int(time.time() * 1000) - start)
-    
+
     # Sometimes we never get a duration when the workaround is applied
     # e.g. for youtube streams
     if workaround_applied:


### PR DESCRIPTION
When trying to add an m3u8 link generated by youtube-dl e.g.

```
olivier@omega ~> youtube-dl -g -f91 "https://www.youtube.com/watch?v=5qap5aO4i9A"
https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/1603437623/ei/1y-SX7_oDsbe7gPb8oYQ/ip/2a02:1811:9d2a:5400:49a9:cebb:127d:88cd/id/5qap5aO4i9A.0/itag/91/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/live/1/goi/160/sgoap/gir%3Dyes%3Bitag%3D139/sgovp/gir%3Dyes%3Bitag%3D160/hls_chunk_host/r2---sn-uxaxoxu-cg0r.googlevideo.com/playlist_duration/30/manifest_duration/30/vprv/1/playlist_type/DVR/initcwndbps/11060/mh/30/mm/44/mn/sn-uxaxoxu-cg0r/ms/lva/mv/m/mvi/2/pl/33/dover/11/keepalive/yes/fexp/23915654/mt/1603415907/disable_polymer/true/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,live,goi,sgoap,sgovp,playlist_duration,manifest_duration,vprv,playlist_type/sig/AOq0QJ8wRgIhALOS-4Q01sjWLNeauBxo3QhF7USMyr1vp9VFcQo1PDfTAiEAvEdwK9O-TWaZsJoySIooOickr1QniBi2yTfXZTVcpsg%3D/lsparams/hls_chunk_host,initcwndbps,mh,mm,mn,ms,mv,mvi,pl/lsig/AG3C_xAwRQIgfesTSjy3Xt4wuNpLPGGl5M4xiWAN-57UFy7WyOGJXW4CIQCb5pcfN61LiilLRJwPKe8VAtw-oiSgzni9b3ivfAZOmA%3D%3D/playlist/index.m3u8
```

I noticed a [workaround](https://github.com/mopidy/mopidy/blob/7dc4283dc03ac716f680e1893e185db98f5bd82b/mopidy/audio/scan.py#L249) got applied because gstreamer reports the stream as seekable but with no duration.

```
DEBUG    2020-10-23 03:21:39,940 [227218:MpdSession-16] mopidy_mpd.session
  Request from [::ffff:127.0.0.1]:56096: add "https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/1603437623/ei/1y-SX7_oDsbe7gPb8oYQ/ip/2a02:1811:9d2a:5400:49a9:cebb:127d:88cd/id/5qap5aO4i9A.0/itag/91/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/live/1/goi/160/sgoap/gir%3Dyes%3Bitag%3D139/sgovp/gir%3Dyes%3Bitag%3D160/hls_chunk_host/r2---sn-uxaxoxu-cg0r.googlevideo.com/playlist_duration/30/manifest_duration/30/vprv/1/playlist_type/DVR/initcwndbps/11060/mh/30/mm/44/mn/sn-uxaxoxu-cg0r/ms/lva/mv/m/mvi/2/pl/33/dover/11/keepalive/yes/fexp/23915654/mt/1603415907/disable_polymer/true/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,live,goi,sgoap,sgovp,playlist_duration,manifest_duration,vprv,playlist_type/sig/AOq0QJ8wRgIhALOS-4Q01sjWLNeauBxo3QhF7USMyr1vp9VFcQo1PDfTAiEAvEdwK9O-TWaZsJoySIooOickr1QniBi2yTfXZTVcpsg%3D/lsparams/hls_chunk_host,initcwndbps,mh,mm,mn,ms,mv,mvi,pl/lsig/AG3C_xAwRQIgfesTSjy3Xt4wuNpLPGGl5M4xiWAN-57UFy7WyOGJXW4CIQCb5pcfN61LiilLRJwPKe8VAtw-oiSgzni9b3ivfAZOmA%3D%3D/playlist/index.m3u8"
DEBUG    2020-10-23 03:21:39,946 [227218:StreamBackend-6] mopidy.stream.actor
  Unwrapping stream from URI: https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/1603437623/ei/1y-SX7_oDsbe7gPb8oYQ/ip/2a02:1811:9d2a:5400:49a9:cebb:127d:88cd/id/5qap5aO4i9A.0/itag/91/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/live/1/goi/160/sgoap/gir%3Dyes%3Bitag%3D139/sgovp/gir%3Dyes%3Bitag%3D160/hls_chunk_host/r2---sn-uxaxoxu-cg0r.googlevideo.com/playlist_duration/30/manifest_duration/30/vprv/1/playlist_type/DVR/initcwndbps/11060/mh/30/mm/44/mn/sn-uxaxoxu-cg0r/ms/lva/mv/m/mvi/2/pl/33/dover/11/keepalive/yes/fexp/23915654/mt/1603415907/disable_polymer/true/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,live,goi,sgoap,sgovp,playlist_duration,manifest_duration,vprv,playlist_type/sig/AOq0QJ8wRgIhALOS-4Q01sjWLNeauBxo3QhF7USMyr1vp9VFcQo1PDfTAiEAvEdwK9O-TWaZsJoySIooOickr1QniBi2yTfXZTVcpsg%3D/lsparams/hls_chunk_host,initcwndbps,mh,mm,mn,ms,mv,mvi,pl/lsig/AG3C_xAwRQIgfesTSjy3Xt4wuNpLPGGl5M4xiWAN-57UFy7WyOGJXW4CIQCb5pcfN61LiilLRJwPKe8VAtw-oiSgzni9b3ivfAZOmA%3D%3D/playlist/index.m3u8
TRACE    2020-10-23 03:21:40,112 [227218:StreamBackend-6] mopidy.audio.scan
  element souphttpsrc0: http-headers, uri=(string)"https://manifest.googlevideo.com/api/manifest/hls_...
TRACE    2020-10-23 03:21:40,112 [227218:StreamBackend-6] mopidy.audio.scan
  element souphttpsrc0: GstMessageDurationChanged;
TRACE    2020-10-23 03:21:40,122 [227218:StreamBackend-6] mopidy.audio.scan
  element typefindelement0: have-type, caps=(structure)"application/x-hls\;";
TRACE    2020-10-23 03:21:40,134 [227218:StreamBackend-6] mopidy.audio.scan
  element hlsdemux0: adaptive-streaming-statistics, manifest-uri=(string)"https://manifest.googlev...
TRACE    2020-10-23 03:21:40,234 [227218:StreamBackend-6] mopidy.audio.scan
  element souphttpsrc1: http-headers, uri=(string)"https://r2---sn-uxaxoxu-cg0r.googlevideo.com/video...
TRACE    2020-10-23 03:21:40,282 [227218:StreamBackend-6] mopidy.audio.scan
  element hlsdemux0: adaptive-streaming-statistics, manifest-uri=(string)"https://manifest.googlev...
TRACE    2020-10-23 03:21:40,283 [227218:StreamBackend-6] mopidy.audio.scan
  element tsdemux0: pat, section=(GstMpegtsSection)NULL;
TRACE    2020-10-23 03:21:40,286 [227218:StreamBackend-6] mopidy.audio.scan
  element tsdemux0: pmt, section=(GstMpegtsSection)NULL;
TRACE    2020-10-23 03:21:40,287 [227218:StreamBackend-6] mopidy.audio.scan
  element decodebin0: have-audio;
TRACE    2020-10-23 03:21:40,288 [227218:StreamBackend-6] mopidy.audio.scan
  element fakesink1: GstMessageTag, taglist=(taglist)"taglist\,\ audio-codec\=\(string\)\"MPEG-4\\...
TRACE    2020-10-23 03:21:40,288 [227218:StreamBackend-6] mopidy.audio.scan
  element fakesink0: GstMessageTag, taglist=(taglist)"taglist\,\ video-codec\=\(string\)H.264\;";
TRACE    2020-10-23 03:21:40,289 [227218:StreamBackend-6] mopidy.audio.scan
  element fakesink0: GstMessageTag, taglist=(taglist)"taglist\,\ video-codec\=\(string\)\"H.264\\\...
TRACE    2020-10-23 03:21:40,289 [227218:StreamBackend-6] mopidy.audio.scan
  element pipeline0: GstMessageAsyncDone, running-time=(guint64)18446744073709551615;
DEBUG    2020-10-23 03:21:40,289 [227218:StreamBackend-6] mopidy.audio.scan
  Using workaround for duration missing before play.
``` 

Since no duration is ever received the operation times out and the first segment link gets used instead.

```
DEBUG    2020-10-23 03:21:44,964 [227218:StreamBackend-6] mopidy.stream.actor
  GStreamer failed scanning URI (https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/1603437623/ei/1y-SX7_oDsbe7gPb8oYQ/ip/2a02:1811:9d2a:5400:49a9:cebb:127d:88cd/id/5qap5aO4i9A.0/itag/91/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/live/1/goi/160/sgoap/gir%3Dyes%3Bitag%3D139/sgovp/gir%3Dyes%3Bitag%3D160/hls_chunk_host/r2---sn-uxaxoxu-cg0r.googlevideo.com/playlist_duration/30/manifest_duration/30/vprv/1/playlist_type/DVR/initcwndbps/11060/mh/30/mm/44/mn/sn-uxaxoxu-cg0r/ms/lva/mv/m/mvi/2/pl/33/dover/11/keepalive/yes/fexp/23915654/mt/1603415907/disable_polymer/true/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,live,goi,sgoap,sgovp,playlist_duration,manifest_duration,vprv,playlist_type/sig/AOq0QJ8wRgIhALOS-4Q01sjWLNeauBxo3QhF7USMyr1vp9VFcQo1PDfTAiEAvEdwK9O-TWaZsJoySIooOickr1QniBi2yTfXZTVcpsg%3D/lsparams/hls_chunk_host,initcwndbps,mh,mm,mn,ms,mv,mvi,pl/lsig/AG3C_xAwRQIgfesTSjy3Xt4wuNpLPGGl5M4xiWAN-57UFy7WyOGJXW4CIQCb5pcfN61LiilLRJwPKe8VAtw-oiSgzni9b3ivfAZOmA%3D%3D/playlist/index.m3u8): Timeout after 4999ms
DEBUG    2020-10-23 03:21:44,972 [227218:StreamBackend-6] urllib3.connectionpool
  Starting new HTTPS connection (1): manifest.googlevideo.com:443
DEBUG    2020-10-23 03:21:45,102 [227218:StreamBackend-6] urllib3.connectionpool
  https://manifest.googlevideo.com:443 "GET /api/manifest/hls_playlist/expire/1603437623/ei/1y-SX7_oDsbe7gPb8oYQ/ip/2a02:1811:9d2a:5400:49a9:cebb:127d:88cd/id/5qap5aO4i9A.0/itag/91/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/live/1/goi/160/sgoap/gir%3Dyes%3Bitag%3D139/sgovp/gir%3Dyes%3Bitag%3D160/hls_chunk_host/r2---sn-uxaxoxu-cg0r.googlevideo.com/playlist_duration/30/manifest_duration/30/vprv/1/playlist_type/DVR/initcwndbps/11060/mh/30/mm/44/mn/sn-uxaxoxu-cg0r/ms/lva/mv/m/mvi/2/pl/33/dover/11/keepalive/yes/fexp/23915654/mt/1603415907/disable_polymer/true/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,live,goi,sgoap,sgovp,playlist_duration,manifest_duration,vprv,playlist_type/sig/AOq0QJ8wRgIhALOS-4Q01sjWLNeauBxo3QhF7USMyr1vp9VFcQo1PDfTAiEAvEdwK9O-TWaZsJoySIooOickr1QniBi2yTfXZTVcpsg%3D/lsparams/hls_chunk_host,initcwndbps,mh,mm,mn,ms,mv,mvi,pl/lsig/AG3C_xAwRQIgfesTSjy3Xt4wuNpLPGGl5M4xiWAN-57UFy7WyOGJXW4CIQCb5pcfN61LiilLRJwPKe8VAtw-oiSgzni9b3ivfAZOmA%3D%3D/playlist/index.m3u8 HTTP/1.1" 200 None
DEBUG    2020-10-23 03:21:45,103 [227218:StreamBackend-6] mopidy.stream.actor
  Parsed playlist (https://manifest.googlevideo.com/api/manifest/hls_playlist/expire/1603437623/ei/1y-SX7_oDsbe7gPb8oYQ/ip/2a02:1811:9d2a:5400:49a9:cebb:127d:88cd/id/5qap5aO4i9A.0/itag/91/source/yt_live_broadcast/requiressl/yes/ratebypass/yes/live/1/goi/160/sgoap/gir%3Dyes%3Bitag%3D139/sgovp/gir%3Dyes%3Bitag%3D160/hls_chunk_host/r2---sn-uxaxoxu-cg0r.googlevideo.com/playlist_duration/30/manifest_duration/30/vprv/1/playlist_type/DVR/initcwndbps/11060/mh/30/mm/44/mn/sn-uxaxoxu-cg0r/ms/lva/mv/m/mvi/2/pl/33/dover/11/keepalive/yes/fexp/23915654/mt/1603415907/disable_polymer/true/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,live,goi,sgoap,sgovp,playlist_duration,manifest_duration,vprv,playlist_type/sig/AOq0QJ8wRgIhALOS-4Q01sjWLNeauBxo3QhF7USMyr1vp9VFcQo1PDfTAiEAvEdwK9O-TWaZsJoySIooOickr1QniBi2yTfXZTVcpsg%3D/lsparams/hls_chunk_host,initcwndbps,mh,mm,mn,ms,mv,mvi,pl/lsig/AG3C_xAwRQIgfesTSjy3Xt4wuNpLPGGl5M4xiWAN-57UFy7WyOGJXW4CIQCb5pcfN61LiilLRJwPKe8VAtw-oiSgzni9b3ivfAZOmA%3D%3D/playlist/index.m3u8) and found new URI: https://r2---sn-uxaxoxu-cg0r.googlevideo.com/videoplayback/id/5qap5aO4i9A.0/itag/91/source/yt_live_broadcast/expire/1603437623/ei/1y-SX7_oDsbe7gPb8oYQ/ip/2a02:1811:9d2a:5400:49a9:cebb:127d:88cd/requiressl/yes/ratebypass/yes/live/1/goi/160/sgoap/gir%3Dyes%3Bitag%3D139/sgovp/gir%3Dyes%3Bitag%3D160/hls_chunk_host/r2---sn-uxaxoxu-cg0r.googlevideo.com/playlist_duration/30/manifest_duration/30/vprv/1/playlist_type/DVR/initcwndbps/11060/mh/30/mm/44/mn/sn-uxaxoxu-cg0r/ms/lva/mv/m/mvi/2/pl/33/keepalive/yes/fexp/23915654/mt/1603415907/disable_polymer/true/sparams/expire,ei,ip,id,itag,source,requiressl,ratebypass,live,goi,sgoap,sgovp,playlist_duration,manifest_duration,vprv,playlist_type/sig/AOq0QJ8wRgIhALOS-4Q01sjWLNeauBxo3QhF7USMyr1vp9VFcQo1PDfTAiEAvEdwK9O-TWaZsJoySIooOickr1QniBi2yTfXZTVcpsg%3D/lsparams/hls_chunk_host,initcwndbps,mh,mm,mn,ms,mv,mvi,pl/lsig/AG3C_xAwRQIgfesTSjy3Xt4wuNpLPGGl5M4xiWAN-57UFy7WyOGJXW4CIQCb5pcfN61LiilLRJwPKe8VAtw-oiSgzni9b3ivfAZOmA%3D%3D/playlist/index.m3u8/sq/4203234/goap/clen%3D31493%3Blmt%3D1603395095753789/govp/clen%3D20860%3Blmt%3D1603395095753792/dur/5.000/file/seg.ts
```
Given that the segment is only a couple of seconds long it makes for a very brief listening experience. :)
Because that the workaround is only applied when everything but the duration is set it seems safe to continue on timeout rather than raise, so this fix aims to do just that.