### PR TITLE
Remove pyobject as explicit dependency

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
           key: ${{ runner.os }}-${{ matrix.python }}-${{ matrix.tox }}-pip-${{ hashFiles('setup.cfg') }}-${{ hashFiles('tox.ini') }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.python }}-${{ matrix.tox }}-pip-
-      - run: python -m pip install tox
+      - run: python -m pip install pygobject tox
       - run: python -m tox -e ${{ matrix.tox }}
         if: ${{ ! matrix.coverage }}
       - run: python -m tox -e ${{ matrix.tox }} -- --cov-report=xml

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,6 @@ packages = find:
 python_requires = >= 3.7
 install_requires =
     Pykka >= 2.0.1
-    pygobject >= 3.30
     requests >= 2.0
     setuptools
     tornado >= 4.4


### PR DESCRIPTION
The explicit dependency seems to break ReadTheDocs' building of the API
documentation. This reverts us back to only installing it for CI builds.
