### PR TITLE
General documentation maintenance

### DIFF
--- a/docs/api/http-server.rst
+++ b/docs/api/http-server.rst
@@ -11,7 +11,7 @@ to expose something over HTTP.
 The HTTP server side API can be used to:
 
 - host static files for e.g. a Mopidy client written in pure JavaScript,
-- host a `Tornado <http://www.tornadoweb.org/>`__ application, or
+- host a `Tornado <https://www.tornadoweb.org/>`__ application, or
 - host a WSGI application, including e.g. Flask applications.
 
 To host static files using the web server, an extension needs to register a

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -147,7 +147,7 @@ extlinks = {
 intersphinx_mapping = {
     "python": ("https://docs.python.org/3", None),
     "pykka": ("https://www.pykka.org/en/latest/", None),
-    "tornado": ("http://www.tornadoweb.org/en/stable/", None),
+    "tornado": ("https://www.tornadoweb.org/en/stable/", None),
 }
 
 # -- Options for linkcheck builder -------------------------------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -112,13 +112,13 @@ Pull request guidelines
    For more inspiration, feel free to read these blog posts:
 
    - `Writing Git commit messages
-     <http://365git.tumblr.com/post/3308646748/writing-git-commit-messages>`_
+     <https://365git.tumblr.com/post/3308646748/writing-git-commit-messages>`_
 
    - `A Note About Git Commit Messages
      <https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html>`_
 
    - `On commit messages
-     <http://who-t.blogspot.ch/2009/12/on-commit-messages.html>`_
+     <https://who-t.blogspot.com/2009/12/on-commit-messages.html>`_
 
 #. Send a pull request to the ``develop`` branch. See the `GitHub pull request
    docs <https://help.github.com/en/articles/about-pull-requests>`_ for help.

--- a/docs/devenv.rst
+++ b/docs/devenv.rst
@@ -196,7 +196,7 @@ use as well. These can be installed into the active virtualenv by running::
 Note that this is the same command as you used to install Mopidy from the Git
 repo, with the addition of the ``[dev]`` suffix after ``.``. This makes pip
 install the "dev" set of extra dependencies. Exactly what the "dev" set
-includes are defined in ``setup.py``.
+includes are defined in ``setup.cfg``.
 
 To upgrade the development tools in the future, just rerun the exact same
 command.
@@ -332,7 +332,7 @@ We're quite pedantic about :ref:`codestyle` and try hard to keep the Mopidy
 code base a very clean and nice place to work in.
 
 Luckily, you can get very far by using the `flake8
-<http://flake8.readthedocs.io/>`_ linter to check your code for issues before
+<https://flake8.pycqa.org/en/latest/>`_ linter to check your code for issues before
 submitting a pull request. Mopidy passes all of flake8's checks, with only a
 very few exceptions configured in :file:`setup.cfg`. You can either run the
 ``flake8`` tox environment, like our CI setup will do on your pull request::
@@ -359,15 +359,17 @@ If successful, the command will not print anything at all.
 Writing documentation
 =====================
 
-To write documentation, we use `Sphinx <http://www.sphinx-doc.org/>`_. See
+To write documentation, we use `Sphinx <https://www.sphinx-doc.org/>`_. See
 their site for lots of documentation on how to use Sphinx.
 
 .. note::
 
-    To generate a few graphs which are part of the documentation, you need some
-    additional dependencies. You can install them from APT with::
+    To generate a few graphs which are part of the documentation, you need to
+    install the graphviz package. You can install it from APT with::
 
-        sudo apt-get install python-pygraphviz graphviz
+        sudo apt install graphviz
+
+    Other distributions typically use the same package name.
 
 To build the documentation, go into the :file:`docs/` directory::
 

--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -87,7 +87,7 @@ with ``#egg=Mopidy-Something-dev`` for installation using
     Mopidy-Soundspot
     ****************
 
-    `Mopidy <http://www.mopidy.com/>`_ extension for playing music from
+    `Mopidy <https://mopidy.com/>`_ extension for playing music from
     `Soundspot <http://soundspot.example.com/>`_.
 
     Requires a Soundspot Platina subscription and the pysoundspot library.
@@ -101,7 +101,7 @@ with ``#egg=Mopidy-Something-dev`` for installation using
         sudo pip install Mopidy-Soundspot
 
     Or, if available, install the Debian/Ubuntu package from `apt.mopidy.com
-    <http://apt.mopidy.com/>`_.
+    <https://apt.mopidy.com/>`_.
 
 
     Configuration


### PR DESCRIPTION
- Update some URLs to use HTTPS, or to follow redirects
- Account for the switch from setup.py to setup.cfg
- Update notes about installing graphviz to account for the fact that
  pygraphviz is now a docs dependency defined in setup.cfg