### PR TITLE
Adjust to API change in gst-python >= 1.18

### DIFF
--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -111,7 +111,14 @@ def _extract_buffer_data(buf):
     success, info = mem.map(Gst.MapFlags.READ)
     if not success:
         return None
-    data = info.data
+    if isinstance(info.data, memoryview):
+        # We need to copy the data as the memoryview is released
+        # when we call mem.unmap()
+        data = bytes(info.data)
+    else:
+        # GStreamer Python bindings <= 1.16 return a copy of the
+        # data as bytes()
+        data = info.data
     mem.unmap(info)
     return data
 


### PR DESCRIPTION
Without this with gst-python-1.18.2 while scanning files there are intermittent fails as follows:

```
ERROR    2020-12-18 18:39:25,302 [426578:Core-8] mopidy.core.library
  FileBackend backend caused an exception.
Traceback (most recent call last):
  File "/usr/lib/python3.9/site-packages/mopidy/core/library.py", line 17, in _backend_error_handling
    yield
  File "/usr/lib/python3.9/site-packages/mopidy/core/library.py", line 217, in lookup
    result = future.get()
  File "/usr/lib/python3.9/site-packages/pykka/_threading.py", line 45, in get
    _compat.reraise(*self._data['exc_info'])
  File "/usr/lib/python3.9/site-packages/pykka/_compat/__init__.py", line 29, in reraise
    raise value
  File "/usr/lib/python3.9/site-packages/pykka/_actor.py", line 193, in _actor_loop
    response = self._handle_receive(envelope.message)
  File "/usr/lib/python3.9/site-packages/pykka/_actor.py", line 299, in _handle_receive
    return callee(*message.args, **message.kwargs)
  File "/usr/lib/python3.9/site-packages/mopidy/file/library.py", line 98, in lookup
    result = self._scanner.scan(uri)
  File "/usr/lib/python3.9/site-packages/mopidy/audio/scan.py", line 70, in scan
    tags, mime, have_audio, duration = _process(pipeline, timeout)
  File "/usr/lib/python3.9/site-packages/mopidy/audio/scan.py", line 268, in _process
    tags.update(tags_lib.convert_taglist(taglist))
  File "/usr/lib/python3.9/site-packages/mopidy/audio/tags.py", line 83, in convert_taglist
    if data:
ValueError: operation forbidden on released memoryview object
```

It's the same problem as fixed in https://github.com/beetbox/audioread/pull/110.