### PR TITLE
Issue #2033: Replace the apt-key command.

### DIFF
--- a/docs/installation/debian.rst
+++ b/docs/installation/debian.rst
@@ -42,7 +42,7 @@ Install from apt.mopidy.com
 
 #. Add the archive's GPG key::
 
-       udo wget -q -O /etc/apt/trusted.gpg.d/mopidy.gpg https://apt.mopidy.com/mopidy.gpg
+       sudo wget -q -O /etc/apt/trusted.gpg.d/mopidy.gpg https://apt.mopidy.com/mopidy.gpg
 
 #. Add the APT repo to your package sources::
 

--- a/docs/installation/debian.rst
+++ b/docs/installation/debian.rst
@@ -42,7 +42,7 @@ Install from apt.mopidy.com
 
 #. Add the archive's GPG key::
 
-       wget -q -O - https://apt.mopidy.com/mopidy.gpg | sudo apt-key add -
+       udo wget -q -O /etc/apt/trusted.gpg.d/mopidy.gpg https://apt.mopidy.com/mopidy.gpg
 
 #. Add the APT repo to your package sources::
 


### PR DESCRIPTION
The apt-key command is deprecated. This uses a different method to add repo keys