### PR TITLE
Require Python >= 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Test: Python 3.7"
-            python: "3.7"
-            tox: py37
-          - name: "Test: Python 3.8"
-            python: "3.8"
-            tox: py38
           - name: "Test: Python 3.9"
             python: "3.9"
             tox: py39
@@ -25,7 +19,7 @@ jobs:
             tox: py310
           - name: "Test: Python 3.11"
             python: "3.11"
-            tox: py310
+            tox: py311
             coverage: true
           - name: "Lint: check-manifest"
             python: "3.11"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,6 +9,15 @@ This changelog is used to track all major changes to Mopidy.
 For older releases, see :ref:`history`.
 
 
+v3.5.0 (UNRELEASED)
+===================
+
+Dependencies
+------------
+
+- Python >= 3.9 is now required. Python 3.7 and 3.8 is no longer supported.
+
+
 v3.4.1 (2022-12-07)
 ===================
 
@@ -49,7 +58,7 @@ v3.3.0 (2022-04-29)
   fields, with the exception of 'any'. Deprecated field 'track' with the
   goal of removing it in the next major release, use 'track_name' instead.
   Backends should support both `track` and `track_name` until they require
-  a version of Mopidy where `track` has been removed. 
+  a version of Mopidy where `track` has been removed.
   (Fixes: :issue:`1900`, PR: :issue:`1899`)
 
 - Core: Add ``musicbrainz_albumid``, ``musicbrainz_artistid``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,7 +15,7 @@ v3.5.0 (UNRELEASED)
 Dependencies
 ------------
 
-- Python >= 3.9 is now required. Python 3.7 and 3.8 is no longer supported.
+- Python >= 3.9 is now required. Python 3.7 and 3.8 are no longer supported.
 
 
 v3.4.1 (2022-12-07)

--- a/docs/devenv.rst
+++ b/docs/devenv.rst
@@ -262,7 +262,7 @@ lints the source code for issues and a ``docs`` environment that tests that the
 documentation can be built. You can also limit tox to just test specific
 environments using the ``-e`` option, e.g. to run just unit tests::
 
-    tox -e py37
+    tox -e py39
 
 To learn more, see the `tox documentation <https://tox.readthedocs.io/>`_ .
 
@@ -270,7 +270,7 @@ To learn more, see the `tox documentation <https://tox.readthedocs.io/>`_ .
 Running unit tests
 ------------------
 
-Under the hood, ``tox -e py37`` will use `pytest <https://docs.pytest.org/>`_
+Under the hood, ``tox -e py39`` will use `pytest <https://docs.pytest.org/>`_
 as the test runner. We can also use it directly to run all tests::
 
     pytest

--- a/docs/installation/pypi.rst
+++ b/docs/installation/pypi.rst
@@ -12,7 +12,7 @@ you can install Mopidy from PyPI using the ``pip`` installer.
 If you are looking to contribute or wish to install from source using ``git``
 please see :ref:`contributing`.
 
-#. First of all, you need Python 3.7 or newer. Check if you have Python and
+#. First of all, you need Python 3.9 or newer. Check if you have Python and
    what version by running::
 
        python3 --version

--- a/mopidy/__init__.py
+++ b/mopidy/__init__.py
@@ -4,9 +4,9 @@ import warnings
 
 import pkg_resources
 
-if not sys.version_info >= (3, 7):
+if not sys.version_info >= (3, 9):
     sys.exit(
-        f"ERROR: Mopidy requires Python >= 3.7, "
+        f"ERROR: Mopidy requires Python >= 3.9, "
         f"but found {platform.python_version()}."
     )
 

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -8,9 +8,7 @@ import pykka
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, List, Optional, Set, TypeVar, Union
-
-    from typing_extensions import Literal
+    from typing import Any, Literal, Optional, TypeVar, Union
 
     from mopidy.models import Image, Playlist, Ref, SearchResult, Track
 
@@ -39,7 +37,7 @@ if TYPE_CHECKING:
 
     F = TypeVar("F")
     QueryValue = Union[str, int]
