### PR TITLE
Added Access-Control-Max-Age to CORS headers

### DIFF
--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -250,6 +250,7 @@ class JsonRpcHandler(tornado.web.RequestHandler):
     def set_cors_headers(self, origin):
         self.set_header("Access-Control-Allow-Origin", f"{origin}")
         self.set_header("Access-Control-Allow-Headers", "Content-Type")
+        self.set_header("Access-Control-Max-Age", "86400")
 
     def options(self):
         if self.csrf_protection:


### PR DESCRIPTION
Added "Access-Control-Max-Age" to CORS headers (using: "self.set_header("Access-Control-Max-Age", "86400")). Now preflight requests can be cached on the browser. This resolves #2043. 