### PR TITLE
Add new config types, improve existing types

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -54,6 +54,9 @@ v3.3.0 (UNRELEASED)
 
 - Add Python 3.10 to our test matrix.
 
+- Core: Added and improved configuration parsing code for extension
+  developers. (PR: :issue:`2010`)
+
 
 v3.2.0 (2021-07-08)
 ===================

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -13,11 +13,13 @@ from mopidy.config.types import (
     ConfigValue,
     Deprecated,
     DeprecatedValue,
+    Float,
     Hostname,
     Integer,
     List,
     LogColor,
     LogLevel,
+    Pair,
     Path,
     Port,
     Secret,
@@ -28,7 +30,9 @@ from mopidy.internal import path, versioning
 __all__ = [
     # TODO List everything that is reexported, not just the unused parts.
     "ConfigValue",
+    "Float",
     "List",
+    "Pair",
 ]
 
 logger = logging.getLogger(__name__)

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -34,6 +34,14 @@ class DeprecatedValue:
     pass
 
 
+class _TransformedValue(str):
+    def __new__(cls, original, transformed):
+        return super().__new__(cls, transformed)
+
+    def __init__(self, original, transformed):
+        self.original = original
+
+
 class ConfigValue:
     """Represents a config key's value and how to handle it.
 
@@ -82,21 +90,32 @@ class String(ConfigValue):
     Is decoded as utf-8 and \\n \\t escapes should work and be preserved.
     """
 
-    def __init__(self, optional=False, choices=None):
+    def __init__(self, optional=False, choices=None, transformer=None):
         self._required = not optional
         self._choices = choices
+        self._transformer = transformer
 
     def deserialize(self, value):
         value = decode(value).strip()
         validators.validate_required(value, self._required)
         if not value:
             return None
+
+        # This is necessary for backwards-compatibility, in case subclasses
+        # aren't calling their parent constructor.
+        transformer = getattr(self, "_transformer", None)
+        if transformer:
+            transformed_value = transformer(value)
+            value = _TransformedValue(value, transformed_value)
+
         validators.validate_choice(value, self._choices)
         return value
 
     def serialize(self, value, display=False):
         if value is None:
             return ""
+        if isinstance(value, _TransformedValue):
+            value = value.original
         return encode(value)
 
 
@@ -109,9 +128,12 @@ class Secret(String):
     displayed.
     """
 
-    def __init__(self, optional=False, choices=None):
-        self._required = not optional
-        self._choices = None  # Choices doesn't make sense for secrets
+    def __init__(self, optional=False, choices=None, transformer=None):
+        super().__init__(
+            optional=optional,
+            choices=None,  # Choices doesn't make sense for secrets
+            transformer=transformer,
+        )
 
     def serialize(self, value, display=False):
         if value is not None and display:
@@ -137,6 +159,25 @@ class Integer(ConfigValue):
             return None
         value = int(value)
         validators.validate_choice(value, self._choices)
+        validators.validate_minimum(value, self._minimum)
+        validators.validate_maximum(value, self._maximum)
+        return value
+
+
+class Float(ConfigValue):
+    """Float value."""
+
+    def __init__(self, minimum=None, maximum=None, optional=False):
+        self._required = not optional
+        self._minimum = minimum
+        self._maximum = maximum
+
+    def deserialize(self, value):
+        value = decode(value)
+        validators.validate_required(value, self._required)
+        if not value:
+            return None
+        value = float(value)
         validators.validate_minimum(value, self._minimum)
         validators.validate_maximum(value, self._maximum)
         return value
@@ -178,15 +219,78 @@ class Boolean(ConfigValue):
             raise ValueError(f"{value!r} is not a boolean")
 
 
+class Pair(ConfigValue):
+    """Pair value
+
+    The value is expected to be a pair of elements, separated by a specified delimiter.
+    Values can optionally not be a pair, in which case the whole input is provided for
+    both sides of the value.
+    """
+
+    def __init__(
+        self, optional=False, optional_pair=False, separator="|", subtypes=None
+    ):
+        self._required = not optional
+        self._optional_pair = optional_pair
+        self._separator = separator
+        if subtypes:
+            self._subtypes = subtypes
+        else:
+            self._subtypes = (String(), String())
+
+    def deserialize(self, value):
+        raw_value = decode(value).strip()
+        validators.validate_required(raw_value, self._required)
+        if not raw_value:
+            return None
+
+        if self._separator in raw_value:
+            values = raw_value.split(self._separator, 1)
+        elif self._optional_pair:
+            values = (raw_value, raw_value)
+        else:
+            raise ValueError(
+                f"Config value must include {self._separator!r} separator: {raw_value}"
+            )
+
+        return (
+            self._subtypes[0].deserialize(encode(values[0])),
+            self._subtypes[1].deserialize(encode(values[1])),
+        )
+
+    def serialize(self, value, display=False):
+        serialized_first_value = self._subtypes[0].serialize(
+            value[0], display=display
+        )
+        serialized_second_value = self._subtypes[1].serialize(
+            value[1], display=display
+        )
+
+        if (
+            not display
+            and self._optional_pair
+            and serialized_first_value == serialized_second_value
+        ):
+            return serialized_first_value
+        else:
+            return "{0}{1}{2}".format(
+                serialized_first_value,
+                self._separator,
+                serialized_second_value,
+            )
+
+
 class List(ConfigValue):
     """List value.
 
-    Supports elements split by commas or newlines. Newlines take presedence and
+    Supports elements split by commas or newlines. Newlines take precedence and
     empty list items will be filtered out.
     """
 
-    def __init__(self, optional=False):
+    def __init__(self, optional=False, unique=False, subtype=None):
         self._required = not optional
+        self._unique = unique
+        self._subtype = subtype if subtype else String()
 
     def deserialize(self, value):
         value = decode(value)
@@ -194,14 +298,37 @@ class List(ConfigValue):
             values = re.split(r"\s*\n\s*", value)
         else:
             values = re.split(r"\s*,\s*", value)
-        values = tuple(v.strip() for v in values if v.strip())
+
+        # This is necessary for backwards-compatibility, in case subclasses
+        # aren't calling their parent constructor.
+        subtype = getattr(self, "_subtype", String())
+
+        values_iter = (
+            subtype.deserialize(v.strip()) for v in values if v.strip()
+        )
+        if self._unique:
+            values = frozenset(values_iter)
+        else:
+            values = tuple(values_iter)
+
         validators.validate_required(values, self._required)
-        return tuple(values)
+        return values
 
     def serialize(self, value, display=False):
         if not value:
             return ""
-        return "\n  " + "\n  ".join(encode(v) for v in value if v)
+
+        # This is necessary for backwards-compatibility, in case subclasses
+        # aren't calling their parent constructor.
+        subtype = getattr(self, "_subtype", String())
+
+        serialized_values = []
+        for item in value:
+            serialized_value = subtype.serialize(item, display=display)
+            if serialized_value:
+                serialized_values.append(serialized_value)
+
+        return "\n  " + "\n  ".join(serialized_values)
 
 
 class LogColor(ConfigValue):
@@ -283,12 +410,9 @@ class Port(Integer):
         )
 
 
-class _ExpandedPath(str):
-    def __new__(cls, original, expanded):
-        return super().__new__(cls, expanded)
-
-    def __init__(self, original, expanded):
-        self.original = original
+# Keep this for backwards compatibility
+class _ExpandedPath(_TransformedValue):
+    pass
 
 
 class Path(ConfigValue):
@@ -316,6 +440,8 @@ class Path(ConfigValue):
         return _ExpandedPath(value, expanded)
 
     def serialize(self, value, display=False):
+        if value is None:
+            return ""
         if isinstance(value, _ExpandedPath):
             value = value.original
         if isinstance(value, bytes):

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -285,6 +285,10 @@ class List(ConfigValue):
 
     Supports elements split by commas or newlines. Newlines take precedence and
     empty list items will be filtered out.
+
+    Enforcing unique entries in the list will result in a set data structure
+    being used. This does not preserve ordering, which could result in the
+    serialized output being unstable.
     """
 
     def __init__(self, optional=False, unique=False, subtype=None):

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -1,4 +1,6 @@
+import codecs
 import logging
+import re
 import socket
 from unittest import mock
 
@@ -107,6 +109,7 @@ class TestString:
 
         assert result == "foo"
         assert isinstance(result, str)
+        assert not isinstance(result, types._TransformedValue)
 
     def test_deserialize_decodes_utf8(self):
         cv = types.String()
@@ -196,6 +199,48 @@ class TestString:
         with pytest.raises(ValueError):
             cv.deserialize(b"foobar")
 
+    @pytest.mark.parametrize(
+        ("original", "transformed"),
+        (
+            ("abc", "abc"),
+            ("ABC", "abc"),
+            ("aBc", "abc"),
+            ("123", "123"),
+            ("abc123def456", "abc123def456"),
+            ("ABC123def456GHI789", "abc123def456ghi789"),
+        ),
+    )
+    def test_deserialize_utilises_transformer(
+        self, original: str, transformed: str
+    ):
+        cv = types.String(transformer=lambda value: value.lower())
+
+        result = cv.deserialize(original)
+        assert isinstance(result, str)
+        assert isinstance(result, types._TransformedValue)
+        assert result == transformed
+        assert result.original == original
+
+    @pytest.mark.parametrize(
+        ("original", "transformed"),
+        (
+            ("abc", "abc"),
+            ("ABC", "abc"),
+            ("aBc", "abc"),
+            ("123", "123"),
+            ("abc123def456", "abc123def456"),
+            ("ABC123def456GHI789", "abc123def456ghi789"),
+        ),
+    )
+    def test_serialize_transformed_value(self, original: str, transformed: str):
+        cv = types.String()
+        transformed_value = types._TransformedValue(original, transformed)
+
+        result = cv.serialize(transformed_value)
+        assert isinstance(result, str)
+        assert not isinstance(result, types._TransformedValue)
+        assert result == original
+
 
 class TestSecret:
     def test_deserialize_decodes_utf8(self):
@@ -204,6 +249,7 @@ class TestSecret:
         result = cv.deserialize("æøå".encode())
 
         assert isinstance(result, str)
+        assert not isinstance(result, types._TransformedValue)
         assert result == "æøå"
 
     def test_deserialize_enforces_required(self):
@@ -218,6 +264,18 @@ class TestSecret:
         assert cv.deserialize(b"") is None
         assert cv.deserialize(b" ") is None
 
+    def test_deserialize_utilises_transformer(self):
+        cv = types.Secret(
+            transformer=lambda value: codecs.decode(value, encoding="rot13")
+        )
+
+        result = cv.deserialize("zbcvql")
+
+        assert isinstance(result, str)
+        assert isinstance(result, types._TransformedValue)
+        assert result == "mopidy"
+        assert result.original == "zbcvql"
+
     def test_serialize_none(self):
         cv = types.Secret()
 
@@ -225,6 +283,16 @@ class TestSecret:
 
         assert isinstance(result, str)
         assert result == ""
+
+    def test_serialize_transformed_value(self):
+        cv = types.Secret()
+        transformed_value = types._TransformedValue("zbcvql", "mopidy")
+
+        result = cv.serialize(transformed_value)
+
+        assert isinstance(result, str)
+        assert not isinstance(result, types._TransformedValue)
+        assert result == "zbcvql"
 
     def test_serialize_for_display_masks_value(self):
         cv = types.Secret()
@@ -241,6 +309,16 @@ class TestSecret:
 
         assert isinstance(result, str)
         assert result == ""
+
+    def test_serialize_transformed_value_for_display_masks_value(self):
+        cv = types.Secret()
+        transformed_value = types._TransformedValue("zbcvql", "mopidy")
+
+        result = cv.serialize(transformed_value, display=True)
+
+        assert isinstance(result, str)
+        assert not isinstance(result, types._TransformedValue)
+        assert result == "********"
 
 
 class TestInteger:
@@ -294,6 +372,55 @@ class TestInteger:
 
         with pytest.raises(ValueError):
             cv.deserialize("15")
+
+
+class TestFloat:
+    def test_deserialize_conversion_success(self):
+        cv = types.Float()
+
+        assert cv.deserialize("123") == 123.0
+        assert cv.deserialize("0") == 0.0
+        assert cv.deserialize("-10") == -10.0
+        assert cv.deserialize("3.14") == 3.14
+        assert cv.deserialize("123.45") == 123.45
+        assert cv.deserialize("-456.78") == -456.78
+
+    def test_deserialize_conversion_failure(self):
+        cv = types.Float()
+
+        errmsg = re.escape("could not convert string to float")
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("asd")
+
+    def test_deserialize_enforces_required(self):
+        cv = types.Float()
+
+        errmsg = "must be set"
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("")
+
+    def test_deserialize_respects_optional(self):
+        cv = types.Float(optional=True)
+
+        assert cv.deserialize("") is None
+
+    def test_deserialize_enforces_minimum(self):
+        cv = types.Float(minimum=10)
+
+        assert cv.deserialize("10.1") == 10.1
+
+        errmsg = re.escape("must be larger than")
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("9.9")
+
+    def test_deserialize_enforces_maximum(self):
+        cv = types.Float(maximum=10)
+
+        assert cv.deserialize("9.9") == 9.9
+
+        errmsg = re.escape("must be smaller than")
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("10.1")
 
 
 class TestBoolean:
@@ -367,9 +494,582 @@ class TestBoolean:
             cv.serialize("1")
 
 
+class TestPair:
+    def test_deserialize_conversion_success(self):
+        cv = types.Pair()
+
+        result = cv.deserialize("foo|bar")
+        assert result == ("foo", "bar")
+
+        result = cv.deserialize("  foo|bar")
+        assert result == ("foo", "bar")
+
+        result = cv.deserialize("foo|bar  ")
+        assert result == ("foo", "bar")
+
+        result = cv.deserialize("  fo o | bar ")
+        assert result == ("fo o", "bar")
+
+        result = cv.deserialize("foo|bar|baz")
+        assert result == ("foo", "bar|baz")
+
+    def test_deserialize_decodes_utf8(self):
+        cv = types.Pair()
+
+        result = cv.deserialize("æ|å".encode())
+        assert result == ("æ", "å")
+
+        result = cv.deserialize("æ | ø\n".encode())
+        assert result == ("æ", "ø")
+
+        result = cv.deserialize("æ ø| å".encode())
+        assert result == ("æ ø", "å")
+
+        result = cv.deserialize(" æ | øå \n".encode())
+        assert result == ("æ", "øå")
+
+    def test_deserialize_enforces_required(self):
+        cv = types.Pair()
+
+        errmsg = re.escape("must be set")
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("")
+
+    def test_deserialize_respects_optional(self):
+        cv = types.Pair(optional=True)
+
+        assert cv.deserialize("") is None
+        assert cv.deserialize(" ") is None
+
+    def test_deserialize_enforces_required_separator(self):
+        cv = types.Pair()
+
+        errmsg = (
+            "^"
+            + re.escape("Config value must include '|' separator: abc")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc")
+
+    def test_deserialize_respects_optional_separator(self):
+        cv = types.Pair(optional_pair=True)
+
+        result = cv.deserialize("abc")
+        assert result == ("abc", "abc")
+
+        result = cv.deserialize("abc|def")
+        assert result == ("abc", "def")
+
+    @pytest.mark.parametrize(
+        "sep", ("!", "@", "#", "$", "%", "^", "&", "*", "/", "\\")
+    )
+    def test_deserialize_respects_custom_separator(self, sep: str):
+        cv = types.Pair(separator=sep)
+
+        result = cv.deserialize(f"abc{sep}def")
+        assert result == ("abc", "def")
+
+        result = cv.deserialize(f"abc|def{sep}ghi|jkl")
+        assert result == ("abc|def", "ghi|jkl")
+
+        result = cv.deserialize(f"abc{sep}def{sep}ghi")
+        assert result == ("abc", f"def{sep}ghi")
+
+        result = cv.deserialize(f"ab|cd{sep}ef|gh{sep}ij|kl")
+        assert result == ("ab|cd", f"ef|gh{sep}ij|kl")
+
+        result = cv.deserialize(f"|abcd|{sep}efgh|")
+        assert result == ("|abcd|", "efgh|")
+
+        errmsg = (
+            "^"
+            + re.escape(f"Config value must include {sep!r} separator: abc|def")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|def")
+
+    @pytest.mark.parametrize(
+        "sep", ("!", "@", "#", "$", "%", "^", "&", "*", "/", "\\")
+    )
+    def test_deserialize_respects_optional_custom_separator(self, sep: str):
+        cv = types.Pair(optional_pair=True, separator=sep)
+
+        result = cv.deserialize(f"abc{sep}def")
+        assert result == ("abc", "def")
+
+        result = cv.deserialize("abcdef")
+        assert result == ("abcdef", "abcdef")
+
+        result = cv.deserialize("abc|def")
+        assert result == ("abc|def", "abc|def")
+
+        result = cv.deserialize(f"|abc{sep}def|")
+        assert result == ("|abc", "def|")
+
+    @pytest.mark.parametrize("optional", (True, False))
+    @pytest.mark.parametrize("optional_pair", (True, False))
+    def test_deserialize_enforces_required_pair_values(
+        self, optional: bool, optional_pair: bool
+    ):
+        cv = types.Pair(optional=optional, optional_pair=optional_pair)
+
+        errmsg = re.escape("must be set")
+
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|")
+
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("|def")
+
+    @pytest.mark.parametrize("optional", (True, False))
+    @pytest.mark.parametrize("optional_pair", (True, False))
+    @pytest.mark.parametrize(
+        "sep", ("!", "@", "#", "$", "%", "^", "&", "*", "/", "\\")
+    )
+    def test_deserialize_enforces_required_pair_values_with_custom_separator(
+        self, optional: bool, optional_pair: bool, sep: str
+    ):
+        cv = types.Pair(
+            optional=optional, optional_pair=optional_pair, separator=sep
+        )
+
+        errmsg = re.escape("must be set")
+
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize(f"abc{sep}")
+
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize(f"{sep}def")
+
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize(f"abc|def{sep}")
+
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize(f"{sep}ghi|jkl")
+
+    def test_deserialize_with_custom_subtypes(self):
+        cv = types.Pair(subtypes=(types.String(), types.Integer()))
+        result = cv.deserialize("abc|10")
+        assert result == ("abc", 10)
+
+        cv = types.Pair(subtypes=(types.Float(), types.Boolean()))
+        result = cv.deserialize("3.14|true")
+        assert result == (3.14, True)
+
+        cv = types.Pair(subtypes=(types.Path(), types.String()))
+        result = cv.deserialize("/dev/null | empty")
+        assert result == ("/dev/null", "empty")
+
+        with mock.patch("socket.getaddrinfo") as getaddrinfo_mock:
+            cv = types.Pair(subtypes=(types.Hostname(), types.Port()))
+            result = cv.deserialize("localhost|6680")
+            assert result == ("localhost", 6680)
+            getaddrinfo_mock.assert_called_once_with("localhost", None)
+
+    def test_deserialize_with_custom_subtypes_enforces_required(self):
+        cv = types.Pair(subtypes=(types.Integer(), types.Integer()))
+
+        errmsg = re.escape("must be set")
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("")
+
+    def test_deserialize_with_custom_subtypes_respects_optional(self):
+        cv = types.Pair(optional=True, subtypes=(types.Float(), types.Float()))
+
+        assert cv.deserialize("") is None
+
+    def test_deserialize_with_custom_subtypes_enforces_required_separator(self):
+        errmsg = "^" + re.escape("Config value must include '|' separator: ")
+
+        cv = types.Pair(subtypes=(types.String(), types.Secret()))
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc")
+
+        cv = types.Pair(subtypes=(types.String(), types.Integer()))
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("123")
+
+    def test_deserialize_with_custom_subtypes_respects_optional_separator(self):
+        cv = types.Pair(
+            optional_pair=True, subtypes=(types.Integer(), types.Integer())
+        )
+        result = cv.deserialize("42")
+        assert result == (42, 42)
+
+        cv = types.Pair(
+            optional_pair=True, subtypes=(types.Path(), types.String())
+        )
+        result = cv.deserialize("/dev/null")
+        assert result == ("/dev/null", "/dev/null")
+
+        cv = types.Pair(
+            optional_pair=True, subtypes=(types.Port(), types.Port())
+        )
+        result = cv.deserialize("443")
+        assert result == (443, 443)
+
+    def test_deserialize_with_custom_subtypes_optional_separator_mixed_types(
+        self,
+    ):
+        cv = types.Pair(
+            optional_pair=True, subtypes=(types.String(), types.Integer())
+        )
+
+        errmsg = re.escape("invalid literal for int() with base 10")
+
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc")
+
+    def test_deserialize_with_optional_custom_subtypes(self):
+        cv = types.Pair(subtypes=(types.String(), types.String(optional=True)))
+        result = cv.deserialize("abc|")
+        assert result == ("abc", None)
+
+        cv = types.Pair(subtypes=(types.String(optional=True), types.String()))
+        result = cv.deserialize("|def")
+        assert result == (None, "def")
+
+        cv = types.Pair(
+            subtypes=(types.String(optional=True), types.String(optional=True))
+        )
+        result = cv.deserialize("|")
+        assert result == (None, None)
+
+    def test_serialize(self):
+        cv = types.Pair()
+        result = cv.serialize(("abc", "def"))
+        assert result == "abc|def"
+        result = cv.serialize(("abc", None))
+        assert result == "abc|"
+        result = cv.serialize((None, "abc"))
+        assert result == "|abc"
+
+        cv = types.Pair(subtypes=(types.String(), types.Integer()))
+        result = cv.serialize(("abc", 42))
+        assert result == "abc|42"
+        result = cv.serialize(("abc", None))
+        assert result == "abc|"
+        result = cv.serialize((None, 42))
+        assert result == "|42"
+
+        cv = types.Pair(subtypes=(types.String(), types.Path()))
+        result = cv.serialize(("null", "/dev/null"))
+        assert result == "null|/dev/null"
+        result = cv.serialize(("tmp", types._ExpandedPath("/tmp", "/tmp")))
+        assert result == "tmp|/tmp"
+        result = cv.serialize(("null", None))
+        assert result == "null|"
+        result = cv.serialize(
+            (None, types._ExpandedPath("/dev/null", "/dev/null"))
+        )
+        assert result == "|/dev/null"
+
+    @pytest.mark.parametrize(
+        "sep", ("!", "@", "#", "$", "%", "^", "&", "*", "/", "\\")
+    )
+    def test_serialize_with_custom_separator(self, sep: str):
+        cv = types.Pair(separator=sep)
+        result = cv.serialize(("abc", "def"))
+        assert result == f"abc{sep}def"
+        result = cv.serialize(("abc", None))
+        assert result == f"abc{sep}"
+        result = cv.serialize((None, "abc"))
+        assert result == f"{sep}abc"
+
+        cv = types.Pair(
+            separator=sep, subtypes=(types.String(), types.Integer())
+        )
+        result = cv.serialize(("abc", 42))
+        assert result == f"abc{sep}42"
+        result = cv.serialize(("abc", None))
+        assert result == f"abc{sep}"
+        result = cv.serialize((None, 42))
+        assert result == f"{sep}42"
+
+        cv = types.Pair(separator=sep, subtypes=(types.String(), types.Path()))
+        result = cv.serialize(("null", "/dev/null"))
+        assert result == f"null{sep}/dev/null"
+        result = cv.serialize(("tmp", types._ExpandedPath("/tmp", "/tmp")))
+        assert result == f"tmp{sep}/tmp"
+        result = cv.serialize(("null", None))
+        assert result == f"null{sep}"
+        result = cv.serialize(
+            (None, types._ExpandedPath("/dev/null", "/dev/null"))
+        )
+        assert result == f"{sep}/dev/null"
+
+    def test_serialize_returns_single_value_with_optional_pair(self):
+        cv = types.Pair(optional_pair=True)
+
+        result = cv.serialize(("abc", "abc"))
+        assert result == "abc"
+
+        result = cv.serialize(("abc", "def"))
+        assert result == "abc|def"
+
+        result = cv.serialize(("abc", "abc"), display=True)
+        assert result == "abc|abc"
+
+        result = cv.serialize(("abc", "def"), display=True)
+        assert result == "abc|def"
+
+    def test_deserialize_nested_pair_success(self):
+        cv = types.Pair(subtypes=(types.Integer(), types.Pair()))
+        result = cv.deserialize("50|def|ghi")
+        assert result == (50, ("def", "ghi"))
+
+        cv = types.Pair(
+            separator="#",
+            subtypes=(
+                types.String(),
+                types.Pair(subtypes=(types.Integer(), types.Integer())),
+            ),
+        )
+        result = cv.deserialize("xyz#4|-5")
+        assert result == ("xyz", (4, -5))
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(
+                    separator="*", subtypes=(types.Float(), types.Float())
+                ),
+                types.String(),
+            ),
+        )
+        result = cv.deserialize("42*2.5|abc")
+        assert result == ((42, 2.5), "abc")
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(separator="#"),
+                types.Pair(),
+            ),
+        )
+        result = cv.deserialize("abc#def|ghi|jkl")
+        assert result == (("abc", "def"), ("ghi", "jkl"))
+
+    def test_deserialize_nested_pair_fail(self):
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(),
+                types.String(),
+            ),
+        )
+        errmsg = (
+            "^"
+            + re.escape("Config value must include '|' separator: abc")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|def|ghi")
+
+        cv = types.Pair(
+            optional_pair=True,
+            subtypes=(
+                types.Pair(),
+                types.String(),
+            ),
+        )
+        errmsg = (
+            "^"
+            + re.escape("Config value must include '|' separator: abc")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|def|ghi")
+
+        cv = types.Pair(
+            optional_pair=True,
+            subtypes=(
+                types.String(),
+                types.Pair(),
+            ),
+        )
+        errmsg = (
+            "^"
+            + re.escape("Config value must include '|' separator: def")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|def")
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(),
+                types.Pair(separator="#"),
+            ),
+        )
+        errmsg = (
+            "^"
+            + re.escape("Config value must include '|' separator: abc")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|def|ghi#jkl")
+
+    def test_deserialize_nested_pair_optional(self):
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(optional=True),
+                types.Pair(),
+            )
+        )
+        result = cv.deserialize("|abc|def")
+        assert result == (None, ("abc", "def"))
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(),
+                types.Pair(optional=True),
+            ),
+        )
+        errmsg = (
+            "^"
+            + re.escape("Config value must include '|' separator: abc")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|def|")
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(separator="#"),
+                types.Pair(optional=True),
+            ),
+        )
+        result = cv.deserialize("abc#def|")
+        assert result == (("abc", "def"), None)
+
+        cv = types.Pair(
+            separator="#",
+            subtypes=(
+                types.Pair(),
+                types.Pair(optional=True),
+            ),
+        )
+        result = cv.deserialize("mno|xyz#")
+        assert result == (("mno", "xyz"), None)
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(optional=True),
+                types.Pair(optional=True),
+            ),
+        )
+        result = cv.deserialize("|")
+        assert result == (None, None)
+
+    def test_deserialize_nested_pair_optional_pair(self):
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(optional_pair=True),
+                types.String(),
+            ),
+        )
+        result = cv.deserialize("abc|def|ghi")
+        assert result == (("abc", "abc"), "def|ghi")
+
+        cv = types.Pair(
+            subtypes=(
+                types.String(),
+                types.Pair(optional_pair=True),
+            )
+        )
+        result = cv.deserialize("abc|def")
+        assert result == ("abc", ("def", "def"))
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(optional_pair=True),
+                types.Pair(),
+            ),
+        )
+        result = cv.deserialize("abc|def|ghi")
+        assert result == (("abc", "abc"), ("def", "ghi"))
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(),
+                types.Pair(optional_pair=True),
+            ),
+        )
+        errmsg = (
+            "^"
+            + re.escape("Config value must include '|' separator: abc")
+            + "$"
+        )
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("abc|def|ghi")
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(separator="#"),
+                types.Pair(optional_pair=True),
+            ),
+        )
+        result = cv.deserialize("abc#def|ghi")
+        assert result == (("abc", "def"), ("ghi", "ghi"))
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(optional_pair=True),
+                types.Pair(optional_pair=True),
+            ),
+        )
+        result = cv.deserialize("abc|def")
+        assert result == (("abc", "abc"), ("def", "def"))
+
+        errmsg = re.escape("must be set")
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("|")
+
+        cv = types.Pair(
+            optional_pair=True,
+            subtypes=(
+                types.Pair(optional_pair=True),
+                types.Pair(optional_pair=True),
+            ),
+        )
+        result = cv.deserialize("abc")
+        assert result == (("abc", "abc"), ("abc", "abc"))
+
+    def test_serialize_nested_pair(self):
+        cv = types.Pair(subtypes=(types.String(), types.Pair()))
+        result = cv.serialize(("abc", ("def", "ghi")))
+        assert result == "abc|def|ghi"
+
+        cv = types.Pair(
+            subtypes=(
+                types.Pair(separator="#"),
+                types.String(),
+            ),
+        )
+        result = cv.serialize((("abc", "def"), "ghi"))
+        assert result == "abc#def|ghi"
+
+        cv = types.Pair(
+            separator="#",
+            subtypes=(types.Pair(), types.Pair()),
+        )
+        result = cv.serialize((("abc", "def"), ("ghi", "jkl")))
+        assert result == "abc|def#ghi|jkl"
+
+        cv = types.Pair(
+            optional_pair=True,
+            subtypes=(
+                types.Pair(optional_pair=True),
+                types.Pair(optional_pair=True),
+            ),
+        )
+        result = cv.serialize((("abc", "abc"), ("abc", "abc")))
+        assert result == "abc"
+        result = cv.serialize((("abc", "abc"), ("abc", "abc")), display=True)
+        assert result == "abc|abc|abc|abc"
+
+
 class TestList:
