### PR TITLE
Add exponential scale option to softwaremixer

### DIFF
--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -15,6 +15,7 @@ from mopidy.config.types import (
     DeprecatedValue,
     Hostname,
     Integer,
+    Float,
     List,
     LogColor,
     LogLevel,

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -142,6 +142,29 @@ class Integer(ConfigValue):
         return value
 
 
+class Float(ConfigValue):
+    """Floating point value."""
+
+    def __init__(
+        self, minimum=None, maximum=None, choices=None, optional=False
+    ):
+        self._required = not optional
+        self._minimum = minimum
+        self._maximum = maximum
+        self._choices = choices
+
+    def deserialize(self, value):
+        value = decode(value)
+        validators.validate_required(value, self._required)
+        if not value:
+            return None
+        value = float(value)
+        validators.validate_choice(value, self._choices)
+        validators.validate_minimum(value, self._minimum)
+        validators.validate_maximum(value, self._maximum)
+        return value
+
+
 class Boolean(ConfigValue):
     """Boolean value.
 

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -81,8 +81,9 @@ class Mixer:
         either because of a call to :meth:`set_volume` or because of any
         external entity changing the volume.
         """
-        logger.debug("Mixer event: volume_changed(volume=%d)", round(self.volume_filter_out(volume)))
-        MixerListener.send("volume_changed", volume=round(self.volume_filter_out(volume)))
+        new_volume = round(self.volume_filter_out(volume))
+        logger.debug("Mixer event: volume_changed(volume=%d)", new_volume)
+        MixerListener.send("volume_changed", volume=new_volume)
 
     def volume_filter_in(self, volume):
         """

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -81,8 +81,50 @@ class Mixer:
         either because of a call to :meth:`set_volume` or because of any
         external entity changing the volume.
         """
-        logger.debug("Mixer event: volume_changed(volume=%d)", volume)
-        MixerListener.send("volume_changed", volume=volume)
+        logger.debug("Mixer event: volume_changed(volume=%d)", round(self.volume_filter_out(volume)))
+        MixerListener.send("volume_changed", volume=round(self.volume_filter_out(volume)))
+
+    def volume_filter_in(self, volume):
+        """
+        Common filtering method to allow scaling/modifying volumes to
+        different scales. The IN method accepts the UI-visible slider
+        volume and returns the internal volume for the mixer.
+
+        Note that this function treats volumes as floating point number
+        to allow precise volume scaling, so any systems that require
+        integer representation to intentionally round the return values
+        to integers. (This is necessary to achieve smooth outputs with
+        some types of volume curves.)
+
+        *MAY be implemented by subclass.*
+
+        :param volume: Volume in the range [0..100]
+        :type volume: float
+
+        :rtype: float in range [0..100]
+        """
+        return volume
+
+    def volume_filter_out(self, volume):
+        """
+        Common filtering method to allow scaling/modifying volumes to
+        different scales. The OUT method accepts the internal volume
+        from the mixer and returns the UI-visible slider volume level.
+
+        Note that this function treats volumes as floating point number
+        to allow precise volume scaling, so any systems that require
+        integer representation to intentionally round the return values
+        to integers. (This is necessary to achieve smooth outputs with
+        some types of volume curves.)
+
+        *MAY be implemented by subclass.*
+
+        :param volume: Volume in the range [0..100]
+        :type volume: float
+
+        :rtype: float in range [0..100]
+        """
+        return volume
 
     def get_mute(self) -> Optional[bool]:
         """

--- a/mopidy/softwaremixer/__init__.py
+++ b/mopidy/softwaremixer/__init__.py
@@ -21,6 +21,11 @@ class Extension(ext.Extension):
         schema["volume_scale"] = config.String(
             choices=("linear", "exp")
         )
+        # NOTE: 1 is straight linear like the default software mixer, while
+        # 3 is an extremely deep curve that goes beyond usefulness in my tests.
+        # The sweet spot on my system is somewhere between about 1.2 and 1.5, but
+        # for audio hardware that has a different inherent volume profile (?),
+        # allowing values up to 3 may be useful.
         schema["volume_exp"] = config.Float(minimum=1, maximum=3)
         return schema
 

--- a/mopidy/softwaremixer/__init__.py
+++ b/mopidy/softwaremixer/__init__.py
@@ -16,6 +16,12 @@ class Extension(ext.Extension):
 
     def get_config_schema(self):
         schema = super().get_config_schema()
+        schema["min_volume"] = config.Integer(minimum=0, maximum=100)
+        schema["max_volume"] = config.Integer(minimum=0, maximum=100)
+        schema["volume_scale"] = config.String(
+            choices=("linear", "exp")
+        )
+        schema["volume_exp"] = config.Float(minimum=1, maximum=3)
         return schema
 
     def setup(self, registry):

--- a/mopidy/softwaremixer/ext.conf
+++ b/mopidy/softwaremixer/ext.conf
@@ -1,2 +1,6 @@
 [softwaremixer]
 enabled = true
+min_volume = 0
+max_volume = 100
+volume_scale = linear
+volume_exp = 1

--- a/mopidy/softwaremixer/mixer.py
+++ b/mopidy/softwaremixer/mixer.py
@@ -17,6 +17,12 @@ class SoftwareMixer(pykka.ThreadingActor, mixer.Mixer):
         self._audio_mixer = None
         self._initial_volume = None
         self._initial_mute = None
+        self._logical_volume = None
+
+        self.min_volume = config["softwaremixer"]["min_volume"]
+        self.max_volume = config["softwaremixer"]["max_volume"]
+        self.volume_scale = config["softwaremixer"]["volume_scale"]
+        self.volume_exp = config["softwaremixer"]["volume_exp"]
 
     def setup(self, mixer_ref):
         self._audio_mixer = mixer_ref
@@ -36,14 +42,41 @@ class SoftwareMixer(pykka.ThreadingActor, mixer.Mixer):
     def get_volume(self):
         if self._audio_mixer is None:
             return None
-        return self._audio_mixer.get_volume().get()
+        return int(self.mixer_volume_to_volume(self._audio_mixer.get_volume().get()))
 
     def set_volume(self, volume):
+        self._logical_volume = self.volume_to_mixer_volume(volume)
         if self._audio_mixer is None:
-            self._initial_volume = volume
+            self._initial_volume = int(self._logical_volume)
             return False
-        self._audio_mixer.set_volume(volume)
+        self._audio_mixer.set_volume(int(self._logical_volume))
         return True
+
+    def mixer_volume_to_volume(self, mixer_volume):
+        volume = mixer_volume
+        if mixer_volume == int(self._logical_volume):
+            # start calculation with exact original value to avoid
+            # loss of precision from mixer/native conversions
+            volume = self._logical_volume
+        if self.volume_scale == "exp":
+            coeff = pow(10, 2 * (self.volume_exp - 1))
+            volume = pow(coeff * volume, 1/self.volume_exp)
+        volume = (
+            (volume - self.min_volume)
+            * 100.0
+            / (self.max_volume - self.min_volume)
+        )
+        return volume
+
+    def volume_to_mixer_volume(self, volume):
+        mixer_volume = (
+            self.min_volume
+            + volume * (self.max_volume - self.min_volume) / 100.0
+        )
+        if self.volume_scale == "exp":
+            coeff = pow(10, 2 * (self.volume_exp - 1))
+            mixer_volume = pow(mixer_volume, self.volume_exp) / coeff
+        return mixer_volume
 
     def get_mute(self):
         if self._audio_mixer is None:

--- a/mopidy/softwaremixer/mixer.py
+++ b/mopidy/softwaremixer/mixer.py
@@ -19,10 +19,11 @@ class SoftwareMixer(pykka.ThreadingActor, mixer.Mixer):
         self._initial_mute = None
         self._logical_volume = None
 
-        self.min_volume = config["softwaremixer"]["min_volume"]
-        self.max_volume = config["softwaremixer"]["max_volume"]
-        self.volume_scale = config["softwaremixer"]["volume_scale"]
-        self.volume_exp = config["softwaremixer"]["volume_exp"]
+        self.config = config
+        self.min_volume = self.config["softwaremixer"]["min_volume"]
+        self.max_volume = self.config["softwaremixer"]["max_volume"]
+        self.volume_scale = self.config["softwaremixer"]["volume_scale"]
+        self.volume_exp = self.config["softwaremixer"]["volume_exp"]
 
     def setup(self, mixer_ref):
         self._audio_mixer = mixer_ref

--- a/mopidy/softwaremixer/mixer.py
+++ b/mopidy/softwaremixer/mixer.py
@@ -42,14 +42,18 @@ class SoftwareMixer(pykka.ThreadingActor, mixer.Mixer):
     def get_volume(self):
         if self._audio_mixer is None:
             return None
-        return int(self.mixer_volume_to_volume(self._audio_mixer.get_volume().get()))
+        mixer_volume = self._audio_mixer.get_volume().get()
+        if mixer_volume == round(self._logical_volume):
+            mixer_volume = self._logical_volume
+        volume = self.volume_filter_out(mixer_volume)
+        return round(volume)
 
     def set_volume(self, volume):
-        self._logical_volume = self.volume_to_mixer_volume(volume)
         if self._audio_mixer is None:
-            self._initial_volume = int(self._logical_volume)
+            self._initial_volume = volume
             return False
-        self._audio_mixer.set_volume(int(self._logical_volume))
+        self._logical_volume = self.volume_filter_in(volume)
+        self._audio_mixer.set_volume(round(self._logical_volume))
         return True
 
     def volume_filter_in(self, volume):

--- a/mopidy/softwaremixer/mixer.py
+++ b/mopidy/softwaremixer/mixer.py
@@ -45,6 +45,16 @@ class SoftwareMixer(pykka.ThreadingActor, mixer.Mixer):
             return None
         mixer_volume = self._audio_mixer.get_volume().get()
         if mixer_volume == round(self._logical_volume):
+            # If the current logical volume yields a filtered output
+            # volume that matches what we currently have, then return
+            # the current logical volume rather than the value obtained
+            # by passing it through the reverse filter. This retains
+            # precision in cases where rounding in the middle of the
+            # conversion/calculation process would otherwise lose it.
+            # For example, an aggressive "volume_exp" value (>1.5) may
+            # result in logical values of 0-7 all rounding to 0, which 
+            # reverse-filters back to a 0 logical value; this code
+            # retains the original input value.
             mixer_volume = self._logical_volume
         volume = self.volume_filter_out(mixer_volume)
         return round(volume)


### PR DESCRIPTION
I have what is probably an uncommon use case, but I think my solution is general and flexible enough to warrant a PR. Basically, I have a collection of RasPi devices, each with a HiFiBerry DAC on top, each feeding into ceiling-mounted speakers in different rooms of the house. I recently switched over to use PulseAudio as a backend to better facilitate multiple simultaneous streams to the same device (music, white noise, door chimes) with independent volume controls. Previously, I had been using ALSA and the `alsamixer` extension, which worked great.

The problem I ran into with `softwaremixer` is that the volume scale made it ridiculously hard to achieve suitably low volumes at the bottom end. I suspect PulseAudio's internal mixing is responsible for this, but regardless, I needed an exponential curve that hugs the low end of the output for a while before rising up to 100% at the top. So, I implemented it with a `volume_scale` setting in `softwaremixer` (like the one in `alsamixer`) and a new `volume_exp` option that is a floating point number between 1 (linear) and 3 (extreme curve). I pulled in the min/max options too, though I haven't changed them in my setup. The default values for all settings result in behavior identical to the original `softwaremixer` implementation, so this change shouldn't break anything.

I made one other modification to the `softwaremixer` code, which is the addition of logical volume storage that retains the precise float value calculated by the `mixer_volume_to_volume()` conversion function. I had to do this because the periodic web UI updates that convert back the other way to ensure the web UI follows volume changes made elsewhere were changing the slider position towards the low end, since multiple input values (e.g. 1 through 5) might generate the same rounded/integer output value for more extreme curves. Now, it returns the stored input value if the rounded output matches, so the slider doesn't jump around as much. (I also needed to do this for compatibility with a little physical media controller I'm building for my daughter, which couldn't adjust the volume in +1/-1 increments properly otherwise.)

The only change I had to make outside of the `softwaremixer` module was to add a new `Float` type to the config types code, since personally I settled on a value of 1.25 for my exponent to achieve the feel I wanted.