### PR TITLE
Updates to ReadTheDocs config

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,7 +1,7 @@
 version: 2
 
 python:
-  version: 3.7
+  version: "3.7"
   install:
     - method: pip
       path: .
@@ -9,7 +9,7 @@ python:
         - docs
 
 sphinx:
-  builder: htmldir
+  builder: dirhtml
   configuration: docs/conf.py
 
 formats:


### PR DESCRIPTION
- The python version field is specified as a string in the docs
- Change 'htmldir' to 'dirhtml' as per the sphinx compatibility note in
  the docs