### PR TITLE
Ignore N818 flake8 lint on existing exception classes (#1988)

### DIFF
--- a/mopidy/exceptions.py
+++ b/mopidy/exceptions.py
@@ -1,4 +1,4 @@
-class MopidyException(Exception):
+class MopidyException(Exception):  # noqa: N818
     def __init__(self, message, *args, **kwargs):
         super().__init__(message, *args, **kwargs)
         self._message = message
@@ -39,13 +39,13 @@ class ScannerError(MopidyException):
     pass
 
 
-class TracklistFull(CoreError):
+class TracklistFull(CoreError):  # noqa: N818
     def __init__(self, message, errno=None):
         super().__init__(message, errno)
         self.errno = errno
 
 
-class AudioException(MopidyException):
+class AudioException(MopidyException):  # noqa: N818
     pass
 
 


### PR DESCRIPTION
Fixes master branch build