### PR TITLE
Support offset values for adding tracks relative to current track

### DIFF
--- a/mopidy/internal/validation.py
+++ b/mopidy/internal/validation.py
@@ -85,6 +85,25 @@ def check_integer(arg, min=None, max=None):
         )
 
 
+def check_offset_str(
+    arg: str,
+    current_pos: int,
+    msg: str = "Offsets must be an integer with a prefix of '+' or '-'",
+) -> int:
+    if not arg.startswith(("+", "-")):
+        raise exceptions.ValidationError(msg)
+
+    try:
+        offset = int(arg[1:])
+    except ValueError as e:
+        raise exceptions.ValidationError(msg) from e
+
+    if arg[0] == "+":
+        return current_pos + 1 + offset
+    else:
+        return max(0, current_pos - offset)
+
+
 def check_query(arg, fields=None, list_values=True):
     if fields is None:
         fields = SEARCH_FIELDS

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -1,7 +1,10 @@
+import re
 import unittest
 from unittest import mock
 
-from mopidy import backend, core
+import pytest
+
+from mopidy import backend, core, exceptions
 from mopidy.internal.models import TracklistState
 from mopidy.models import TlTrack, Track
 
@@ -295,3 +298,138 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
 
     def test_load_none(self):
         self.core.tracklist._load_state(None, None)
