### PR TITLE
Resolve issue with backend lists preparation

### DIFF
--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -254,10 +254,8 @@ class Backends(list):
                 has_playlists = b.has_playlists().get()
             except Exception:
                 self.remove(b)
-                logger.exception(
-                    "Fetching backend info for %s failed",
-                    b.actor_ref.actor_class.__name__,
-                )
+                logger.exception("Fetching backend info for %s failed", name(b))
+                continue
 
             for scheme in b.uri_schemes.get():
                 if scheme in backends_by_scheme:


### PR DESCRIPTION
Previously when preparing sub-lists of backends (based on what they
support), we would still try to add the relevant backend to each list
even if an exception was thrown while fetching the relevant information.
This was problematic:

- If the very first backend encountered an issue, this code would also
  throw an exception because some variables would be undefined
- If any other backends encountered an issue, this code would make
  decisions based on the data obtained from a previous backend

Now we don't try to proceed with adding a backend to any sub-list if an
error occurs.

Also, the code used to construct the relevant error message in this
situation now uses an existing function to get the relevant backend's
classname.