### PR TITLE
docs: Use Debian default keyring path.

### DIFF
--- a/docs/installation/debian.rst
+++ b/docs/installation/debian.rst
@@ -42,8 +42,8 @@ Install from apt.mopidy.com
 
 #. Add the archive's GPG key::
 
-       sudo mkdir -p /usr/local/share/keyrings
-       sudo wget -q -O /usr/local/share/keyrings/mopidy-archive-keyring.gpg \
+       sudo mkdir -p /usr/share/keyrings
+       sudo wget -q -O /usr/share/keyrings/mopidy-archive-keyring.gpg \
          https://apt.mopidy.com/mopidy.gpg
 
 #. Add the APT repo to your package sources::

--- a/docs/installation/debian.rst
+++ b/docs/installation/debian.rst
@@ -42,8 +42,8 @@ Install from apt.mopidy.com
 
 #. Add the archive's GPG key::
 
-       sudo mkdir -p /usr/share/keyrings
-       sudo wget -q -O /usr/share/keyrings/mopidy-archive-keyring.gpg \
+       sudo mkdir -p /etc/apt/keyrings
+       sudo wget -q -O /etc/apt/keyrings/mopidy-archive-keyring.gpg \
          https://apt.mopidy.com/mopidy.gpg
 
 #. Add the APT repo to your package sources::


### PR DESCRIPTION
As per https://wiki.debian.org/DebianRepository/UseThirdParty

Fixes #2069