### PR TITLE
Weekly build on next Ubuntu version

### DIFF
--- a/.github/workflows/ubuntu-devel.yml
+++ b/.github/workflows/ubuntu-devel.yml
@@ -1,0 +1,29 @@
+name: "Ubuntu devel"
+
+on:
+  schedule:
+    # Every Friday at 18:20 UTC, so we can fix the issue over the weekend
+    - cron: "20 18 * * 5"
+  workflow_dispatch:
+
+jobs:
+  main:
+    name: "Test: Python 3.9"
+    runs-on: ubuntu-20.04
+
+    # The container should be automatically updated from time to time.
+    container: ubuntu:devel
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          apt-get update
+          DEBIAN_FRONTEND=noninteractive apt-get install -y \
+            gstreamer1.0-plugins-bad \
+            gstreamer1.0-plugins-good \
+            gstreamer1.0-plugins-ugly \
+            python3-gst-1.0 \
+            python3 \
+            tox
+      - run: tox -e py39


### PR DESCRIPTION
This PR adds a new GitHub Action independent of the CI setup that runs once every week, or when manually started from the GitHub Acitons UI.

Instead of using a custom Docker container as the CI build, which we must maintain, it uses the upstream `ubuntu:devel` container plus installation of Debian packages on each build. The benefit is that it will always use the latest version of the container, which is update now and then during the development of a new Ubuntu version, hopefully informing us of breaking GStreamer changes in time for us to fix it before the Ubuntu release. The drawback is that this build will be a bit slower than the regular CI build. However, that doesn't matter much as the build doesn't keep humans waiting for a green build on their PRs.