### PR TITLE
audio: log first few bytes only of tag value changes.

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -343,7 +343,9 @@ class _Handler:
 
     def on_tag(self, taglist):
         tags = tags_lib.convert_taglist(taglist)
-        gst_logger.debug("Got TAG bus message: tags=%r", dict(tags))
+        gst_logger.debug(
+            f"Got TAG bus message: tags={tags_lib.repr_tags(tags)}"
+        )
 
         # Postpone emitting tags until stream start.
         if self._audio._pending_tags is not None:

--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -10,6 +10,26 @@ from mopidy.models import Album, Artist, Track
 logger = logging.getLogger(__name__)
 
 
+def repr_tags(taglist, max_bytes=10):
+    """Returns a printable representation of a :class:`Gst.TagList`.
+
+    Tag values of type bytes are truncated to the specified length to avoid
+    large amounts of output when logging.
+
+    :param taglist: A GStreamer taglist to be represented.
+    :type taglist: :class:`Gst.TagList`
+    :param max_bytes: The maximum number of bytes to show for bytes tag values.
+    :type max_bytes: int
+    :rtype: string
+    """
+    result = dict(taglist)
+    for tag_values in result.values():
+        for i, val in enumerate(tag_values):
+            if type(val) is bytes and len(val) > max_bytes:
+                tag_values[i] = val[:max_bytes] + b"..."
+    return repr(result)
+
+
 def convert_taglist(taglist):
     """Convert a :class:`Gst.TagList` to plain Python types.
 

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -5,6 +5,22 @@ from mopidy.internal.gi import GLib, GObject, Gst
 from mopidy.models import Album, Artist, Track
 
 
+class TestReprTags:
+    def test_bytes_truncated_default(self):
+        taglist = {"foo": [b"abcdefghijkl", b"mnop", "qrstuvwxyzabc"]}
+
+        result = tags.repr_tags(taglist)
+
+        assert result == "{'foo': [b'abcdefghij...', b'mnop', 'qrstuvwxyzabc']}"
+
+    def test_max_bytes_two(self):
+        taglist = {"foo": [b"1234", b"5678", "abcd", 67]}
+
+        result = tags.repr_tags(taglist, 2)
+
+        assert result == "{'foo': [b'12...', b'56...', 'abcd', 67]}"
+
+
 class TestConvertTaglist:
     def make_taglist(self, tag, values):
         taglist = Gst.TagList.new_empty()


### PR DESCRIPTION
These really clutter the debug log output and I am yet to find a case where it was interesting. Couldn't think of a better name for this function, open to suggestions!