### PR TITLE
Fix dbus exception where algorithm 'plain' is not supported

### DIFF
--- a/mopidy/config/keyring.py
+++ b/mopidy/config/keyring.py
@@ -41,7 +41,12 @@ def fetch():
         return []
 
     service = _service(bus)
-    session = service.OpenSession("plain", EMPTY_STRING)[1]
+    try:
+        session = service.OpenSession("plain", EMPTY_STRING)[1]
+    except dbus.exceptions.DBusException as e:
+        logger.debug("%s (%s)", FETCH_ERROR, e)
+        return []
+
     items, locked = service.SearchItems({"service": "mopidy"})
 
     if not locked and not items:


### PR DESCRIPTION
I'e been getting a strange error on Kubuntu 22.04. I can run Mopidy as a service, and I can run it from a .desktop file in ~/.config/autostart. But when I try to run it once logged in (ie from a terminal) I get

```
Traceback (most recent call last):
  File "/home/bob/.virtualenvs/mopidy/bin/mopidy", line 33, in <module>
    sys.exit(load_entry_point('Mopidy', 'console_scripts', 'mopidy')())
  File "/home/bob/github/mopidy-dev/mopidy/mopidy/__main__.py", line 55, in main
    config, config_errors = config_lib.load(
  File "/home/bob/github/mopidy-dev/mopidy/mopidy/config/__init__.py", line 111, in load
    raw_config = _load(files, defaults, keyring.fetch() + (overrides or []))
  File "/home/bob/github/mopidy-dev/mopidy/mopidy/config/keyring.py", line 44, in fetch
    session = service.OpenSession("plain", EMPTY_STRING)[1]
  File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 72, in __call__
    return self._proxy_method(*args, **keywords)
  File "/usr/lib/python3/dist-packages/dbus/proxies.py", line 141, in __call__
    return self._connection.call_blocking(self._named_service,
  File "/usr/lib/python3/dist-packages/dbus/connection.py", line 652, in call_blocking
    reply_message = self.send_message_with_reply_and_block(
dbus.exceptions.DBusException: org.freedesktop.DBus.Error.InvalidArgs: Algorithm plain is not supported. (only dh-ietf1024-sha256-aes128-cbc-pkcs7 is supported)

```

I've no desire to understand dbus, and if something can cause an exception then that should be trapped, so I put a try/except block around the offending code.