### PR TITLE
Added a new testcase in "test_history.py"

### DIFF
--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -46,8 +46,16 @@ class PlaybackHistoryTest(unittest.TestCase):
         assert track.name in ref.name
         for artist in track.artists:
             assert artist.name in ref.name
-        
-
+      
+class test_without_name(unittest.TestCase):
+    def setUp(self):
+        self.tracks = [
+            Track(uri="dummy1:a", name="foober"),
+            Track(uri="dummy2:a", name="foo"),
+            Track(uri="dummy3:a", name="bar")
+        ]
+        self.history = HistoryController()
+    
 class CoreHistorySaveLoadStateTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
         self.tracks = [

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -47,7 +47,7 @@ class PlaybackHistoryTest(unittest.TestCase):
         for artist in track.artists:
             assert artist.name in ref.name
       
-class test_without_name(unittest.TestCase):
+class TestWithoutName(unittest.TestCase):
     def setUp(self):  # noqa: N802
         self.tracks = [
             Track(

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -46,15 +46,6 @@ class PlaybackHistoryTest(unittest.TestCase):
         assert track.name in ref.name
         for artist in track.artists:
             assert artist.name in ref.name
-
-class test_without_name(unittest.TestCase):
-    def setUp(self):
-        self.tracks = [
-            Track(uri="dummy1:a", name="foober"),
-            Track(uri="dummy2:a", name="foo"),
-            Track(uri="dummy3:a", name="bar")
-        ]
-        self.history = HistoryController()
         
 
 class CoreHistorySaveLoadStateTest(unittest.TestCase):

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -48,7 +48,7 @@ class PlaybackHistoryTest(unittest.TestCase):
             assert artist.name in ref.name
       
 class test_without_name(unittest.TestCase):
-    def setUp(self):
+    def setUp(self):  # noqa: N802
         self.tracks = [
             Track(
                 uri="dummy1:a",

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -47,6 +47,15 @@ class PlaybackHistoryTest(unittest.TestCase):
         for artist in track.artists:
             assert artist.name in ref.name
 
+class test_without_name(unittest.TestCase):
+    def setUp(self):
+        self.tracks = [
+            Track(uri="dummy1:a", name="foober"),
+            Track(uri="dummy2:a", name="foo"),
+            Track(uri="dummy3:a", name="bar")
+        ]
+        self.history = HistoryController()
+        
 
 class CoreHistorySaveLoadStateTest(unittest.TestCase):
     def setUp(self):  # noqa: N802

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -50,11 +50,43 @@ class PlaybackHistoryTest(unittest.TestCase):
 class test_without_name(unittest.TestCase):
     def setUp(self):
         self.tracks = [
-            Track(uri="dummy1:a", name="foober"),
+            Track(
+                uri="dummy1:a",
+                name="foo",
+                artists=[Artist(name=None), Artist(name=None)],
+            ),
             Track(uri="dummy2:a", name="foo"),
             Track(uri="dummy3:a", name="bar")
         ]
         self.history = HistoryController()
+    def test_add_track(self):
+        self.history._add_track(self.tracks[0])
+        assert self.history.get_length() == 1
+
+        self.history._add_track(self.tracks[1])
+        assert self.history.get_length() == 2
+
+        self.history._add_track(self.tracks[2])
+        assert self.history.get_length() == 3
+
+    def test_non_tracks_are_rejected(self):
+        with self.assertRaises(TypeError):
+            self.history._add_track(object())
+
+        assert self.history.get_length() == 0
+
+    def test_history_entry_contents(self):
+        track = self.tracks[0]
+        self.history._add_track(track)
+
+        result = self.history.get_history()
+        (timestamp, ref) = result[0]
+
+        assert isinstance(timestamp, int)
+        assert track.uri == ref.uri
+        assert track.name in ref.name
+        for artist in track.artists:
+            assert artist.name in ref.name
     
 class CoreHistorySaveLoadStateTest(unittest.TestCase):
     def setUp(self):  # noqa: N802


### PR DESCRIPTION
Added a new testcase in "test_history.py"  for the issue #1991 
```
Jul 19 16:30:13 lysmarine sh[694]:     getattr(self, event)(**kwargs)
Jul 19 16:30:13 lysmarine sh[694]:   File "/usr/lib/python3/dist-packages/mopidy/core/actor.py", line 85, in stream_changed
Jul 19 16:30:13 lysmarine sh[694]:     self.playback._on_stream_changed(uri)
Jul 19 16:30:13 lysmarine sh[694]:   File "/usr/lib/python3/dist-packages/mopidy/core/playback.py", line 147, in _on_stream_ch
Jul 19 16:30:13 lysmarine sh[694]:     self._trigger_track_playback_started()
Jul 19 16:30:13 lysmarine sh[694]:   File "/usr/lib/python3/dist-packages/mopidy/core/playback.py", line 514, in _trigger_trac
Jul 19 16:30:13 lysmarine sh[694]:     self.core.history._add_track(tl_track.track)
Jul 19 16:30:13 lysmarine sh[694]:   File "/usr/lib/python3/dist-packages/mopidy/core/history.py", line 31, in _add_track
Jul 19 16:30:13 lysmarine sh[694]:     ", ".join(artist.name for artist in track.artists)
Jul 19 16:30:13 lysmarine sh[694]: TypeError: sequence item 0: expected str instance, NoneType found
```
Added a testcase having an `Artist` without a name.
This testcase is to resolve the type error exception when playing track with unnamed artists.
