### PR TITLE
fix test failure on python 3.10a2

### DIFF
--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -492,8 +492,8 @@ class JsonRpcSingleCommandErrorTest(JsonRpcTestBase):
         data = error["data"]
         assert data["type"] == "TypeError"
         assert (
-            data["message"]
-            == "get_uri_schemes() takes 1 positional argument but 2 were given"
+            "get_uri_schemes() takes 1 positional argument but 2 were given"
+            in data["message"]
         )
         assert "traceback" in data
         assert "Traceback (most recent call last):" in data["traceback"]


### PR DESCRIPTION
reported via https://bugzilla.redhat.com/show_bug.cgi?id=1903954

```
tests/internal/test_jsonrpc.py .......................F................                                       [100%]

===================================================== FAILURES ======================================================
___________________ JsonRpcSingleCommandErrorTest.test_invalid_params_causes_invalid_params_error ___________________

self = <tests.internal.test_jsonrpc.JsonRpcSingleCommandErrorTest testMethod=test_invalid_params_causes_invalid_params_error>

    def test_invalid_params_causes_invalid_params_error(self):
        request = {
            "jsonrpc": "2.0",
            "method": "core.get_uri_schemes",
            "params": ["bogus"],
            "id": 1,
        }
        response = self.jrw.handle_data(request)
    
        error = response["error"]
        assert error["code"] == (-32602)
        assert error["message"] == "Invalid params"
    
        data = error["data"]
        assert data["type"] == "TypeError"
>       assert (
            data["message"]
            == "get_uri_schemes() takes 1 positional argument but 2 were given"
        )
E       AssertionError: assert 'Core.get_uri... 2 were given' == 'get_uri_sche... 2 were given'
E         - get_uri_schemes() takes 1 positional argument but 2 were given
E         + Core.get_uri_schemes() takes 1 positional argument but 2 were given
E         ? +++++

tests/internal/test_jsonrpc.py:494: AssertionError
============================================== short test summary info ==============================================
FAILED tests/internal/test_jsonrpc.py::JsonRpcSingleCommandErrorTest::test_invalid_params_causes_invalid_params_error
```