### PR TITLE
typing: added missing library stubs and fixed logging DelayedHandler

### DIFF
--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -59,9 +59,10 @@ class DelayedHandler(logging.Handler):
         self._released = False
         self._buffer: List[LogRecord] = []
 
-    def handle(self, record: LogRecord) -> None:
+    def handle(self, record: LogRecord) -> bool:
         if not self._released:
             self._buffer.append(record)
+        return True
 
     def release_delayed_logs(self) -> None:
         self._released = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -55,6 +55,8 @@ lint =
     isort
     mypy
     pep8-naming
+    types-requests
+    types-setuptools
 test =
     pytest
     pytest-cov


### PR DESCRIPTION
This fixes the mypy part of the build. @jodal are these extra deps the correct way to do this or should we do something like this:

```
mypy --install-types --non-interactive
```
as mentioned at https://mypy.readthedocs.io/en/stable/running_mypy.html#missing-imports