-    # TODO: add test_deserialize_ignores_blank
-    # TODO: add test_serialize_ignores_blank
     # TODO: add test_deserialize_handles_escapes
 
     def test_deserialize_conversion_success(self):
@@ -381,11 +1081,29 @@ class TestList:
         result = cv.deserialize(b" foo,bar\nbar\nbaz")
         assert result == ("foo,bar", "bar", "baz")
 
+    def test_deserialize_conversion_success_unique(self):
+        cv = types.List(unique=True)
+
+        result = cv.deserialize("foo, bar, baz ")
+        assert result == {"foo", "bar", "baz"}
+
+        result = cv.deserialize("foo,bar,foo,baz,foo")
+        assert result == {"foo", "bar", "baz"}
+
+        result = cv.deserialize(" foo,bar\nbar\nbaz")
+        assert result == {"foo,bar", "bar", "baz"}
+
     def test_deserialize_creates_tuples(self):
         cv = types.List(optional=True)
 
         assert isinstance(cv.deserialize(b"foo,bar,baz"), tuple)
         assert isinstance(cv.deserialize(b""), tuple)
+
+    def test_deserialize_creates_frozensets(self):
+        cv = types.List(optional=True, unique=True)
+
+        assert isinstance(cv.deserialize("foo,bar,baz"), frozenset)
+        assert isinstance(cv.deserialize(""), frozenset)
 
     def test_deserialize_decodes_utf8(self):
         cv = types.List()
