### PR TITLE
Fix missing CORS headers on RPC response.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -44,6 +44,9 @@ v3.2.1 (UNRELEASED)
   ``musicbrainz_trackid``, and ``disc_no`` to the permitted search query
   fields. (Fixes: :issue:`1900`, PR: :issue:`1899`)
 
+- HTTP: Fix missing CORS headers on RPC response. (Fixes: :issue:`2028`,
+  PR: :issue:`2029`)
+
 
 v3.2.0 (2021-07-08)
 ===================

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -201,6 +201,17 @@ class JsonRpcHandler(tornado.web.RequestHandler):
 
     def post(self):
         if self.csrf_protection:
+            origin = self.request.headers.get("Origin")
+
+            if not check_origin(
+                origin, self.request.headers, self.allowed_origins
+            ):
+                self.set_status(403, f"Access denied for origin {origin}")
+                return
+
+            self.set_header("Access-Control-Allow-Origin", f"{origin}")
+            self.set_header("Access-Control-Allow-Headers", "Content-Type")
+
             content_type = (
                 self.request.headers.get("Content-Type", "")
                 .split(";")[0]

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -157,58 +157,6 @@ class MopidyRPCHandlerTest(HttpServerTest):
             "result": mopidy.__version__,
         } == tornado.escape.json_decode(response.body)
 
-    def test_should_return_extra_headers(self):
-        response = self.fetch("/mopidy/rpc", method="HEAD")
-
-        assert "Accept" in response.headers
-        assert "X-Mopidy-Version" in response.headers
-        assert "Cache-Control" in response.headers
-        assert "Content-Type" in response.headers
-
-    def test_should_require_correct_content_type(self):
-        cmd = tornado.escape.json_encode(
-            {
-                "method": "core.get_version",
-                "params": [],
-                "jsonrpc": "2.0",
-                "id": 1,
-            }
-        )
-
-        response = self.fetch(
-            "/mopidy/rpc",
-            method="POST",
-            body=cmd,
-            headers={"Content-Type": "text/plain"},
-        )
-
-        assert response.code == 415
-        assert response.reason == "Content-Type must be application/json"
-
-    def test_different_origin_returns_access_denied(self):
-        response = self.fetch(
-            "/mopidy/rpc",
-            method="OPTIONS",
-            headers={"Host": "me:6680", "Origin": "http://evil:666"},
-        )
-
-        assert response.code == 403
-        assert response.reason == "Access denied for origin http://evil:666"
-
-    def test_same_origin_returns_cors_headers(self):
-        response = self.fetch(
-            "/mopidy/rpc",
-            method="OPTIONS",
-            headers={"Host": "me:6680", "Origin": "http://me:6680"},
-        )
-
-        assert (
-            response.headers["Access-Control-Allow-Origin"] == "http://me:6680"
-        )
-        assert (
-            response.headers["Access-Control-Allow-Headers"] == "Content-Type"
-        )
-
 
 class MopidyRPCHandlerNoCSRFProtectionTest(HttpServerTest):
     def get_config(self):


### PR DESCRIPTION
Fixes #2028.

Add CORS headers to RPC response.
This fixes a CORS error on chrome.

See #2028 for more information.

