### PR TITLE
Translate relative paths in M3U playlists with local track URIs

### DIFF
--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -388,6 +388,11 @@ class TracklistController:
 
         if tracks is None:
             tracks = []
+            # counteract upmpdcli trick to fool BubbleUPnP
+            uris = [
+                uri[len("http://127.0.0.1/"):] if uri.startswith("http://127.0.0.1/") else uri
+                for uri in uris
+            ]
             track_map = self.core.library.lookup(uris=uris)
             for uri in uris:
                 tracks.extend(track_map[uri])

--- a/mopidy/m3u/__init__.py
+++ b/mopidy/m3u/__init__.py
@@ -23,6 +23,7 @@ class Extension(ext.Extension):
         schema["default_encoding"] = config.String()
         schema["default_extension"] = config.String(choices=[".m3u", ".m3u8"])
         schema["playlists_dir"] = config.Path(optional=True)
+        schema["local_tracks"] = config.Boolean(optional=True)
         return schema
 
     def setup(self, registry):

--- a/mopidy/m3u/ext.conf
+++ b/mopidy/m3u/ext.conf
@@ -4,3 +4,4 @@ playlists_dir =
 base_dir = $XDG_MUSIC_DIR
 default_encoding = latin-1
 default_extension = .m3u8
+local_tracks = false

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -59,6 +59,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             self._base_dir = path.expand_path(ext_config["base_dir"])
         self._default_encoding = ext_config["default_encoding"]
         self._default_extension = ext_config["default_extension"]
+        self._local_tracks = ext_config["local_tracks"]
 
     def as_list(self):
         result = []
@@ -104,7 +105,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             return None
         try:
             with self._open(path, "r") as fp:
-                items = translator.load_items(fp, self._base_dir)
+                items = translator.load_items(fp, self._base_dir, self._local_tracks)
         except OSError as e:
             log_environment_error(f"Error reading playlist {uri!r}", e)
         else:
@@ -117,7 +118,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             return None
         try:
             with self._open(path, "r") as fp:
-                items = translator.load_items(fp, self._base_dir)
+                items = translator.load_items(fp, self._base_dir, self._local_tracks)
             mtime = self._abspath(path).stat().st_mtime
         except OSError as e:
             log_environment_error(f"Error reading playlist {uri!r}", e)


### PR DESCRIPTION
I was bothered by the fact that M3U items were handled in a different way from tracks scanned by the local backend (also M3U playlists don't work from MPD clients). So I patched the M3U backend to translate file URIs to local URIs (`local:track:path_to_file`).  
This new behavior must be enabled manually by setting `m3u/local_tracks=true`. That of course assumes that all playlists have relative filenames inside.

It works for me, I wonder if this is the right approach for this problem, would someone review it please and maybe make some suggestions to improve it?

Thanks!