### PR TITLE
Improve handling of "allowed_origins" HTTP config

### DIFF
--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -23,7 +23,10 @@ class Extension(ext.Extension):
         schema["port"] = config_lib.Port()
         schema["static_dir"] = config_lib.Deprecated()
         schema["zeroconf"] = config_lib.String(optional=True)
-        schema["allowed_origins"] = config_lib.List(optional=True)
+        schema["allowed_origins"] = config_lib.List(
+            unique=True,
+            subtype=config_lib.String(transformer=lambda x: x.lower()),
+        )
         schema["csrf_protection"] = config_lib.Boolean(optional=True)
         schema["default_app"] = config_lib.String(optional=True)
         return schema

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -51,7 +51,7 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     handlers.WebSocketHandler,
                     {
                         "core": self.core,
-                        "allowed_origins": set(),
+                        "allowed_origins": frozenset(),
                         "csrf_protection": True,
                     },
                 )

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -18,7 +18,7 @@ class HttpServerTest(tornado.testing.AsyncHTTPTestCase):
                 "hostname": "127.0.0.1",
                 "port": 6680,
                 "zeroconf": "",
-                "allowed_origins": [],
+                "allowed_origins": frozenset(),
                 "csrf_protection": True,
                 "default_app": "mopidy",
             }


### PR DESCRIPTION
This moves all of the processing for the `allowed_origins` HTTP setting into the config system, allowing it to be more easily reused by other extensions. It takes advantage of some new functionality in the `List` and `String` config types.