### PR TITLE
Iterate over copy of websocket clients

### DIFF
--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -116,7 +116,7 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
     def broadcast(cls, msg, io_loop):
         # This can be called from outside the Tornado ioloop, so we need to
         # safely cross the thread boundary by adding a callback to the loop.
-        for client in cls.clients:
+        for client in cls.clients.copy():
             # One callback per client to keep time we hold up the loop short
             io_loop.add_callback(
                 functools.partial(_send_broadcast, client, msg)


### PR DESCRIPTION
If clients are added/removed while a message is broadcast, a python error is raised: 
```
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/pykka/_actor.py", line 193, in _actor_loop
    response = self._handle_receive(envelope.message)
  File "/usr/lib/python3/dist-packages/pykka/_actor.py", line 299, in _handle_receive
    return callee(*message.args, **message.kwargs)
  File "/usr/lib/python3/dist-packages/mopidy/http/actor.py", line 82, in on_event
    on_event(name, self.server.io_loop, **data)
  File "/usr/lib/python3/dist-packages/mopidy/http/actor.py", line 89, in on_event
    handlers.WebSocketHandler.broadcast(message, io_loop)
  File "/usr/lib/python3/dist-packages/mopidy/http/handlers.py", line 112, in broadcast
    for client in cls.clients:
RuntimeError: Set changed size during iteration
```

For me this happens when testing a project that uses [mopidyapi](https://github.com/AsbjornOlling/mopidyapi/). During testing, websocket connections are frequently created/removed, which sometimes leads to this error. Code to reproduce:
```python
from mopidyapi import MopidyAPI
# for me the error started showing up with ~4 iterations,
# but more make it appear more frequently
for _ in range(8):
    api = MopidyAPI()
    api.playback.pause()
```

This pull request prevents this by iterating over a copy of the clients instead of the original set. A shallow copy should be sufficient, as the clients are only added/removed from the set and not changed. In my use-case this caused no problems.