+
+
+class TracklistAddTest(unittest.TestCase):
+    def setUp(self):
+        config = {"core": {"max_tracklist_length": 10000}}
+
+        tracks = [
+            Track(uri="dummy1:a", name="foo"),
+            Track(uri="dummy1:b", name="foo"),
+            Track(uri="dummy1:c", name="bar"),
+        ]
+
+        def lookup(uris):
+            return {u: [t for t in tracks if t.uri == u] for u in uris}
+
+        self.core = core.Core(config, mixer=None, backends=[])
+        self.core.library = mock.Mock(spec=core.LibraryController)
+        self.core.library.lookup.side_effect = lookup
+
+        self.core.playback = mock.Mock(spec=core.PlaybackController)
+
+        self.tl_tracks = self.core.tracklist.add(uris=[t.uri for t in tracks])
+
+    def test_add_appends_by_default(self):
+        new_track = self.core.tracklist.add(uris=["dummy1:a"])[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[3].tlid == new_track.tlid
+
+    def test_add_inserts_at_supplied_position(self):
+        new_track = self.core.tracklist.add(at_position=1, uris=["dummy1:c"])[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[1].tlid == new_track.tlid
+
+    def test_add_inserts_at_negative_supplied_position(self):
+        new_tracks = self.core.tracklist.add(at_position=-1, uris=["dummy1:a"])
+        new_track = new_tracks[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[2].tlid == new_track.tlid
+
+    def test_add_inserts_at_start(self):
+        new_track = self.core.tracklist.add(at_position=0, uris=["dummy1:c"])[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[0].tlid == new_track.tlid
+
+    def test_add_inserts_after_currently_playing_track(self):
+        self.core.playback.get_current_tl_track.return_value = self.tl_tracks[0]
+        new_tracks = self.core.tracklist.add(
+            at_position="+0", uris=["dummy1:c"]
+        )
+        new_track = new_tracks[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[1].tlid == new_track.tlid
+
+    def test_add_inserts_further_after_currently_playing_track(self):
+        self.core.playback.get_current_tl_track.return_value = self.tl_tracks[1]
+        new_tracks = self.core.tracklist.add(
+            at_position="+1", uris=["dummy1:b"]
+        )
+        new_track = new_tracks[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[3].tlid == new_track.tlid
+
+    def test_add_inserts_much_further_after_currently_playing_track(self):
+        self.core.playback.get_current_tl_track.return_value = self.tl_tracks[1]
+        new_tracks = self.core.tracklist.add(
+            at_position="+5", uris=["dummy1:b"]
+        )
+        new_track = new_tracks[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[3].tlid == new_track.tlid
+
+    def test_add_inserts_before_currently_playing_track(self):
+        self.core.playback.get_current_tl_track.return_value = self.tl_tracks[2]
+        new_tracks = self.core.tracklist.add(
+            at_position="-0", uris=["dummy1:c"]
+        )
+        new_track = new_tracks[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[2].tlid == new_track.tlid
+
+    def test_add_inserts_further_before_currently_playing_track(self):
+        self.core.playback.get_current_tl_track.return_value = self.tl_tracks[2]
+        new_tracks = self.core.tracklist.add(
+            at_position="-1", uris=["dummy1:c"]
+        )
+        new_track = new_tracks[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[1].tlid == new_track.tlid
+
+    def test_add_inserts_much_further_before_currently_playing_track(self):
+        self.core.playback.get_current_tl_track.return_value = self.tl_tracks[2]
+        new_tracks = self.core.tracklist.add(
+            at_position="-5", uris=["dummy1:c"]
+        )
+        new_track = new_tracks[0]
+        all_tracks = self.core.tracklist.get_tl_tracks()
+        assert len(all_tracks) == 4
+        assert all_tracks[0].tlid == new_track.tlid
+
+    def test_add_rejects_invalid_offsets(self):
+        self.core.playback.get_current_tl_track.return_value = self.tl_tracks[0]
+        err_msg = re.escape(
+            "Expected an integer, or a string representing an offset from the current track, with a prefix of '+' or '-'"
+        )
+
+        with pytest.raises(exceptions.ValidationError, match=err_msg):
+            self.core.tracklist.add(at_position="0", uris=["dummy1:c"])
+
+        with pytest.raises(exceptions.ValidationError, match=err_msg):
+            self.core.tracklist.add(at_position="4", uris=["dummy1:a"])
+
+        with pytest.raises(exceptions.ValidationError, match=err_msg):
+            self.core.tracklist.add(at_position="next", uris=["dummy1:b"])
+
+        with pytest.raises(exceptions.ValidationError, match=err_msg):
+            self.core.tracklist.add(at_position=object(), uris=["dummy1:c"])
+
+        with pytest.raises(exceptions.ValidationError, match=err_msg):
+            self.core.tracklist.add(at_position=self, uris=["dummy1:a"])
+
+    def test_add_rejects_offsets_when_no_track_playing(self):
+        err_msg = re.escape("Cannot use offset when no track is playing")
+
+        self.core.playback.get_current_tl_track.return_value = None
+        with pytest.raises(exceptions.ValidationError, match=err_msg):
+            self.core.tracklist.add(at_position="+0", uris=["dummy1:b"])

--- a/tests/internal/test_validation.py
+++ b/tests/internal/test_validation.py
@@ -1,3 +1,5 @@
+import re
+
 from pytest import raises
 
 from mopidy import exceptions
@@ -119,6 +121,37 @@ def test_check_values_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_query({"any": "abc"})
     assert 'Expected "any" to be list of strings, not' in str(excinfo.value)
+
+
+def test_check_offset_str_positive_offset():
+    assert validation.check_offset_str("+0", 6) == 7
+    assert validation.check_offset_str("+1", 4) == 6
+    assert validation.check_offset_str("+3", 0) == 4
+
+
+def test_check_offset_str_negative_offset():
+    assert validation.check_offset_str("-0", 0) == 0
+    assert validation.check_offset_str("-0", 1) == 1
+    assert validation.check_offset_str("-1", 1) == 0
+    assert validation.check_offset_str("-1", 2) == 1
+    assert validation.check_offset_str("-2", 4) == 2
+    assert validation.check_offset_str("-4", 3) == 0
+
+
+def test_check_offset_str_invalid_string():
+    err_msg = re.escape(
+        "Offsets must be an integer with a prefix of '+' or '-'"
+    )
+    with raises(exceptions.ValidationError, match=err_msg):
+        validation.check_offset_str("foo", 4)
+
+
+def test_check_offset_str_invalid_number():
+    err_msg = re.escape(
+        "Offsets must be an integer with a prefix of '+' or '-'"
+    )
+    with raises(exceptions.ValidationError, match=err_msg):
+        validation.check_offset_str("+1.5", 8)
 
 
 def test_check_uri_with_valid_values():


### PR DESCRIPTION
With this change, you can add tracks directly before or after the currently playing track without first having to retrieve the position of the currently playing track value yourself. When used over Mopidy's HTTP interfaces, this reduces the chance that the tracks you're adding will accidentally be skipped over between your two requests.

The syntax for the offset strings matches MPD's support that was implemented as part of 0.23.

I noticed there were no existing tests for the at_position argument, so I added some at the same time to handle other existing cases in addition to the new cases.