### PR TITLE
Add missing playback controller method to API docs

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -125,6 +125,7 @@ Current track
 
 .. automethod:: mopidy.core.PlaybackController.get_current_tl_track
 .. automethod:: mopidy.core.PlaybackController.get_current_track
+.. automethod:: mopidy.core.PlaybackController.get_current_tlid
 .. automethod:: mopidy.core.PlaybackController.get_stream_title
 .. automethod:: mopidy.core.PlaybackController.get_time_position
 


### PR DESCRIPTION
I noticed this method was missing by chance while working on the API
explorer.