### PR TITLE
bug fix for invalid verbosity level setting it zero by default

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ v3.2.1 (UNRELEASED)
 - Core: Fix TypeError exception when playing track with unnamed artists.
   (Fixes: :issue:`1991`, PR: :issue:`2012`)
 
+- Core: Fixes invalid verbosity logging levels.
+  (Fixes: :issue:`1947`)
 
 v3.2.0 (2021-07-08)
 ===================

--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -125,7 +125,7 @@ def get_verbosity_level(
     if args_verbosity_level:
         result = base_verbosity_level + args_verbosity_level
     else:
-        result = base_verbosity_level + logging_config["verbosity"]
+        result = base_verbosity_level + logging_config["verbosity"] or 0
 
     if result < min(LOG_LEVELS.keys()):
         result = min(LOG_LEVELS.keys())


### PR DESCRIPTION
fixes: #1947 