### PR TITLE
Fix deprecation warning in pytest

### DIFF
--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -7,7 +7,7 @@ import pytest
 from mopidy.internal import xdg
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def environ():
     patcher = mock.patch.dict(os.environ, clear=True)
     yield patcher.start()

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -38,7 +38,7 @@ def audio():
     return mock.Mock()
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def scanner():
     patcher = mock.patch.object(scan, "Scanner")
     yield patcher.start()()

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -72,7 +72,7 @@ class TestExtension:
 
 
 class TestLoadExtensions:
-    @pytest.yield_fixture
+    @pytest.fixture
     def iter_entry_points_mock(self, request):
         patcher = mock.patch("pkg_resources.iter_entry_points")
         iter_entry_points = patcher.start()


### PR DESCRIPTION
@pytest.yield_fixture has been deprecated, as @pytest.fixture supports
generators just fine.