### PR TITLE
Update library.py suffix => suffix.lower()

### DIFF
--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -64,7 +64,7 @@ class FileLibraryProvider(backend.LibraryProvider):
 
             if (
                 self._excluded_file_extensions
-                and dir_entry.suffix in self._excluded_file_extensions
+                and dir_entry.suffix.lower() in self._excluded_file_extensions
             ):
                 continue
 


### PR DESCRIPTION
file exclusion not working for capital letter extensions as config is changed to lower(), but suffix is not changed if capital letters