### PR TITLE
Change name of "release" method in delayed logs handler

### DIFF
--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -29,7 +29,7 @@ class DelayedHandler(logging.Handler):
         if not self._released:
             self._buffer.append(record)
 
-    def release(self):
+    def release_delayed_logs(self):
         self._released = True
         root = logging.getLogger("")
         while self._buffer:
@@ -76,7 +76,7 @@ def setup_logging(config, base_verbosity_level, args_verbosity_level):
 
     logging.getLogger("").addHandler(handler)
 
-    _delayed_handler.release()
+    _delayed_handler.release_delayed_logs()
 
 
 def get_verbosity_level(config, base_verbosity_level, args_verbosity_level):


### PR DESCRIPTION
The previous name of this method overrode a method with the same name in
the parent class that was related to lock acquisition. This was being
called internally by python logging code. Instead of releasing the lock,
this will have been accidentally dumping logs gathered before they were
ready to be handled. From what I can tell, this was happening just
before we manually called release(). This would give the appearance that
these logs were not being captured when in fact they were.

This fixes #1958