### PR TITLE
Generic mechanism for setting source properties

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -445,6 +445,7 @@ class Audio(pykka.ThreadingActor):
         self._outputs = None
         self._queue = None
         self._about_to_finish_callback = None
+        self._source_setup_callback = None
 
         self._handler = _Handler(self)
         self._appsrc = _Appsrc()
@@ -571,6 +572,10 @@ class Audio(pykka.ThreadingActor):
         else:
             self._appsrc.reset()
 
+        if self._source_setup_callback:
+            logger.debug("Running source-setup callback")
+            self._source_setup_callback(source)
+
         if self._live_stream and hasattr(source.props, "is_live"):
             gst_logger.debug("Enabling live stream mode")
             source.set_live(True)
@@ -664,6 +669,17 @@ class Audio(pykka.ThreadingActor):
         :rtype: boolean
         """
         return self._appsrc.push(buffer_)
+
+    def set_source_setup_callback(self, callback):
+        """
+        Configure audio to use a source-setup callback.
+
+        This should be used to modify source-specific properties such as login
+        details.
+
+        :param callable callback: Callback to run when we setup the source.
+        """
+        self._source_setup_callback = callback
 
     def set_about_to_finish_callback(self, callback):
         """

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -44,6 +44,8 @@ if TYPE_CHECKING:
     Uri = str
     UriScheme = str
 
+    GstElement = TypeVar("GstElement")
+
 
 logger = logging.getLogger(__name__)
 
@@ -295,6 +297,20 @@ class PlaybackProvider:
         """
         return False
 
+    def on_source_setup(self, source: GstElement) -> None:
+        """
+        Called when a new GStreamer source is created, allowing us to configure
+        the source. This runs in the audio thread so should not block.
+
+        *MAY be reimplemented by subclass.*
+
+        :param source: the GStreamer source element
+        :type source: GstElement
+
+        .. versionadded:: 3.4
+        """
+        pass
+
     def change_track(self, track: Track) -> bool:
         """
         Switch to provided track.
@@ -317,6 +333,7 @@ class PlaybackProvider:
             logger.debug("Backend translated URI from %s to %s", track.uri, uri)
         if not uri:
             return False
+        self.audio.set_source_setup_callback(self.on_source_setup).get()
         self.audio.set_uri(
             uri,
             live_stream=self.is_live(uri),


### PR DESCRIPTION
Backends may reimplement `PlaybackProvider.on_source_setup` if they need to set additional source element properties e.g.
for authentication.

We'll need this (or something like this) to set the credentials for `spotifyaudiosrc`. 

Needs some tests.