-    Query = Dict[F, List[QueryValue]]
+    Query = dict[F, list[QueryValue]]
 
     Uri = str
     UriScheme = str
@@ -88,7 +86,7 @@ class Backend:
     playlists: Optional[PlaylistsProvider] = None
 
     #: List of URI schemes this backend can handle.
-    uri_schemes: List[UriScheme] = []
+    uri_schemes: list[UriScheme] = []
 
     # Because the providers is marked as pykka.traversable(), we can't get()
     # them from another actor, and need helper methods to check if the
@@ -134,7 +132,7 @@ class LibraryProvider:
     def __init__(self, backend: Backend) -> None:
         self.backend = backend
 
-    def browse(self, uri: Uri) -> List[Ref]:
+    def browse(self, uri: Uri) -> list[Ref]:
         """
         See :meth:`mopidy.core.LibraryController.browse`.
 
@@ -147,7 +145,7 @@ class LibraryProvider:
 
     def get_distinct(
         self, field: DistinctField, query: Optional[Query[DistinctField]] = None
-    ) -> Set[str]:
+    ) -> set[str]:
         """
         See :meth:`mopidy.core.LibraryController.get_distinct`.
 
@@ -160,7 +158,7 @@ class LibraryProvider:
         """
         return set()
 
-    def get_images(self, uris: List[Uri]) -> Dict[Uri, List[Image]]:
+    def get_images(self, uris: list[Uri]) -> dict[Uri, list[Image]]:
         """
         See :meth:`mopidy.core.LibraryController.get_images`.
 
@@ -170,7 +168,7 @@ class LibraryProvider:
         """
         return {}
 
-    def lookup(self, uri: Uri) -> Dict[Uri, List[Track]]:
+    def lookup(self, uri: Uri) -> dict[Uri, list[Track]]:
         """
         See :meth:`mopidy.core.LibraryController.lookup`.
 
@@ -189,9 +187,9 @@ class LibraryProvider:
     def search(
         self,
         query: Query[SearchField],
-        uris: Optional[List[Uri]] = None,
+        uris: Optional[list[Uri]] = None,
         exact: bool = False,
-    ) -> List[SearchResult]:
+    ) -> list[SearchResult]:
         """
         See :meth:`mopidy.core.LibraryController.search`.
 
@@ -402,7 +400,7 @@ class PlaylistsProvider:
     def __init__(self, backend: Backend) -> None:
         self.backend = backend
 
-    def as_list(self) -> List[Ref]:
+    def as_list(self) -> list[Ref]:
         """
         Get a list of the currently available playlists.
 
@@ -416,7 +414,7 @@ class PlaylistsProvider:
         """
         raise NotImplementedError
 
-    def get_items(self, uri: Uri) -> Optional[List[Ref]]:
+    def get_items(self, uri: Uri) -> Optional[list[Ref]]:
         """
         Get the items in a playlist specified by ``uri``.
 

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -273,7 +273,7 @@ class Pair(ConfigValue):
         ):
             return serialized_first_value
         else:
