### PR TITLE
Allow tests to run on MacOS.

### DIFF
--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -11,7 +11,7 @@ from mopidy.internal.gi import GLib
 
 class GetOrCreateDirTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
-        self.parent = pathlib.Path(tempfile.mkdtemp())
+        self.parent = pathlib.Path(tempfile.mkdtemp()).resolve()
 
     def tearDown(self):  # noqa: N802
         if self.parent.is_dir():
@@ -59,7 +59,7 @@ class GetOrCreateDirTest(unittest.TestCase):
 
 class GetOrCreateFileTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
-        self.parent = pathlib.Path(tempfile.mkdtemp())
+        self.parent = pathlib.Path(tempfile.mkdtemp()).resolve()
 
     def tearDown(self):  # noqa: N802
         if self.parent.is_dir():
@@ -182,7 +182,7 @@ class ExpandPathTest(unittest.TestCase):
     def test_absolute_path(self):
         result = path.expand_path("/tmp/foo")
 
-        assert result == pathlib.Path("/tmp/foo")
+        assert result == pathlib.Path("/tmp/foo").resolve()
 
     def test_home_dir_expansion(self):
         result = path.expand_path("~/foo")

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -310,7 +310,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         result = self.core.playlists.lookup("m3u:test.m3u")
         assert "m3u:test.m3u" == result.uri
         assert playlist.name == result.name
-        assert filepath.as_uri() == result.tracks[0].uri
+        assert filepath.resolve().as_uri() == result.tracks[0].uri
 
     def test_playlist_sort_order(self):
         def check_order(playlists, names):

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -251,7 +251,7 @@ class TestValidateExtensionData:
         with mock.patch.object(ext.path, "get_or_create_dir"):
             cache_dir = extension.get_cache_dir(config)
 
-        expected = pathlib.Path(core_cache_dir) / extension.ext_name
+        expected = pathlib.Path(core_cache_dir).resolve() / extension.ext_name
         assert cache_dir == expected
 
     def test_get_config_dir(self, ext_data):
@@ -262,7 +262,7 @@ class TestValidateExtensionData:
         with mock.patch.object(ext.path, "get_or_create_dir"):
             config_dir = extension.get_config_dir(config)
 
-        expected = pathlib.Path(core_config_dir) / extension.ext_name
+        expected = pathlib.Path(core_config_dir).resolve() / extension.ext_name
         assert config_dir == expected
 
     def test_get_data_dir(self, ext_data):
@@ -273,5 +273,5 @@ class TestValidateExtensionData:
         with mock.patch.object(ext.path, "get_or_create_dir"):
             data_dir = extension.get_data_dir(config)
 
-        expected = pathlib.Path(core_data_dir) / extension.ext_name
+        expected = pathlib.Path(core_data_dir).resolve() / extension.ext_name
         assert data_dir == expected


### PR DESCRIPTION
MacOS is a little bit different than Linux basically it puts "/private" in front of a number of standard paths.

I added conftest.py for now just with 2 tests IS_DARWIN and IS_WINDOWS, but I believe there are more common items between the test files, that could later go into conftest.py

I changed a few test in a way that the difference in path is very clear, which I prefer because "you see what you get" :-) but if there is a preference for a central function I can easily make that.

I am (currently) not trying to make mopidy work on MacOS, that would take a lot more testing, I just want a clean environment so that I can test locally before submitting my bug fixes.