@@ -416,13 +1134,39 @@ class TestList:
 
         assert cv.deserialize(b"") == ()
 
-    def test_serialize(self):
+    @pytest.mark.parametrize(
+        "value",
+        (
+            "foo,,bar,,baz",
+            "foo, ,bar, , baz",
+            "foo, ,bar, , baz, ",
+            "foo\n\nbar\n\nbaz\n",
+            "foo \n bar \n \n baz",
+        ),
+    )
+    def test_deserialize_ignores_blanks(self, value):
+        cv = types.List()
+
+        result = cv.deserialize(value)
+        assert result == ("foo", "bar", "baz")
+
+    def test_serialize_tuples(self):
         cv = types.List()
 
         result = cv.serialize(("foo", "bar", "baz"))
 
         assert isinstance(result, str)
         assert result == "\n  foo\n  bar\n  baz"
+
+    def test_serialize_sets(self):
+        cv = types.List(unique=True)
+
+        result = cv.serialize({"foo", "bar", "baz"})
+
+        assert isinstance(result, str)
+        assert "\n  foo" in result
+        assert "\n  bar" in result
+        assert "\n  baz" in result
 
     def test_serialize_none(self):
         cv = types.List()
@@ -431,6 +1175,97 @@ class TestList:
 
         assert isinstance(result, str)
         assert result == ""
