### PR TITLE
http: Fixed optional allowed_origins config setting.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,12 @@ This changelog is used to track all major changes to Mopidy.
 For older releases, see :ref:`history`.
 
 
+v3.4.1 (UNRELEASED)
+===================
+
+- HTTP: Fix non-optional ``allowed_origins`` config setting. (PR: :issue:`2066`)
+
+
 v3.4.0 (2022-11-28)
 ===================
 

--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -24,6 +24,7 @@ class Extension(ext.Extension):
         schema["static_dir"] = config_lib.Deprecated()
         schema["zeroconf"] = config_lib.String(optional=True)
         schema["allowed_origins"] = config_lib.List(
+            optional=True,
             unique=True,
             subtype=config_lib.String(transformer=lambda x: x.lower()),
         )

--- a/tests/http/test_extension.py
+++ b/tests/http/test_extension.py
@@ -1,0 +1,35 @@
+from mopidy import config as config_lib
+from mopidy.http import Extension
+
+
+def test_get_default_config():
+    ext = Extension()
+
+    config = ext.get_default_config()
+
+    assert "[http]" in config
+    assert "enabled = true" in config
+
+
+def test_get_config_schema():
+    ext = Extension()
+
+    schema = ext.get_config_schema()
+
+    assert "enabled" in schema
+    assert "hostname" in schema
+    assert "port" in schema
+    assert "zeroconf" in schema
+    assert "allowed_origins" in schema
+    assert "csrf_protection" in schema
+    assert "default_app" in schema
+
+
+def test_default_config_is_valid():
+    ext = Extension()
+
+    config = ext.get_default_config()
+    schema = ext.get_config_schema()
+    _, errors = config_lib.load([], [schema], [config], [])
+
+    assert errors.get("http") is None


### PR DESCRIPTION
This was broken in #2054