### PR TITLE
Require GStreamer >= 1.18

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -17,6 +17,8 @@ Dependencies
 
 - Python >= 3.9 is now required. Python 3.7 and 3.8 are no longer supported.
 
+- GStreamer >= 1.18.0 is now required.
+
 
 v3.4.1 (2022-12-07)
 ===================

--- a/docs/installation/pypi.rst
+++ b/docs/installation/pypi.rst
@@ -33,7 +33,7 @@ please see :ref:`contributing`.
 
        sudo dnf install -y gcc python3-devel python3-pip
 
-#. Then you'll need to install GStreamer >= 1.14.0, with Python bindings.
+#. Then you'll need to install GStreamer >= 1.18.0, with Python bindings.
    GStreamer is packaged for most popular Linux distributions. Search for
    GStreamer in your package manager, and make sure to install the Python
    bindings, and the "good" and "ugly" plugin sets.

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -30,7 +30,7 @@ else:
 GLib.set_prgname("mopidy")
 GLib.set_application_name("Mopidy")
 
-REQUIRED_GST_VERSION = (1, 14, 0)
+REQUIRED_GST_VERSION = (1, 18, 0)
 REQUIRED_GST_VERSION_DISPLAY = ".".join(map(str, REQUIRED_GST_VERSION))
 
 if Gst.version() < REQUIRED_GST_VERSION:


### PR DESCRIPTION
With the same reasoning as in #2075, we should be able to increase the minimum
supported GStreamer version too:

- Debian 11 has GStreamer 1.18
- Ubuntu 22.04 LTS has GStreamer 1.20
- Ubuntu 23.04 will have GStreamer 1.22 next month
- Debian 12 will have GStreamer 1.22 this year

Thus, we can move to GStreamer 1.18 now and maybe 1.22 later this year.