+
+    @pytest.mark.parametrize(
+        "value",
+        (
+            ("foo", "", "bar", "baz"),
+            ("foo", "bar", "", "", "baz"),
+        ),
+    )
+    def test_serialize_ignores_blanks(self, value):
+        cv = types.List()
+
+        result = cv.serialize(value)
+
+        assert result == "\n  foo\n  bar\n  baz"
+
+    def test_serialize_ignores_blanks_sets(self):
+        cv = types.List(unique=True)
+
+        result = cv.serialize({"foo", "", "bar", "baz"})
+        assert "\n  foo" in result
+        assert "\n  bar" in result
+        assert "\n  baz" in result
+        assert "\n  \n" not in result
+        assert not result.endswith("\n  ")
+
+    def test_deserialize_with_custom_subtype(self):
+        cv = types.List(subtype=types.Integer())
+        expected = (1, 2, 3)
+        assert cv.deserialize("1, 2, 3") == expected
+        assert cv.deserialize("1\n2\n3") == expected
+        assert cv.deserialize("\n  1\n  2\n  3") == expected
+
+        cv = types.List(subtype=types.Pair())
+        expected = (("a", "x"), ("b", "y"), ("c", "z"))
+        assert cv.deserialize("a|x,b|y,c|z") == expected
+        assert cv.deserialize("a|x\nb|y\nc|z") == expected
+        assert cv.deserialize("\n  a|x\n  b|y\n  c|z") == expected
+
+        cv = types.List(
+            subtype=types.Pair(subtypes=(types.Integer(), types.Integer())),
+        )
+        expected = ((7, 1), (8, 2), (9, 3))
+        assert cv.deserialize("7|1,8|2,9|3") == expected
+        assert cv.deserialize("7|1\n8|2\n9|3") == expected
+        assert cv.deserialize("\n  7|1\n  8|2\n  9|3") == expected
+
+        with mock.patch("socket.getaddrinfo") as getaddrinfo_mock:
+            cv = types.List(
+                subtype=types.Pair(subtypes=(types.Hostname(), types.Port())),
+            )
+            expected = (("localhost", 8080), ("example.com", 443))
+            assert cv.deserialize("localhost|8080,example.com|443") == expected
+            assert cv.deserialize("localhost|8080\nexample.com|443") == expected
+            call_localhost = mock.call("localhost", None)
+            call_examplecom = mock.call("example.com", None)
+            assert getaddrinfo_mock.mock_calls == [
+                call_localhost,
+                call_examplecom,
+                call_localhost,
+                call_examplecom,
+            ]
+
+    def test_deserialize_with_custom_subtype_enforces_required(self):
+        cv = types.List(subtype=types.Float())
+
+        errmsg = re.escape("must be set")
+        with pytest.raises(ValueError, match=errmsg):
+            cv.deserialize("")
+
+    def test_deserialize_with_custom_subtype_respects_optional(self):
+        cv = types.List(optional=True, subtype=types.Float())
+
+        assert cv.deserialize("") == ()
+
+    def test_serialize_with_custom_subtype(self):
+        cv = types.List(subtype=types.Integer())
+        result = cv.serialize((1, 2, 3))
+        assert result == "\n  1\n  2\n  3"
+
+        cv = types.List(subtype=types.Pair())
+        result = cv.serialize((("a", "x"), ("b", "y"), ("c", "z")))
+        assert result == "\n  a|x\n  b|y\n  c|z"
+
+        cv = types.List(
+            subtype=types.Pair(
+                separator="#",
+                subtypes=(types.Integer(), types.Integer()),
+            ),
+        )
+        result = cv.serialize(((7, 1), (8, 2), (9, 3)))
+        assert result == "\n  7#1\n  8#2\n  9#3"
 
 
 class TestLogColor:
