### PR TITLE
Correct file/follow_symlinks error.

### DIFF
--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -68,7 +68,7 @@ class FileLibraryProvider(backend.LibraryProvider):
             ):
                 continue
 
-            if child_path.is_symlink() and not self._follow_symlinks:
+            if dir_entry.is_symlink() and not self._follow_symlinks:
                 logger.debug("Ignoring symlink: %s", uri)
                 continue
 


### PR DESCRIPTION
While testing Mopidy-File.browse() it turned out that follow_symlinks=false do not work !

Current test is:
```
    if child_path.is_symlink() and not self._follow_symlinks:
                logger.debug("Ignoring symlink: %s", uri)
                continue
```
but child_path is made with .resolve(), therefore symlinks are resolved, and follow_symlinks=false fails.

Changed to use dir_entry instead, which contains the unresolved entry (symlink etc.)