-            return "{0}{1}{2}".format(
+            return "{}{}{}".format(
                 serialized_first_value,
                 self._separator,
                 serialized_second_value,

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -11,20 +11,21 @@ from mopidy import exceptions
 from mopidy.internal import path
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
     from pathlib import Path
-    from typing import Any, Dict, Iterator, List, Optional, Type
+    from typing import Any, Optional
 
     from mopidy.commands import Command
     from mopidy.config import ConfigSchema
 
-    Config = Dict[str, Dict[str, Any]]
+    Config = dict[str, dict[str, Any]]
 
 
 logger = logging.getLogger(__name__)
 
 
 class ExtensionData(NamedTuple):
-    extension: "Extension"
+    extension: Extension
     entry_point: Any
     config_schema: ConfigSchema
     config_defaults: Any
@@ -144,7 +145,7 @@ class Extension:
         """
         pass
 
-    def setup(self, registry: "Registry") -> None:
+    def setup(self, registry: Registry) -> None:
         """
         Register the extension's components in the extension :class:`Registry`.
 
@@ -188,16 +189,16 @@ class Registry(Mapping):
     """
 
     def __init__(self) -> None:
-        self._registry: Dict[str, List[Type[Any]]] = {}
+        self._registry: dict[str, list[type[Any]]] = {}
 
-    def add(self, name: str, cls: Type[Any]) -> None:
+    def add(self, name: str, cls: type[Any]) -> None:
         """Add a component to the registry.
 
         Multiple classes can be registered to the same name.
         """
         self._registry.setdefault(name, []).append(cls)
 
-    def __getitem__(self, name: str) -> List[Type[Any]]:
+    def __getitem__(self, name: str) -> list[type[Any]]:
         return self._registry.setdefault(name, [])
 
     def __iter__(self) -> Iterator[str]:
@@ -207,7 +208,7 @@ class Registry(Mapping):
         return len(self._registry)
 
 
-def load_extensions() -> List[ExtensionData]:
+def load_extensions() -> list[ExtensionData]:
     """Find all installed extensions.
 
     :returns: list of installed extensions

--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -19,7 +19,7 @@ from mopidy.http import Extension, handlers
 from mopidy.internal import formatting, network
 
 if TYPE_CHECKING:
-    from typing import Any, ClassVar, List, Type
+    from typing import Any, ClassVar
 
 try:
     import asyncio
@@ -31,8 +31,8 @@ logger = logging.getLogger(__name__)
 
 
 class HttpFrontend(pykka.ThreadingActor, CoreListener):
-    apps: ClassVar[List[Type[Any]]] = []
-    statics: ClassVar[List[Type[Any]]] = []
+    apps: ClassVar[list[type[Any]]] = []
+    statics: ClassVar[list[type[Any]]] = []
 
     def __init__(self, config, core):
         super().__init__()

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -16,7 +16,7 @@ from mopidy import core, models
 from mopidy.internal import jsonrpc
 
 if TYPE_CHECKING:
-    from typing import ClassVar, Set
+    from typing import ClassVar
 
 
 logger = logging.getLogger(__name__)
@@ -107,7 +107,7 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
     # XXX This set is shared by all WebSocketHandler objects. This isn't
     # optimal, but there's currently no use case for having more than one of
     # these anyway.
-    clients: ClassVar[Set[WebSocketHandler]] = set()
+    clients: ClassVar[set[WebSocketHandler]] = set()
 
     @classmethod
     def broadcast(cls, msg, io_loop):

--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -8,9 +8,9 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from logging import LogRecord
-    from typing import Dict, List, Optional, Tuple
+    from typing import Literal, Optional
 
-    from typing_extensions import Literal, TypedDict
+    from typing_extensions import TypedDict
 
     LogColor = Literal[
         "black",
@@ -27,8 +27,8 @@ if TYPE_CHECKING:
 
     class Config(TypedDict):
         logging: LoggingConfig
-        loglevels: Dict[str, int]
-        logcolors: Dict[str, LogColor]
+        loglevels: dict[str, int]
+        logcolors: dict[str, LogColor]
 
     class LoggingConfig(TypedDict):
         verbosity: int
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
         config_file: str
 
 
-LOG_LEVELS: Dict[int, Dict[str, int]] = {
+LOG_LEVELS: dict[int, dict[str, int]] = {
     -1: dict(root=logging.ERROR, mopidy=logging.WARNING),
     0: dict(root=logging.ERROR, mopidy=logging.INFO),
     1: dict(root=logging.WARNING, mopidy=logging.DEBUG),
@@ -57,7 +57,7 @@ class DelayedHandler(logging.Handler):
     def __init__(self) -> None:
         logging.Handler.__init__(self)
         self._released = False
-        self._buffer: List[LogRecord] = []
+        self._buffer: list[LogRecord] = []
 
     def handle(self, record: LogRecord) -> bool:
         if not self._released:
@@ -136,7 +136,7 @@ def get_verbosity_level(
 
 
 class VerbosityFilter(logging.Filter):
-    def __init__(self, verbosity_level: int, loglevels: Dict[str, int]):
+    def __init__(self, verbosity_level: int, loglevels: dict[str, int]):
         self.verbosity_level = verbosity_level
         self.loglevels = loglevels
 
@@ -153,7 +153,7 @@ class VerbosityFilter(logging.Filter):
 
 
 #: Available log colors.
-COLORS: List[LogColor] = [
+COLORS: list[LogColor] = [
     "black",
     "red",
     "green",
@@ -180,7 +180,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
     """
 
     # Map logging levels to (background, foreground, bold/intense)
-    level_map: Dict[int, Tuple[Optional[LogColor], LogColor, bool]] = {
+    level_map: dict[int, tuple[Optional[LogColor], LogColor, bool]] = {
         TRACE_LOG_LEVEL: (None, "blue", False),
         logging.DEBUG: (None, "blue", False),
         logging.INFO: (None, "white", False),
@@ -189,14 +189,14 @@ class ColorizingStreamHandler(logging.StreamHandler):
         logging.CRITICAL: ("red", "white", True),
     }
     # Map logger name to foreground colors
-    logger_map: Dict[str, LogColor] = {}
+    logger_map: dict[str, LogColor] = {}
 
     csi = "\x1b["
     reset = "\x1b[0m"
 
     is_windows = platform.system() == "Windows"
 
-    def __init__(self, logger_colors: Dict[str, LogColor]) -> None:
+    def __init__(self, logger_colors: dict[str, LogColor]) -> None:
         super().__init__()
         self.logger_map = logger_colors
 

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -6,9 +6,7 @@ from typing import TYPE_CHECKING
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing import Any, Dict, Optional
-
-    from typing_extensions import Literal
+    from typing import Any, Literal, Optional
 
     MixerEvent = Literal["mute_changed", "volume_changed"]
 
@@ -39,7 +37,7 @@ class Mixer:
     mixer.
     """
 
-    def __init__(self, config: Dict) -> None:
+    def __init__(self, config: dict) -> None:
         pass
 
     def get_volume(self) -> Optional[int]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 30.3.0", "wheel"]
 
 
 [tool.black]
-target-version = ["py37", "py38", "py39", "py310"]
+target-version = ["py39", "py310", "py311"]
 line-length = 80
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,8 +22,6 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
@@ -34,7 +32,7 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >= 3.7
+python_requires = >= 3.9
 install_requires =
     Pykka >= 2.0.1
     requests >= 2.0

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -365,7 +365,7 @@ class HttpServerWithStaticDefaultApp(tornado.testing.AsyncHTTPTestCase):
 
 class HttpServerWithInvalidDefaultApp(HttpServerTest):
     def get_config(self):
-        config = super(HttpServerWithInvalidDefaultApp, self).get_config()
+        config = super().get_config()
         config["http"]["default_app"] = "invalid_webclient"
         return config
 

--- a/tests/test_version.py
+++ b/tests/test_version.py
@@ -1,9 +1,0 @@
-import unittest
-from distutils.version import StrictVersion
-
-from mopidy import __version__
-
-
-class VersionTest(unittest.TestCase):
-    def test_current_version_is_parsable_as_a_strict_version_number(self):
-        StrictVersion(__version__)

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py37, py38, py39, py310, py311, check-manifest, docs, flake8, mypy
+envlist = py39, py310, py311, check-manifest, docs, flake8, mypy
 
 [testenv]
 sitepackages = true


### PR DESCRIPTION
Python 3.7 reaches end-of-life in a couple of months. The question then is what
minimum Python version we should support now.

We usually look to Debian stable and Ubuntu LTS when deciding what versions to
require of our dependencies:

- The 1y7m old Debian stable (Bullseye) includes Python 3.9.
- The 1y old Ubuntu LTS includes Python 3.10.
- The next Debian stable includes Python 3.11.

With this background, and the fact that Python 3.9 is already 2y5m old, it
seems very reasonable to skip Python 3.8 and increase our minimum supported
Python version to 3.9.