@@ -622,3 +1457,8 @@ class TestPath:
         cv = types.Path()
 
         assert cv.serialize("æøå") == "æøå"
+
+    def test_serialize_none(self):
+        cv = types.Path()
+
+        assert cv.serialize(None) == ""


### PR DESCRIPTION
- Added new Float type. It's very similar to the existing Integer type,
  but accepts floating point numbers, and doesn't allow you to set
  choices.
- Added new Pair type, for when you want to accept a pair of values in a
  single config setting. Pairs default to a pair of strings, but you can
  set either subtype to whatever type you want (including nested pairs).
- Added transformer property to String type. This allows you to apply an
  arbitrary transformation to individual config settings that could
  utimately be anything at all.
- If a transformation is applied to a String config value, it will now
  return a subclass of the built-in str type. This subclass stores the
  original value as well as the transformed value, so that it can be
  re-serialised correctly.
- The "Expected Path" type originally created for the Path type is (for
  now) just a subclass of the "Transformed Value" class, due to the
  duplicate implementation. In future, this should be updated to return
  pathlib Path objects, not strings.
- Made Secret type pass through the transformer property correctly to
  its String parent class.
- Lists can now return a frozenset instead of a tuple, configured by the
  "unique" property.
- Lists now accept an arbitrary subtype, similar to the Pair type. This
  can be any type at all, including Pairs.
- Resolved a couple of todo comments regarding missing tests for the
  List type.
- The Path type will now correctly serialise None to an empty string.