### PR TITLE
Listening to "reached_end_of_stream"

### DIFF
--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -80,6 +80,7 @@ class Core(
 
     def reached_end_of_stream(self):
         self.playback._on_end_of_stream()
+        CoreListener.send("reached_end_of_stream")
 
     def stream_changed(self, uri):
         self.playback._on_stream_changed(uri)

--- a/mopidy/core/listener.py
+++ b/mopidy/core/listener.py
@@ -140,6 +140,14 @@ class CoreListener(listener.Listener):
         *MAY* be implemented by actor.
         """
         pass
+    
+    def reached_end_of_stream(self):
+        """
+        Called whenever the end of a stream is reached.
+
+        *MAY* be implemented by actor.
+        """
+        pass
 
     def volume_changed(self, volume):
         """


### PR DESCRIPTION
Listening to "reached_end_of_stream" is missing in the CoreListener.
This patch simply adds this feature.