### PR TITLE
Make systemd service wait for internet connection

### DIFF
--- a/extra/systemd/mopidy.service
+++ b/extra/systemd/mopidy.service
@@ -2,7 +2,8 @@
 Description=Mopidy music server
 After=avahi-daemon.service
 After=dbus.service
-After=network.target
+After=network-online.target
+Wants=network-online.target
 After=nss-lookup.target
 After=pulseaudio.service
 After=remote-fs.target


### PR DESCRIPTION
This small change to the systemd service file will make mopidy wait for [`network-online.target`](https://www.freedesktop.org/wiki/Software/systemd/NetworkTarget/).

The current behavior of this service is to only wait for `network.target`, which is specified in the standard to not wait for the internet to actually be up, only for the network interface to be functioning. This current behavior is unideal for users of extensions such as mopidy-spotify, where a functioning internet connection is expected and required at the time of startup.

This change will allow any mopidy extensions that require an internet connection to function properly on system startup, without needing to be manually reloaded after logging in. The impact to startup time should be trivial, a properly configured network manager will fulfill `network-online.target` as soon as an internet connection is available.