### PR TITLE
log: fix typing CI failure

### DIFF
--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -203,7 +203,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
     @property
     def is_tty(self) -> bool:
         isatty = getattr(self.stream, "isatty", None)
-        return isatty and isatty()
+        return isatty is not None and isatty()
 
     def emit(self, record: LogRecord) -> None:
         try:


### PR DESCRIPTION
Fixes Incompatible return value type (got "Optional[Any]", expected "bool")