### PR TITLE
Switch from mypy to pyright (and improve typing enough to pass CI)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,9 +29,9 @@ jobs:
           - name: "Lint: flake8"
             python: "3.11"
             tox: flake8
-          - name: "Lint: mypy"
+          - name: "Lint: pyright"
             python: "3.11"
-            tox: mypy
+            tox: pyright
           - name: "Docs"
             python: "3.11"
             tox: docs

--- a/mopidy/audio/__init__.py
+++ b/mopidy/audio/__init__.py
@@ -1,4 +1,6 @@
 # flake8: noqa
+from typing import TYPE_CHECKING
+
 from .actor import Audio
 from .constants import PlaybackState
 from .listener import AudioListener
@@ -8,3 +10,6 @@ from .utils import (
     millisecond_to_clocktime,
     supported_uri_schemes,
 )
+
+if TYPE_CHECKING:
+    from .actor import AudioProxy

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -888,3 +888,31 @@ class Audio(pykka.ThreadingActor):
         # TODO: should we return None when stopped?
         # TODO: support only fetching keys we care about?
         return self._tags
+
+
+if TYPE_CHECKING:
+    from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
+
+    class AudioProxy(ActorMemberMixin, pykka.ActorProxy[Audio]):
+        """Audio layer wrapped in a Pykka actor proxy."""
+
+        state = proxy_field(Audio.state)
+        set_uri = proxy_method(Audio.set_uri)
+        set_appsrc = proxy_method(Audio.set_appsrc)
+        emit_data = proxy_method(Audio.emit_data)
+        set_source_setup_callback = proxy_method(
+            Audio.set_source_setup_callback
+        )
+        set_about_to_finish_callback = proxy_method(
+            Audio.set_about_to_finish_callback
+        )
+        get_position = proxy_method(Audio.get_position)
+        set_position = proxy_method(Audio.set_position)
+        start_playback = proxy_method(Audio.start_playback)
+        pause_playback = proxy_method(Audio.pause_playback)
+        prepare_change = proxy_method(Audio.prepare_change)
+        stop_playback = proxy_method(Audio.stop_playback)
+        wait_for_state_change = proxy_method(Audio.wait_for_state_change)
+        enable_sync_handler = proxy_method(Audio.enable_sync_handler)
+        set_metadata = proxy_method(Audio.set_metadata)
+        get_current_tags = proxy_method(Audio.get_current_tags)

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -1,6 +1,9 @@
+from __future__ import annotations
+
 import logging
 import os
 import threading
+from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import pykka
 
@@ -12,6 +15,12 @@ from mopidy.audio.listener import AudioListener
 from mopidy.internal import process
 from mopidy.internal.gi import GLib, GObject, Gst, GstPbutils
 
+if TYPE_CHECKING:
+    from mopidy.config import Config
+    from mopidy.mixer import MixerProxy
+    from mopidy.models import Track
+    from mopidy.softwaremixer.mixer import SoftwareMixerProxy
+
 logger = logging.getLogger(__name__)
 
 # This logger is only meant for debug logging of low level GStreamer info such
@@ -22,7 +31,7 @@ gst_logger = logging.getLogger("mopidy.audio.gst")
 _GST_PLAY_FLAGS_AUDIO = 0x02
 _GST_PLAY_FLAGS_DOWNLOAD = 0x80
 
-_GST_STATE_MAPPING = {
+_GST_STATE_MAPPING: dict[Gst.State, PlaybackState] = {
     Gst.State.PLAYING: PlaybackState.PLAYING,
     Gst.State.PAUSED: PlaybackState.PAUSED,
     Gst.State.NULL: PlaybackState.STOPPED,
@@ -34,19 +43,31 @@ class _Appsrc:
 
     """Helper class for dealing with appsrc based playback."""
 
-    def __init__(self):
+    def __init__(self) -> None:
         self._signals = utils.Signals()
         self.reset()
 
-    def reset(self):
+    def reset(self) -> None:
         """Reset the helper.
 
         Should be called whenever the source changes and we are not setting up
         a new appsrc.
         """
-        self.prepare(None, None, None, None)
+        self.prepare(
+            caps=None,
+            need_data=None,
+            enough_data=None,
+            seek_data=None,
+        )
 
-    def prepare(self, caps, need_data, enough_data, seek_data):
+    def prepare(
+        self,
+        *,
+        caps: Optional[Gst.Caps],
+        need_data: Optional[Callable],
+        enough_data: Optional[Callable],
+        seek_data: Optional[Callable],
+    ) -> None:
         """Store info we will need when the appsrc element gets installed."""
         self._signals.clear()
         self._source = None
@@ -55,7 +76,7 @@ class _Appsrc:
         self._seek_data_callback = seek_data
         self._enough_data_callback = enough_data
 
-    def configure(self, source):
+    def configure(self, source) -> None:
         """Configure the supplied source for use.
 
         Should be called whenever we get a new appsrc.
@@ -85,7 +106,7 @@ class _Appsrc:
 
         self._source = source
 
-    def push(self, buffer_):
+    def push(self, buffer_) -> bool:
         if self._source is None:
             return False
 
@@ -97,7 +118,7 @@ class _Appsrc:
             result = self._source.emit("push-buffer", buffer_)
             return result == Gst.FlowReturn.OK
 
-    def _on_signal(self, element, clocktime, func):
+    def _on_signal(self, element, clocktime, func) -> bool:
         # This shim is used to ensure we always return true, and also handles
         # that not all the callbacks have a time argument.
         if clocktime is None:
@@ -113,94 +134,118 @@ class _Outputs(Gst.Bin):
         Gst.Bin.__init__(self)
         # TODO gst1: Set 'outputs' as the Bin name for easier debugging
 
-        self._tee = Gst.ElementFactory.make("tee")
+        tee = Gst.ElementFactory.make("tee")
+        if tee is None:
+            raise exceptions.AudioException("Failed to create GStreamer tee.")
+        self._tee = tee
         self.add(self._tee)
 
-        ghost_pad = Gst.GhostPad.new("sink", self._tee.get_static_pad("sink"))
+        tee_sink = self._tee.get_static_pad("sink")
+        if tee_sink is None:
+            raise exceptions.AudioException(
+                "Failed to get sink from GStreamer tee."
+            )
+        ghost_pad = Gst.GhostPad.new("sink", tee_sink)
         self.add_pad(ghost_pad)
 
-    def add_output(self, description):
+    def add_output(self, description) -> None:
         # XXX This only works for pipelines not in use until #790 gets done.
         try:
             output = Gst.parse_bin_from_description(
                 description, ghost_unlinked_pads=True
             )
-        except GLib.GError as ex:
+        except GLib.Error as exc:
             logger.error(
-                'Failed to create audio output "%s": %s', description, ex
+                'Failed to create audio output "%s": %s', description, exc
             )
-            raise exceptions.AudioException(ex)
+            raise exceptions.AudioException(exc)
 
         self._add(output)
         logger.info('Audio output set to "%s"', description)
 
-    def _add(self, element):
-        queue = Gst.ElementFactory.make("queue")
+    def _add(self, element) -> None:
         self.add(element)
+
+        queue = Gst.ElementFactory.make("queue")
+        if queue is None:
+            raise exceptions.AudioException("Failed to create GStreamer queue.")
         self.add(queue)
+
         queue.link(element)
         self._tee.link(queue)
 
 
-class SoftwareMixer:
-    def __init__(self, mixer):
+class SoftwareMixerAdapter:
+    _mixer: SoftwareMixerProxy
+    _element: Optional[Gst.Element]
+    _last_volume: Optional[int]
+    _last_mute: Optional[bool]
+    _signals: utils.Signals
+
+    def __init__(self, mixer: SoftwareMixerProxy) -> None:
         self._mixer = mixer
         self._element = None
         self._last_volume = None
         self._last_mute = None
         self._signals = utils.Signals()
 
-    def setup(self, element, mixer_ref):
+    def setup(self, element, mixer_ref) -> None:
         self._element = element
         self._mixer.setup(mixer_ref)
 
-    def teardown(self):
+    def teardown(self) -> None:
         self._signals.clear()
         self._mixer.teardown()
 
-    def get_volume(self):
+    def get_volume(self) -> int:
+        assert self._element
         return int(round(self._element.get_property("volume") * 100))
 
-    def set_volume(self, volume):
+    def set_volume(self, volume: int) -> None:
+        assert self._element
         self._element.set_property("volume", volume / 100.0)
         self._mixer.trigger_volume_changed(self.get_volume())
 
-    def get_mute(self):
+    def get_mute(self) -> bool:
+        assert self._element
         return self._element.get_property("mute")
 
-    def set_mute(self, mute):
+    def set_mute(self, mute: bool) -> None:
+        assert self._element
         self._element.set_property("mute", bool(mute))
         self._mixer.trigger_mute_changed(self.get_mute())
 
 
 class _Handler:
-    def __init__(self, audio):
+    def __init__(self, audio: Audio) -> None:
         self._audio = audio
         self._element = None
         self._pad = None
         self._message_handler_id = None
         self._event_handler_id = None
 
-    def setup_message_handling(self, element):
+    def setup_message_handling(self, element) -> None:
         self._element = element
         bus = element.get_bus()
         bus.add_signal_watch()
         self._message_handler_id = bus.connect("message", self.on_message)
 
-    def setup_event_handling(self, pad):
+    def setup_event_handling(self, pad) -> None:
         self._pad = pad
         self._event_handler_id = pad.add_probe(
             Gst.PadProbeType.EVENT_BOTH, self.on_pad_event
         )
 
-    def teardown_message_handling(self):
-        bus = self._element.get_bus()
-        bus.remove_signal_watch()
-        bus.disconnect(self._message_handler_id)
+    def teardown_message_handling(self) -> None:
+        if self._element is not None:
+            bus = self._element.get_bus()
+            bus.remove_signal_watch()
+            bus.disconnect(self._message_handler_id)
         self._message_handler_id = None
 
-    def teardown_event_handling(self):
-        self._pad.remove_probe(self._event_handler_id)
+    def teardown_event_handling(self) -> None:
+        if self._pad is not None:
+            self._pad.remove_probe(self._event_handler_id)
         self._event_handler_id = None
 
     def on_message(self, bus, msg):
@@ -286,11 +331,16 @@ class _Handler:
             AudioListener.send("stream_changed", uri=None)
 
         if "GST_DEBUG_DUMP_DOT_DIR" in os.environ:
+            assert self._audio._playbin
             Gst.debug_bin_to_dot_file(
-                self._audio._playbin, Gst.DebugGraphDetails.ALL, "mopidy"
+                bin=cast(Gst.Bin, self._audio._playbin),
+                details=Gst.DebugGraphDetails.ALL,
+                file_name="mopidy",
             )
 
     def on_buffering(self, percent, structure=None):
+        assert self._audio._playbin
+
         if self._audio._target_state < Gst.State.PAUSED:
             gst_logger.debug("Skip buffering during track change.")
             return
@@ -381,6 +431,8 @@ class _Handler:
         # required helper installed?
 
     def on_stream_start(self):
+        assert self._audio._playbin
+
         gst_logger.debug("Got STREAM_START bus message")
         uri = self._audio._pending_uri
         logger.debug("Audio event: stream_changed(uri=%r)", uri)
@@ -424,52 +476,57 @@ class Audio(pykka.ThreadingActor):
     """
 
     #: The GStreamer state mapped to :class:`mopidy.audio.PlaybackState`
-    state = PlaybackState.STOPPED
+    state: PlaybackState = PlaybackState.STOPPED
 
-    #: The software mixing interface :class:`mopidy.audio.actor.SoftwareMixer`
-    mixer = None
+    #: The software mixing interface :class:`mopidy.audio.actor.SoftwareMixerAdapter`
+    mixer: Optional[SoftwareMixerAdapter] = None
 
-    def __init__(self, config, mixer):
+    def __init__(
+        self,
+        config: Config,
+        mixer: Optional[MixerProxy],
+    ) -> None:
         super().__init__()
 
         self._config = config
-        self._target_state = Gst.State.NULL
-        self._buffering = False
-        self._live_stream = False
-        self._tags = {}
-        self._pending_uri = None
-        self._pending_tags = None
+        self._target_state: Gst.State = Gst.State.NULL
+        self._buffering: bool = False
+        self._live_stream: bool = False
+        self._tags: dict[str, list[Any]] = {}
+        self._pending_uri: Optional[str] = None
+        self._pending_tags: Optional[dict[str, list[Any]]] = None
         self._pending_metadata = None
 
-        self._playbin = None
+        self._playbin: Optional[Gst.Element] = None
         self._outputs = None
         self._queue = None
-        self._about_to_finish_callback = None
-        self._source_setup_callback = None
+        self._about_to_finish_callback: Optional[Callable] = None
+        self._source_setup_callback: Optional[Callable] = None
 
         self._handler = _Handler(self)
         self._appsrc = _Appsrc()
         self._signals = utils.Signals()
 
         if mixer and self._config["audio"]["mixer"] == "software":
-            self.mixer = pykka.traversable(SoftwareMixer(mixer))
+            mixer = cast(SoftwareMixerProxy, mixer)
+            self.mixer = pykka.traversable(SoftwareMixerAdapter(mixer))
 
-    def on_start(self):
+    def on_start(self) -> None:
         self._thread = threading.current_thread()
         try:
             self._setup_preferences()
             self._setup_playbin()
             self._setup_outputs()
             self._setup_audio_sink()
-        except GLib.GError as ex:
-            logger.exception(ex)
+        except GLib.Error as exc:
+            logger.exception(exc)
             process.exit_process()
 
-    def on_stop(self):
+    def on_stop(self) -> None:
         self._teardown_mixer()
         self._teardown_playbin()
 
-    def _setup_preferences(self):
+    def _setup_preferences(self) -> None:
         # TODO: move out of audio actor?
         # Fix for https://github.com/mopidy/mopidy/issues/604
         registry = Gst.Registry.get()
@@ -477,8 +534,12 @@ class Audio(pykka.ThreadingActor):
         if jacksink:
             jacksink.set_rank(Gst.Rank.SECONDARY)
 
-    def _setup_playbin(self):
+    def _setup_playbin(self) -> None:
         playbin = Gst.ElementFactory.make("playbin")
+        if playbin is None:
+            raise exceptions.AudioException(
+                "Failed to create GStreamer playbin."
+            )
         playbin.set_property("flags", _GST_PLAY_FLAGS_AUDIO)
 
         # TODO: turn into config values...
@@ -493,18 +554,24 @@ class Audio(pykka.ThreadingActor):
         self._playbin = playbin
         self._handler.setup_message_handling(playbin)
 
-    def _teardown_playbin(self):
+    def _teardown_playbin(self) -> None:
         self._handler.teardown_message_handling()
         self._handler.teardown_event_handling()
-        self._signals.disconnect(self._playbin, "about-to-finish")
-        self._signals.disconnect(self._playbin, "source-setup")
-        self._playbin.set_state(Gst.State.NULL)
+        if self._playbin is not None:
+            self._signals.disconnect(self._playbin, "about-to-finish")
+            self._signals.disconnect(self._playbin, "source-setup")
+            self._playbin.set_state(Gst.State.NULL)
 
-    def _setup_outputs(self):
+    def _setup_outputs(self) -> None:
         # We don't want to use outputs for regular testing, so just install
         # an unsynced fakesink when someone asks for a 'testoutput'.
         if self._config["audio"]["output"] == "testoutput":
-            self._outputs = Gst.ElementFactory.make("fakesink")
+            fakesink = Gst.ElementFactory.make("fakesink")
+            if fakesink is None:
+                raise exceptions.AudioException(
+                    "Failed to create GStreamer fakesink element."
+                )
+            self._outputs = fakesink
         else:
             self._outputs = _Outputs()
             try:
@@ -514,10 +581,30 @@ class Audio(pykka.ThreadingActor):
 
         self._handler.setup_event_handling(self._outputs.get_static_pad("sink"))
 
-    def _setup_audio_sink(self):
+    def _setup_audio_sink(self) -> None:
+        assert self._playbin
+
+        if self._outputs is None:
+            raise TypeError("Audio outputs must be set up before audio sinks.")
+
         audio_sink = Gst.ElementFactory.make("bin", "audio-sink")
+        if audio_sink is None:
+            raise exceptions.AudioException(
+                "Failed to create GStreamer bin 'audio-sink'."
+            )
+        audio_sink = cast(Gst.Bin, audio_sink)
+
         queue = Gst.ElementFactory.make("queue")
+        if queue is None:
+            raise exceptions.AudioException(
+                "Failed to create GStreamer queue element."
+            )
+
         volume = Gst.ElementFactory.make("volume")
+        if volume is None:
+            raise exceptions.AudioException(
+                "Failed to create GStreamer volume element."
+            )
 
         # Queue element to buy us time between the about-to-finish event and
         # the actual switch, i.e. about to switch can block for longer thanks
@@ -540,17 +627,22 @@ class Audio(pykka.ThreadingActor):
         if self.mixer:
             self.mixer.setup(volume, self.actor_ref.proxy().mixer)
 
-        ghost_pad = Gst.GhostPad.new("sink", queue.get_static_pad("sink"))
+        queue_sink = queue.get_static_pad("sink")
+        if queue_sink is None:
+            raise exceptions.AudioException(
+                "Failed to get sink from GStreamer queue."
+            )
+        ghost_pad = Gst.GhostPad.new("sink", queue_sink)
         audio_sink.add_pad(ghost_pad)
 
         self._playbin.set_property("audio-sink", audio_sink)
         self._queue = queue
 
-    def _teardown_mixer(self):
+    def _teardown_mixer(self) -> None:
         if self.mixer:
             self.mixer.teardown()
 
-    def _on_about_to_finish(self, element):
+    def _on_about_to_finish(self, element: Gst.Element) -> None:
         if self._thread == threading.current_thread():
             logger.error(
                 "about-to-finish in actor, aborting to avoid deadlock."
@@ -562,12 +654,22 @@ class Audio(pykka.ThreadingActor):
             logger.debug("Running about-to-finish callback.")
             self._about_to_finish_callback()
 
-    def _on_source_setup(self, element, source):
+    def _on_source_setup(
+        self,
+        element: Gst.Element,
+        source: Gst.Element,
+    ) -> None:
         gst_logger.debug(
             "Got source-setup signal: element=%s", source.__class__.__name__
         )
 
-        if source.get_factory().get_name() == "appsrc":
+        source_factory = source.get_factory()
+        if source_factory is None:
+            raise exceptions.AudioException(
+                "Failed to get factory from GStreamer source."
+            )
+
+        if source_factory.get_name() == "appsrc":
             self._appsrc.configure(source)
         else:
             self._appsrc.reset()
@@ -578,11 +680,18 @@ class Audio(pykka.ThreadingActor):
 
         if self._live_stream and hasattr(source.props, "is_live"):
             gst_logger.debug("Enabling live stream mode")
-            source.set_live(True)
+            # TODO(typing): Once pygobject-stubs includes GstApp, cast to AppSrc:
+            # source = cast(GstApp.AppSrc, source)
+            source.set_live(True)  # pyright: ignore[reportGeneralTypeIssues]
 
         utils.setup_proxy(source, self._config["proxy"])
 
-    def set_uri(self, uri, live_stream=False, download=False):
+    def set_uri(
+        self,
+        uri: str,
+        live_stream: bool = False,
+        download: bool = False,
+    ) -> None:
         """
         Set URI of audio to be played.
 
@@ -596,6 +705,7 @@ class Audio(pykka.ThreadingActor):
         :param download: enables "download" buffering mode
         :type download: bool
         """
+        assert self._playbin
 
         # XXX: Hack to workaround issue on Mac OS X where volume level
         # does not persist between track changes. mopidy/mopidy#886
@@ -625,8 +735,12 @@ class Audio(pykka.ThreadingActor):
             self.mixer.set_volume(current_volume)
 
     def set_appsrc(
-        self, caps, need_data=None, enough_data=None, seek_data=None
-    ):
+        self,
+        caps: str,
+        need_data: Optional[Callable] = None,
+        enough_data: Optional[Callable] = None,
+        seek_data: Optional[Callable] = None,
+    ) -> None:
         """
         Switch to using appsrc for getting audio to be played.
 
@@ -643,8 +757,13 @@ class Audio(pykka.ThreadingActor):
             to continue playback
         :type seek_data: callable which takes time position in ms
         """
+        assert self._playbin
+
         self._appsrc.prepare(
-            Gst.Caps.from_string(caps), need_data, enough_data, seek_data
+            caps=Gst.Caps.from_string(caps),
+            need_data=need_data,
+            enough_data=enough_data,
+            seek_data=seek_data,
         )
         uri = "appsrc://"
         self._pending_uri = uri
@@ -652,7 +771,7 @@ class Audio(pykka.ThreadingActor):
         self._playbin.set_property("flags", _GST_PLAY_FLAGS_AUDIO)
         self._playbin.set_property("uri", uri)
 
-    def emit_data(self, buffer_):
+    def emit_data(self, buffer_: Optional[Gst.Buffer]) -> bool:
         """
         Call this to deliver raw audio data to be played.
 
@@ -670,7 +789,7 @@ class Audio(pykka.ThreadingActor):
         """
         return self._appsrc.push(buffer_)
 
-    def set_source_setup_callback(self, callback):
+    def set_source_setup_callback(self, callback: Callable) -> None:
         """
         Configure audio to use a source-setup callback.
 
@@ -681,7 +800,7 @@ class Audio(pykka.ThreadingActor):
         """
         self._source_setup_callback = callback
 
-    def set_about_to_finish_callback(self, callback):
+    def set_about_to_finish_callback(self, callback: Callable) -> None:
         """
         Configure audio to use an about-to-finish callback.
 
@@ -694,12 +813,14 @@ class Audio(pykka.ThreadingActor):
         """
         self._about_to_finish_callback = callback
 
-    def get_position(self):
+    def get_position(self) -> int:
         """
         Get position in milliseconds.
 
         :rtype: int
         """
+        assert self._playbin
+
         success, position = self._playbin.query_position(Gst.Format.TIME)
 
         if not success:
@@ -710,7 +831,7 @@ class Audio(pykka.ThreadingActor):
 
         return utils.clocktime_to_millisecond(position)
 
-    def set_position(self, position):
+    def set_position(self, position: int) -> bool:
         """
         Set position in milliseconds.
 
@@ -718,6 +839,8 @@ class Audio(pykka.ThreadingActor):
         :type position: int
         :rtype: :class:`True` if successful, else :class:`False`
         """
+        assert self._queue
+
         # TODO: double check seek flags in use.
         gst_position = utils.millisecond_to_clocktime(position)
         gst_logger.debug("Sending flushing seek: position=%r", gst_position)
@@ -731,7 +854,7 @@ class Audio(pykka.ThreadingActor):
         )
         return result
 
-    def start_playback(self):
+    def start_playback(self) -> bool:
         """
         Notify GStreamer that it should start playback.
 
@@ -739,7 +862,7 @@ class Audio(pykka.ThreadingActor):
         """
         return self._set_state(Gst.State.PLAYING)
 
-    def pause_playback(self):
+    def pause_playback(self) -> bool:
         """
         Notify GStreamer that it should pause playback.
 
@@ -747,7 +870,7 @@ class Audio(pykka.ThreadingActor):
         """
         return self._set_state(Gst.State.PAUSED)
 
-    def prepare_change(self):
+    def prepare_change(self) -> bool:
         """
         Notify GStreamer that we are about to change state of playback.
 
@@ -758,7 +881,7 @@ class Audio(pykka.ThreadingActor):
         """
         return self._set_state(Gst.State.READY)
 
-    def stop_playback(self):
+    def stop_playback(self) -> bool:
         """
         Notify GStreamer that is should stop playback.
 
@@ -766,27 +889,35 @@ class Audio(pykka.ThreadingActor):
         """
         return self._set_state(Gst.State.NULL)
 
-    def wait_for_state_change(self):
+    def wait_for_state_change(self) -> None:
         """Block until any pending state changes are complete.
 
         Should only be used by tests.
         """
+        assert self._playbin
+
         self._playbin.get_state(timeout=Gst.CLOCK_TIME_NONE)
 
-    def enable_sync_handler(self):
+    def enable_sync_handler(self) -> None:
         """Enable manual processing of messages from bus.
 
         Should only be used by tests.
         """
+        assert self._playbin
 
         def sync_handler(bus, message):
             self._handler.on_message(bus, message)
             return Gst.BusSyncReply.DROP
 
         bus = self._playbin.get_bus()
+        if bus is None:
+            raise exceptions.AudioException(
+                "Failed to get bus from GStreamer playbin."
+            )
+
         bus.set_sync_handler(sync_handler)
 
-    def _set_state(self, state):
+    def _set_state(self, state: Gst.State) -> bool:
         """
         Internal method for setting the raw GStreamer state.
 
@@ -807,6 +938,8 @@ class Audio(pykka.ThreadingActor):
         :type state: :class:`Gst.State`
         :rtype: :class:`True` if successfull, else :class:`False`
         """
+        assert self._playbin
+
         if state < Gst.State.PAUSED:
             self._buffering = False
 
@@ -828,7 +961,7 @@ class Audio(pykka.ThreadingActor):
         return True
 
     # TODO: bake this into setup appsrc perhaps?
-    def set_metadata(self, track):
+    def set_metadata(self, track: Track) -> None:
         """
         Set track metadata for currently playing song.
 
@@ -839,6 +972,8 @@ class Audio(pykka.ThreadingActor):
         :param track: the current track
         :type track: :class:`mopidy.models.Track`
         """
+        assert self._playbin
+
         taglist = Gst.TagList.new_empty()
         artists = [a for a in (track.artists or []) if a.name]
 
@@ -873,7 +1008,7 @@ class Audio(pykka.ThreadingActor):
         else:
             self._playbin.send_event(event)
 
-    def get_current_tags(self):
+    def get_current_tags(self) -> dict[str, list[Any]]:
         """
         Get the currently playing media's tags.
 

--- a/mopidy/audio/constants.py
+++ b/mopidy/audio/constants.py
@@ -1,4 +1,7 @@
-class PlaybackState:
+from enum import Enum
+
+
+class PlaybackState(str, Enum):
 
     """
     Enum of playback states.

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -1,48 +1,46 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, Union
 
 import pykka
 
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, Optional, TypeVar, Union
-
+    from mopidy.audio.actor import AudioProxy
+    from mopidy.internal.gi import Gst
     from mopidy.models import Image, Playlist, Ref, SearchResult, Track
 
-    # TODO Fix duplication with mopidy.internal.validation.TRACK_FIELDS_WITH_TYPES
-    TrackField = Literal[
-        "uri",
-        "track_name",
-        "album",
-        "artist",
-        "albumartist",
-        "composer",
-        "performer",
-        "track_no",
-        "genre",
-        "date",
-        "comment",
-        "disc_no",
-        "musicbrainz_albumid",
-        "musicbrainz_artistid",
-        "musicbrainz_trackid",
-    ]
+# TODO Fix duplication with mopidy.internal.validation.TRACK_FIELDS_WITH_TYPES
+TrackField = Literal[
+    "uri",
+    "track_name",
+    "album",
+    "artist",
+    "albumartist",
+    "composer",
+    "performer",
+    "track_no",
+    "genre",
+    "date",
+    "comment",
+    "disc_no",
+    "musicbrainz_albumid",
+    "musicbrainz_artistid",
+    "musicbrainz_trackid",
+]
 
-    SearchField = Literal[TrackField, "any"]
+SearchField = Literal[TrackField, "any"]
 
-    DistinctField = TrackField
+DistinctField = TrackField
 
-    F = TypeVar("F")
-    QueryValue = Union[str, int]
-    Query = dict[F, list[QueryValue]]
+F = TypeVar("F")
+QueryValue = Union[str, int]
+Query = dict[F, list[QueryValue]]
 
-    Uri = str
-    UriScheme = str
-
-    GstElement = TypeVar("GstElement")
+Uri = str
+UriScheme = str
 
 
 logger = logging.getLogger(__name__)
@@ -67,8 +65,7 @@ class Backend:
     #:
     #: Should be passed to the backend constructor as the kwarg ``audio``,
     #: which will then set this field.
-    # TODO(typing) Replace Any with an ActorProxy[Audio] type
-    audio: Optional[Any] = None
+    audio: AudioProxy
 
     #: The library provider. An instance of
     #: :class:`~mopidy.backend.LibraryProvider`, or :class:`None` if
@@ -211,8 +208,7 @@ class PlaybackProvider:
     :type backend: :class:`mopidy.backend.Backend`
     """
 
-    def __init__(self, audio: Any, backend: Backend) -> None:
-        # TODO(typing) Replace Any with an ActorProxy[Audio] type
+    def __init__(self, audio: AudioProxy, backend: Backend) -> None:
         self.audio = audio
         self.backend = backend
 
@@ -295,7 +291,7 @@ class PlaybackProvider:
         """
         return False
 
-    def on_source_setup(self, source: GstElement) -> None:
+    def on_source_setup(self, source: Gst.Element) -> None:
         """
         Called when a new GStreamer source is created, allowing us to configure
         the source. This runs in the audio thread so should not block.

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -529,3 +529,56 @@ class BackendListener(listener.Listener):
         *MAY* be implemented by actor.
         """
         pass
+
+
+if TYPE_CHECKING:
+    from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
+
+    class BackendActor(pykka.ThreadingActor, Backend):
+        pass
+
+    class BackendProxy(ActorMemberMixin, pykka.ActorProxy[BackendActor]):
+        """Backend wrapped in a Pykka actor proxy."""
+
+        audio = proxy_field(BackendActor.audio)
+        library: LibraryProviderProxy
+        playback: PlaybackProviderProxy
+        playlists: PlaylistsProviderProxy
+        uri_schemes = proxy_field(BackendActor.uri_schemes)
+        has_library = proxy_method(BackendActor.has_library)
+        has_library_browse = proxy_method(BackendActor.has_library_browse)
+        has_playback = proxy_method(BackendActor.has_playback)
+        has_playlists = proxy_method(BackendActor.has_playlists)
+        ping = proxy_method(BackendActor.ping)
+
+    class LibraryProviderProxy:
+        root_directory = proxy_field(LibraryProvider.root_directory)
+        browse = proxy_method(LibraryProvider.browse)
+        get_distinct = proxy_method(LibraryProvider.get_distinct)
+        get_images = proxy_method(LibraryProvider.get_images)
+        lookup = proxy_method(LibraryProvider.lookup)
+        refresh = proxy_method(LibraryProvider.refresh)
+        search = proxy_method(LibraryProvider.search)
+
+    class PlaybackProviderProxy:
+        pause = proxy_method(PlaybackProvider.pause)
+        play = proxy_method(PlaybackProvider.play)
+        prepare_change = proxy_method(PlaybackProvider.prepare_change)
+        translate_uri = proxy_method(PlaybackProvider.translate_uri)
+        is_live = proxy_method(PlaybackProvider.is_live)
+        should_download = proxy_method(PlaybackProvider.should_download)
+        on_source_setup = proxy_method(PlaybackProvider.on_source_setup)
+        change_track = proxy_method(PlaybackProvider.change_track)
+        resume = proxy_method(PlaybackProvider.resume)
+        seek = proxy_method(PlaybackProvider.seek)
+        stop = proxy_method(PlaybackProvider.stop)
+        get_time_position = proxy_method(PlaybackProvider.get_time_position)
+
+    class PlaylistsProviderProxy:
+        as_list = proxy_method(PlaylistsProvider.as_list)
+        get_items = proxy_method(PlaylistsProvider.get_items)
+        create = proxy_method(PlaylistsProvider.create)
+        delete = proxy_method(PlaylistsProvider.delete)
+        lookup = proxy_method(PlaylistsProvider.lookup)
+        refresh = proxy_method(PlaylistsProvider.refresh)
+        save = proxy_method(PlaylistsProvider.save)

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -305,9 +305,10 @@ class RootCommand(Command):
         )
 
     def run(self, args, config):
-        def on_sigterm(loop):
+        def on_sigterm(loop) -> bool:
             logger.info("GLib mainloop got SIGTERM. Exiting...")
             loop.quit()
+            return GLib.SOURCE_REMOVE
 
         loop = GLib.MainLoop()
         GLib.unix_signal_add(

--- a/mopidy/config/keyring.py
+++ b/mopidy/config/keyring.py
@@ -3,7 +3,7 @@ import logging
 logger = logging.getLogger(__name__)
 
 try:
-    import dbus
+    import dbus  # pyright: ignore[reportMissingImports]
 except ImportError:
     dbus = None
 
@@ -155,6 +155,7 @@ def _collection(bus):
 # NOTE: Hack to probe if a given collection actually exists. Needed to work
 # around an introspection bug in setting passwords for non-existant aliases.
 def _collection_exists(bus, path):
+    assert dbus
     try:
         item = _interface(bus, path, "org.freedesktop.DBus.Properties")
         item.Get("org.freedesktop.Secret.Collection", "Label")
@@ -178,5 +179,6 @@ def _item_attributes(bus, path):
 
 
 def _interface(bus, path, interface):
+    assert dbus
     obj = bus.get_object("org.freedesktop.secrets", path)
     return dbus.Interface(obj, interface)

--- a/mopidy/config/schemas.py
+++ b/mopidy/config/schemas.py
@@ -1,4 +1,5 @@
 import collections
+from typing import Any
 
 from mopidy.config import types
 
@@ -47,17 +48,20 @@ class ConfigSchema(collections.OrderedDict):
     persistence.
     """
 
-    def __init__(self, name):
+    def __init__(self, name: str) -> None:
         super().__init__()
         self.name = name
 
-    def deserialize(self, values):
+    def deserialize(
+        self,
+        values: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
         """Validates the given ``values`` using the config schema.
 
         Returns a tuple with cleaned values and errors.
         """
-        errors = {}
-        result = {}
+        errors: dict[str, Any] = {}
+        result: dict[str, Any] = {}
 
         for key, value in values.items():
             try:
@@ -80,13 +84,18 @@ class ConfigSchema(collections.OrderedDict):
 
         return result, errors
 
-    def serialize(self, values, display=False):
+    def serialize(
+        self,
+        values: dict[str, Any],
+        display: bool = False,
+    ) -> dict[str, Any]:
         """Converts the given ``values`` to a format suitable for persistence.
 
         If ``display`` is :class:`True` secret config values, like passwords,
         will be masked out.
 
-        Returns a dict of config keys and values."""
+        Returns a dict of config keys and values.
+        """
         result = collections.OrderedDict()
         for key in self.keys():
             if key in values:
@@ -102,13 +111,16 @@ class MapConfigSchema:
     serialize/deserialize interface.
     """
 
-    def __init__(self, name, value_type):
+    def __init__(self, name: str, value_type: types.ConfigValue) -> None:
         self.name = name
         self._value_type = value_type
 
-    def deserialize(self, values):
-        errors = {}
-        result = {}
+    def deserialize(
+        self,
+        values: dict[str, Any],
+    ) -> tuple[dict[str, Any], dict[str, Any]]:
+        errors: dict[str, Any] = {}
+        result: dict[str, Any] = {}
 
         for key, value in values.items():
             try:
@@ -118,7 +130,11 @@ class MapConfigSchema:
                 errors[key] = str(e)
         return result, errors
 
-    def serialize(self, values, display=False):
+    def serialize(
+        self,
+        values: dict[str, Any],
+        display: bool = False,
+    ) -> dict[str, Any]:
         result = collections.OrderedDict()
         for key in sorted(values.keys()):
             result[key] = self._value_type.serialize(values[key], display)

--- a/mopidy/config/validators.py
+++ b/mopidy/config/validators.py
@@ -1,7 +1,23 @@
+from __future__ import annotations
+
+from abc import abstractmethod
+from typing import TYPE_CHECKING, Any, Iterable, Optional, Protocol, TypeVar
+
+if TYPE_CHECKING:
+
+    class Comparable(Protocol):
+        @abstractmethod
+        def __lt__(self: CT, other: CT, /) -> bool:
+            ...
+
+    T = TypeVar("T")
+    CT = TypeVar("CT", bound=Comparable)
+
+
 # TODO: add validate regexp?
 
 
-def validate_required(value, required):
+def validate_required(value: Any, required: bool) -> None:
     """Validate that ``value`` is set if ``required``
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize` on
@@ -11,7 +27,7 @@ def validate_required(value, required):
         raise ValueError("must be set.")
 
 
-def validate_choice(value, choices):
+def validate_choice(value: T, choices: Optional[Iterable[T]]) -> None:
     """Validate that ``value`` is one of the ``choices``
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
@@ -21,7 +37,7 @@ def validate_choice(value, choices):
         raise ValueError(f"must be one of {names}, not {value}.")
 
 
-def validate_minimum(value, minimum):
+def validate_minimum(value: CT, minimum: Optional[CT]) -> None:
     """Validate that ``value`` is at least ``minimum``
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
@@ -30,7 +46,7 @@ def validate_minimum(value, minimum):
         raise ValueError(f"{value!r} must be larger than {minimum!r}.")
 
 
-def validate_maximum(value, maximum):
+def validate_maximum(value: CT, maximum: Optional[CT]) -> None:
     """Validate that ``value`` is at most ``maximum``
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.

--- a/mopidy/core/__init__.py
+++ b/mopidy/core/__init__.py
@@ -1,4 +1,6 @@
 # flake8: noqa
+from typing import TYPE_CHECKING
+
 from .actor import Core
 from .history import HistoryController
 from .library import LibraryController
@@ -7,3 +9,6 @@ from .mixer import MixerController
 from .playback import PlaybackController, PlaybackState
 from .playlists import PlaylistsController
 from .tracklist import TracklistController
+
+if TYPE_CHECKING:
+    from .actor import CoreProxy

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -1,6 +1,8 @@
-import collections
+from __future__ import annotations
+
 import itertools
 import logging
+from typing import TYPE_CHECKING
 
 import pykka
 
@@ -16,6 +18,14 @@ from mopidy.core.playlists import PlaylistsController
 from mopidy.core.tracklist import TracklistController
 from mopidy.internal import path, storage, validation, versioning
 from mopidy.internal.models import CoreState
+
+if TYPE_CHECKING:
+    from mopidy.core.history import HistoryControllerProxy
+    from mopidy.core.library import LibraryControllerProxy
+    from mopidy.core.mixer import MixerControllerProxy
+    from mopidy.core.playback import PlaybackControllerProxy
+    from mopidy.core.playlists import PlaylistsControllerProxy
+    from mopidy.core.tracklist import TracklistControllerProxy
 
 logger = logging.getLogger(__name__)
 
@@ -272,3 +282,25 @@ class Backends(list):
                     self.with_playback[scheme] = b
                 if has_playlists:
                     self.with_playlists[scheme] = b
+
+
+if TYPE_CHECKING:
+    from pykka.typing import ActorMemberMixin, proxy_method
+
+    class CoreProxy(ActorMemberMixin, pykka.ActorProxy[Core]):
+        library: LibraryControllerProxy
+        history: HistoryControllerProxy
+        mixer: MixerControllerProxy
+        playback: PlaybackControllerProxy
+        playlists: PlaylistsControllerProxy
+        tracklist: TracklistControllerProxy
+        get_uri_schemes = proxy_method(Core.get_uri_schemes)
+        get_version = proxy_method(Core.get_version)
+        reached_end_of_stream = proxy_method(Core.reached_end_of_stream)
+        stream_changed = proxy_method(Core.stream_changed)
+        position_changed = proxy_method(Core.position_changed)
+        state_changed = proxy_method(Core.state_changed)
+        playlists_loaded = proxy_method(Core.playlists_loaded)
+        volume_changed = proxy_method(Core.volume_changed)
+        mute_changed = proxy_method(Core.mute_changed)
+        tags_changed = proxy_method(Core.tags_changed)

--- a/mopidy/core/history.py
+++ b/mopidy/core/history.py
@@ -1,6 +1,7 @@
 import copy
 import logging
 import time
+from typing import TYPE_CHECKING
 
 from mopidy import models
 from mopidy.internal.models import HistoryState, HistoryTrack
@@ -73,3 +74,11 @@ class HistoryController:
     def _load_state(self, state, coverage):
         if state and "history" in coverage:
             self._history = [(h.timestamp, h.track) for h in state.history]
+
+
+if TYPE_CHECKING:
+    from pykka.typing import proxy_method
+
+    class HistoryControllerProxy:
+        get_length = proxy_method(HistoryController.get_length)
+        get_history = proxy_method(HistoryController.get_history)

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -4,6 +4,7 @@ import logging
 import operator
 import urllib
 from collections.abc import Mapping
+from typing import TYPE_CHECKING
 
 from mopidy import exceptions, models
 from mopidy.internal import deprecation, validation
@@ -363,3 +364,15 @@ def _normalize_query(query):
             "and file a bug."
         )
     return query
+
+
+if TYPE_CHECKING:
+    from pykka.typing import proxy_method
+
+    class LibraryControllerProxy:
+        browse = proxy_method(LibraryController.browse)
+        get_distinct = proxy_method(LibraryController.get_distinct)
+        get_images = proxy_method(LibraryController.get_images)
+        lookup = proxy_method(LibraryController.lookup)
+        refresh = proxy_method(LibraryController.refresh)
+        search = proxy_method(LibraryController.search)

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -1,13 +1,20 @@
+from __future__ import annotations
+
 import collections
 import contextlib
 import logging
 import operator
-import urllib
+import urllib.parse
 from collections.abc import Mapping
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional, cast
 
 from mopidy import exceptions, models
+from mopidy.backend import DistinctField
 from mopidy.internal import deprecation, validation
+
+if TYPE_CHECKING:
+    from mopidy.backend import BackendProxy
+    from mopidy.core.actor import Backends, Core
 
 logger = logging.getLogger(__name__)
 
@@ -32,11 +39,11 @@ def _backend_error_handling(backend, reraise=None):
 
 
 class LibraryController:
-    def __init__(self, backends, core):
+    def __init__(self, backends: Backends, core: Core) -> None:
         self.backends = backends
         self.core = core
 
-    def _get_backend(self, uri):
+    def _get_backend(self, uri: str) -> Optional[BackendProxy]:
         uri_scheme = urllib.parse.urlparse(uri).scheme
         return self.backends.with_library.get(uri_scheme, None)
 
@@ -146,9 +153,12 @@ class LibraryController:
         else:
             validation.check_choice(field, validation.DISTINCT_FIELDS.keys())
             field_type = validation.DISTINCT_FIELDS.get(field)
-        query is None or validation.check_query(query)  # TODO: normalize?
+        if query is not None:
+            validation.check_query(query)  # TODO: normalize?
 
-        compat_field = {"track_name": "track"}.get(field, field)
+        compat_field = cast(
+            DistinctField, {"track_name": "track"}.get(field, field)
+        )
 
         result = set()
         futures = {
@@ -159,7 +169,8 @@ class LibraryController:
             with _backend_error_handling(backend):
                 values = future.get()
                 if values is not None:
-                    validation.check_instances(values, field_type)
+                    if field_type is not None:
+                        validation.check_instances(values, field_type)
                     result.update(values)
         return result
 
@@ -237,14 +248,15 @@ class LibraryController:
 
         return results
 
-    def refresh(self, uri=None):
+    def refresh(self, uri: Optional[str] = None):
         """
         Refresh library. Limit to URI and below if an URI is given.
 
         :param uri: directory or track URI
         :type uri: string
         """
-        uri is None or validation.check_uri(uri)
+        if uri is not None:
+            validation.check_uri(uri)
 
         futures = {}
         backends = {}
@@ -306,7 +318,8 @@ class LibraryController:
         """
         query = _normalize_query(query)
 
-        uris is None or validation.check_uris(uris)
+        if uris is not None:
+            validation.check_uris(uris)
         validation.check_query(query)
         validation.check_boolean(exact)
 

--- a/mopidy/core/mixer.py
+++ b/mopidy/core/mixer.py
@@ -1,10 +1,15 @@
+from __future__ import annotations
+
 import contextlib
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from mopidy import exceptions
 from mopidy.internal import validation
 from mopidy.internal.models import MixerState
+
+if TYPE_CHECKING:
+    from mopidy.mixer import MixerProxy
 
 logger = logging.getLogger(__name__)
 
@@ -27,7 +32,7 @@ def _mixer_error_handling(mixer):
 
 
 class MixerController:
-    def __init__(self, mixer):
+    def __init__(self, mixer: Optional[MixerProxy]):
         self._mixer = mixer
 
     def get_volume(self):
@@ -42,7 +47,8 @@ class MixerController:
 
         with _mixer_error_handling(self._mixer):
             volume = self._mixer.get_volume().get()
-            volume is None or validation.check_integer(volume, min=0, max=100)
+            if volume is not None:
+                validation.check_integer(volume, min=0, max=100)
             return volume
 
         return None
@@ -79,7 +85,8 @@ class MixerController:
 
         with _mixer_error_handling(self._mixer):
             mute = self._mixer.get_mute().get()
-            mute is None or validation.check_instance(mute, bool)
+            if mute is not None:
+                validation.check_instance(mute, bool)
             return mute
 
         return None

--- a/mopidy/core/mixer.py
+++ b/mopidy/core/mixer.py
@@ -1,5 +1,6 @@
 import contextlib
 import logging
+from typing import TYPE_CHECKING
 
 from mopidy import exceptions
 from mopidy.internal import validation
@@ -109,3 +110,13 @@ class MixerController:
             self.set_mute(state.mute)
             if state.volume:
                 self.set_volume(state.volume)
+
+
+if TYPE_CHECKING:
+    from pykka.typing import proxy_method
+
+    class MixerControllerProxy:
+        get_volume = proxy_method(MixerController.get_volume)
+        set_volume = proxy_method(MixerController.set_volume)
+        get_mute = proxy_method(MixerController.get_mute)
+        set_mute = proxy_method(MixerController.set_mute)

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -1,5 +1,6 @@
 import logging
 import urllib
+from typing import TYPE_CHECKING
 
 from pykka.messages import ProxyCall
 
@@ -560,3 +561,24 @@ class PlaybackController:
             if state.state in (PlaybackState.PLAYING, PlaybackState.PAUSED):
                 self._start_at_position = state.time_position
                 self.play(tlid=state.tlid)
+
+
+if TYPE_CHECKING:
+    from pykka.typing import proxy_method
+
+    class PlaybackControllerProxy:
+        get_current_tl_track = proxy_method(
+            PlaybackController.get_current_tl_track
+        )
+        get_current_track = proxy_method(PlaybackController.get_current_track)
+        get_current_tlid = proxy_method(PlaybackController.get_current_tlid)
+        get_stream_title = proxy_method(PlaybackController.get_stream_title)
+        get_state = proxy_method(PlaybackController.get_state)
+        set_state = proxy_method(PlaybackController.set_state)
+        get_time_position = proxy_method(PlaybackController.get_time_position)
+        next = proxy_method(PlaybackController.next)
+        pause = proxy_method(PlaybackController.pause)
+        play = proxy_method(PlaybackController.play)
+        previous = proxy_method(PlaybackController.previous)
+        seek = proxy_method(PlaybackController.seek)
+        stop = proxy_method(PlaybackController.stop)

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -175,8 +175,8 @@ class PlaybackController:
         """
         self.core.actor_ref.ask(
             ProxyCall(
-                attr_path=["playback", "_on_about_to_finish"],
-                args=[],
+                attr_path=("playback", "_on_about_to_finish"),
+                args=(),
                 kwargs={},
             )
         )

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -1,6 +1,6 @@
 import contextlib
 import logging
-import urllib
+import urllib.parse
 from typing import TYPE_CHECKING
 
 from mopidy import exceptions
@@ -73,8 +73,7 @@ class PlaylistsController:
             except NotImplementedError:
                 backend_name = b.actor_ref.actor_class.__name__
                 logger.warning(
-                    "%s does not implement playlists.as_list(). "
-                    "Please upgrade it.",
+                    "%s does not implement playlists.as_list(). Please upgrade it.",
                     backend_name,
                 )
 
@@ -104,7 +103,8 @@ class PlaylistsController:
 
         with _backend_error_handling(backend):
             items = backend.playlists.get_items(uri).get()
-            items is None or validation.check_instances(items, Ref)
+            if items is not None:
+                validation.check_instances(items, Ref)
             return items
 
         return None
@@ -196,7 +196,8 @@ class PlaylistsController:
 
         with _backend_error_handling(backend):
             playlist = backend.playlists.lookup(uri).get()
-            playlist is None or validation.check_instance(playlist, Playlist)
+            if playlist is not None:
+                validation.check_instance(playlist, Playlist)
             return playlist
 
         return None
@@ -271,7 +272,8 @@ class PlaylistsController:
         # TODO: we let AssertionError error through due to legacy tests :/
         with _backend_error_handling(backend, reraise=AssertionError):
             playlist = backend.playlists.save(playlist).get()
-            playlist is None or validation.check_instance(playlist, Playlist)
+            if playlist is not None:
+                validation.check_instance(playlist, Playlist)
             if playlist:
                 listener.CoreListener.send(
                     "playlist_changed", playlist=playlist

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -1,6 +1,7 @@
 import contextlib
 import logging
 import urllib
+from typing import TYPE_CHECKING
 
 from mopidy import exceptions
 from mopidy.core import listener
@@ -278,3 +279,17 @@ class PlaylistsController:
             return playlist
 
         return None
+
+
+if TYPE_CHECKING:
+    from pykka.typing import proxy_method
+
+    class PlaylistsControllerProxy:
+        get_uri_schemes = proxy_method(PlaylistsController.get_uri_schemes)
+        as_list = proxy_method(PlaylistsController.as_list)
+        get_items = proxy_method(PlaylistsController.get_items)
+        create = proxy_method(PlaylistsController.create)
+        delete = proxy_method(PlaylistsController.delete)
+        lookup = proxy_method(PlaylistsController.lookup)
+        refresh = proxy_method(PlaylistsController.refresh)
+        save = proxy_method(PlaylistsController.save)

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -167,8 +167,10 @@ class TracklistController:
         .. versionadded:: 1.1
             The *tlid* parameter
         """
-        tl_track is None or validation.check_instance(tl_track, TlTrack)
-        tlid is None or validation.check_integer(tlid, min=1)
+        if tl_track is not None:
+            validation.check_instance(tl_track, TlTrack)
+        if tlid is not None:
+            validation.check_integer(tlid, min=1)
 
         if tl_track is None and tlid is None:
             tl_track = self.core.playback.get_current_tl_track()
@@ -216,7 +218,8 @@ class TracklistController:
         :rtype: :class:`mopidy.models.TlTrack` or :class:`None`
         """
         deprecation.warn("core.tracklist.eot_track")
-        tl_track is None or validation.check_instance(tl_track, TlTrack)
+        if tl_track is not None:
+            validation.check_instance(tl_track, TlTrack)
         if self.get_single() and self.get_repeat():
             return tl_track
         elif self.get_single():
@@ -266,7 +269,8 @@ class TracklistController:
         :rtype: :class:`mopidy.models.TlTrack` or :class:`None`
         """
         deprecation.warn("core.tracklist.next_track")
-        tl_track is None or validation.check_instance(tl_track, TlTrack)
+        if tl_track is not None:
+            validation.check_instance(tl_track, TlTrack)
 
         if not self._tl_tracks:
             return None
@@ -335,7 +339,8 @@ class TracklistController:
         :rtype: :class:`mopidy.models.TlTrack` or :class:`None`
         """
         deprecation.warn("core.tracklist.previous_track")
-        tl_track is None or validation.check_instance(tl_track, TlTrack)
+        if tl_track is not None:
+            validation.check_instance(tl_track, TlTrack)
 
         if self.get_repeat() or self.get_consume() or self.get_random():
             return tl_track
@@ -380,8 +385,10 @@ class TracklistController:
         if sum(o is not None for o in [tracks, uris]) != 1:
             raise ValueError('Exactly one of "tracks" or "uris" must be set')
 
-        tracks is None or validation.check_instances(tracks, Track)
-        uris is None or validation.check_uris(uris)
+        if tracks is not None:
+            validation.check_instances(tracks, Track)
+        if uris is not None:
+            validation.check_uris(uris)
         validation.check_integer(at_position or 0)
 
         if tracks:
@@ -390,6 +397,7 @@ class TracklistController:
         if tracks is None:
             tracks = []
             track_map = self.core.library.lookup(uris=uris)
+            assert uris is not None
             for uri in uris:
                 tracks.extend(track_map[uri])
 

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -1,5 +1,6 @@
 import logging
 import random
+from typing import TYPE_CHECKING
 
 from mopidy import exceptions
 from mopidy.core import listener
@@ -624,3 +625,35 @@ class TracklistController:
                 self._next_tlid = max(state.next_tlid, self._next_tlid)
                 self._tl_tracks = list(state.tl_tracks)
                 self._increase_version()
+
+
+if TYPE_CHECKING:
+    from pykka.typing import proxy_method
+
+    class TracklistControllerProxy:
+        get_tl_tracks = proxy_method(TracklistController.get_tl_tracks)
+        get_tracks = proxy_method(TracklistController.get_tracks)
+        get_length = proxy_method(TracklistController.get_length)
+        get_version = proxy_method(TracklistController.get_version)
+        get_consume = proxy_method(TracklistController.get_consume)
+        set_consume = proxy_method(TracklistController.set_consume)
+        get_random = proxy_method(TracklistController.get_random)
+        set_random = proxy_method(TracklistController.set_random)
+        get_repeat = proxy_method(TracklistController.get_repeat)
+        set_repeat = proxy_method(TracklistController.set_repeat)
+        get_single = proxy_method(TracklistController.get_single)
+        set_single = proxy_method(TracklistController.set_single)
+        index = proxy_method(TracklistController.index)
+        get_eot_tlid = proxy_method(TracklistController.get_eot_tlid)
+        eot_track = proxy_method(TracklistController.eot_track)
+        get_next_tlid = proxy_method(TracklistController.get_next_tlid)
+        next_track = proxy_method(TracklistController.next_track)
+        get_previous_tlid = proxy_method(TracklistController.get_previous_tlid)
+        previous_track = proxy_method(TracklistController.previous_track)
+        add = proxy_method(TracklistController.add)
+        clear = proxy_method(TracklistController.clear)
+        filter = proxy_method(TracklistController.filter)
+        move = proxy_method(TracklistController.move)
+        remove = proxy_method(TracklistController.remove)
+        shuffle = proxy_method(TracklistController.shuffle)
+        slice = proxy_method(TracklistController.slice)

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from typing import TYPE_CHECKING, NamedTuple
+from typing import TYPE_CHECKING, NamedTuple, Union
 
 import pkg_resources
 
@@ -15,10 +15,13 @@ if TYPE_CHECKING:
     from pathlib import Path
     from typing import Any, Optional
 
+    from typing_extensions import TypeAlias
+
     from mopidy.commands import Command
     from mopidy.config import ConfigSchema
 
     Config = dict[str, dict[str, Any]]
+    RegistryEntry: TypeAlias = Union[type[Any], dict[str, Any]]
 
 
 logger = logging.getLogger(__name__)
@@ -189,16 +192,16 @@ class Registry(Mapping):
     """
 
     def __init__(self) -> None:
-        self._registry: dict[str, list[type[Any]]] = {}
+        self._registry: dict[str, list[RegistryEntry]] = {}
 
-    def add(self, name: str, cls: type[Any]) -> None:
+    def add(self, name: str, entry: RegistryEntry) -> None:
         """Add a component to the registry.
 
         Multiple classes can be registered to the same name.
         """
-        self._registry.setdefault(name, []).append(cls)
+        self._registry.setdefault(name, []).append(entry)
 
-    def __getitem__(self, name: str) -> list[type[Any]]:
+    def __getitem__(self, name: str) -> list[RegistryEntry]:
         return self._registry.setdefault(name, [])
 
     def __iter__(self) -> Iterator[str]:

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import functools
 import logging
 import os
-import urllib
+import urllib.parse
 from typing import TYPE_CHECKING
 
 import tornado.escape

--- a/mopidy/httpclient.py
+++ b/mopidy/httpclient.py
@@ -1,11 +1,17 @@
+"""Helpers for configuring HTTP clients used in Mopidy extensions."""
+
+from __future__ import annotations
+
 import platform
+from typing import TYPE_CHECKING, Optional
 
 import mopidy
 
-"Helpers for configuring HTTP clients used in Mopidy extensions."
+if TYPE_CHECKING:
+    from mopidy.config import ProxyConfig
 
 
-def format_proxy(proxy_config, auth=True):
+def format_proxy(proxy_config: ProxyConfig, auth: bool = True) -> Optional[str]:
     """Convert a Mopidy proxy config to the commonly used proxy string format.
 
     Outputs ``scheme://host:port``, ``scheme://user:pass@host:port`` or
@@ -33,7 +39,7 @@ def format_proxy(proxy_config, auth=True):
         return f"{scheme}://{hostname}:{port}"
 
 
-def format_user_agent(name=None):
+def format_user_agent(name: Optional[str] = None) -> str:
     """Construct a User-Agent suitable for use in client code.
 
     This will identify use by the provided ``name`` (which should be on the

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -1,3 +1,5 @@
+# pyright: reportMissingModuleSource=false
+
 import sys
 import textwrap
 

--- a/mopidy/internal/http.py
+++ b/mopidy/internal/http.py
@@ -1,19 +1,29 @@
+from __future__ import annotations
+
 import logging
 import time
+from typing import TYPE_CHECKING
 
 import requests
 
 from mopidy import httpclient
 
+if TYPE_CHECKING:
+    from mopidy.httpclient import ProxyConfig
+
 logger = logging.getLogger(__name__)
 
 
-def get_requests_session(proxy_config, user_agent):
-    proxy = httpclient.format_proxy(proxy_config)
-    full_user_agent = httpclient.format_user_agent(user_agent)
-
+def get_requests_session(
+    proxy_config: ProxyConfig,
+    user_agent: str,
+) -> requests.Session:
     session = requests.Session()
-    session.proxies.update({"http": proxy, "https": proxy})
+
+    if proxy := httpclient.format_proxy(proxy_config):
+        session.proxies.update({"http": proxy, "https": proxy})
+
+    full_user_agent = httpclient.format_user_agent(user_agent)
     session.headers.update({"user-agent": full_user_agent})
 
     return session

--- a/mopidy/internal/jsonrpc.py
+++ b/mopidy/internal/jsonrpc.py
@@ -362,7 +362,7 @@ class JsonRpcInspector:
     def _describe_params(self, method):
         argspec = inspect.getfullargspec(method)
 
-        defaults = argspec.defaults and list(argspec.defaults) or []
+        defaults = list(argspec.defaults) if argspec.defaults else []
         num_args_without_default = len(argspec.args) - len(defaults)
         no_defaults = [None] * num_args_without_default
         defaults = no_defaults + defaults

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -1,7 +1,7 @@
 import logging
 import pathlib
 import re
-import urllib
+import urllib.parse
 
 from mopidy.internal import xdg
 

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -67,7 +67,7 @@ def uri_to_path(uri):
     return pathlib.Path(unicode_path)
 
 
-def expand_path(path):
+def expand_path(path) -> pathlib.Path:
     if isinstance(path, bytes):
         path = path.decode(errors="surrogateescape")
     path = str(pathlib.Path(path))
@@ -75,7 +75,7 @@ def expand_path(path):
     for xdg_var, xdg_dir in XDG_DIRS.items():
         path = path.replace("$" + xdg_var, str(xdg_dir))
     if "$" in path:
-        return None
+        raise ValueError(f"Unexpanded '$...' in path {path!r}")
 
     return pathlib.Path(path).expanduser().resolve()
 

--- a/mopidy/internal/playlists.py
+++ b/mopidy/internal/playlists.py
@@ -90,11 +90,14 @@ def parse_pls(data):
 
 
 def parse_xspf(data):
+    element = None
     try:
         # Last element will be root.
         for _event, element in elementtree.iterparse(io.BytesIO(data)):
             element.tag = element.tag.lower()  # normalize
     except elementtree.ParseError:
+        return
+    if element is None:
         return
 
     ns = "http://xspf.org/ns/0/"
@@ -104,11 +107,14 @@ def parse_xspf(data):
 
 
 def parse_asx(data):
+    element = None
     try:
         # Last element will be root.
         for _event, element in elementtree.iterparse(io.BytesIO(data)):
             element.tag = element.tag.lower()  # normalize
     except elementtree.ParseError:
+        return
+    if element is None:
         return
 
     for ref in element.findall("entry/ref[@href]"):

--- a/mopidy/internal/validation.py
+++ b/mopidy/internal/validation.py
@@ -1,11 +1,14 @@
-import urllib
+import urllib.parse
 from collections.abc import Iterable, Mapping
+from typing import Any, Optional, TypeVar, Union
 
 from mopidy import exceptions
 
+T = TypeVar("T")
+
 PLAYBACK_STATES = {"paused", "stopped", "playing"}
 
-TRACK_FIELDS_WITH_TYPES = {
+TRACK_FIELDS_WITH_TYPES: dict[str, Union[type[str], type[int]]] = {
     "uri": str,
     "track_name": str,
     "album": str,
@@ -40,7 +43,11 @@ DISTINCT_FIELDS = dict(TRACK_FIELDS_WITH_TYPES)
 
 
 # TODO: _check_iterable(check, msg, **kwargs) + [check(a) for a in arg]?
-def _check_iterable(arg, msg, **kwargs):
+def _check_iterable(
+    arg,
+    msg,
+    **kwargs: Any,
+) -> None:
     """Ensure we have an iterable which is not a string or an iterator"""
     if isinstance(arg, str):
         raise exceptions.ValidationError(msg.format(arg=arg, **kwargs))
@@ -50,29 +57,48 @@ def _check_iterable(arg, msg, **kwargs):
         raise exceptions.ValidationError(msg.format(arg=arg, **kwargs))
 
 
-def check_choice(arg, choices, msg="Expected one of {choices}, not {arg!r}"):
+def check_choice(
+    arg: T,
+    choices: Iterable[T],
+    msg: str = "Expected one of {choices}, not {arg!r}",
+) -> None:
     if arg not in choices:
         raise exceptions.ValidationError(
             msg.format(arg=arg, choices=tuple(choices))
         )
 
 
-def check_boolean(arg, msg="Expected a boolean, not {arg!r}"):
+def check_boolean(
+    arg: bool,
+    msg: str = "Expected a boolean, not {arg!r}",
+) -> None:
     check_instance(arg, bool, msg=msg)
 
 
-def check_instance(arg, cls, msg="Expected a {name} instance, not {arg!r}"):
+def check_instance(
+    arg: T,
+    cls: type[T],
+    msg: str = "Expected a {name} instance, not {arg!r}",
+) -> None:
     if not isinstance(arg, cls):
         raise exceptions.ValidationError(msg.format(arg=arg, name=cls.__name__))
 
 
-def check_instances(arg, cls, msg="Expected a list of {name}, not {arg!r}"):
+def check_instances(
+    arg: Iterable[Any],
+    cls: type,
+    msg: str = "Expected a list of {name}, not {arg!r}",
+) -> None:
     _check_iterable(arg, msg, name=cls.__name__)
     if not all(isinstance(instance, cls) for instance in arg):
         raise exceptions.ValidationError(msg.format(arg=arg, name=cls.__name__))
 
 
-def check_integer(arg, min=None, max=None):
+def check_integer(
+    arg: int,
+    min: Optional[int] = None,
+    max: Optional[int] = None,
+) -> None:
     if not isinstance(arg, int):
         raise exceptions.ValidationError(f"Expected an integer, not {arg!r}")
     elif min is not None and arg < min:
@@ -85,7 +111,11 @@ def check_integer(arg, min=None, max=None):
         )
 
 
-def check_query(arg, fields=None, list_values=True):
+def check_query(
+    arg: dict[str, Any],
+    fields: Optional[set[str]] = None,
+    list_values: bool = True,
+) -> None:
     if fields is None:
         fields = SEARCH_FIELDS
     # TODO: normalize name  -> track_name
@@ -114,18 +144,28 @@ def check_query(arg, fields=None, list_values=True):
             )
 
 
-def _check_query_value(key, arg, msg):
+def _check_query_value(
+    key: str,
+    arg: Any,
+    msg: str,
+) -> None:
     if not isinstance(arg, str) or not arg.strip():
         raise exceptions.ValidationError(msg.format(arg=arg, key=key))
 
 
-def check_uri(arg, msg="Expected a valid URI, not {arg!r}"):
+def check_uri(
+    arg: str,
+    msg="Expected a valid URI, not {arg!r}",
+) -> None:
     if not isinstance(arg, str):
         raise exceptions.ValidationError(msg.format(arg=arg))
     elif urllib.parse.urlparse(arg).scheme == "":
         raise exceptions.ValidationError(msg.format(arg=arg))
 
 
-def check_uris(arg, msg="Expected a list of URIs, not {arg!r}"):
+def check_uris(
+    arg: Iterable[str],
+    msg="Expected a list of URIs, not {arg!r}",
+) -> None:
     _check_iterable(arg, msg)
     [check_uri(a, msg) for a in arg]

--- a/mopidy/internal/versioning.py
+++ b/mopidy/internal/versioning.py
@@ -23,6 +23,7 @@ def get_git_version():
     )
     if process.wait() != 0:
         raise OSError('Execution of "git describe" failed')
+    assert process.stdout
     version = process.stdout.read().strip().decode()
     if version.startswith("v"):
         version = version[1:]

--- a/mopidy/listener.py
+++ b/mopidy/listener.py
@@ -21,8 +21,8 @@ def send(cls, event, **kwargs):
         # quickly deadlock.
         listener.tell(
             ProxyCall(
-                attr_path=["on_event"],
-                args=[event],
+                attr_path=("on_event",),
+                args=(event,),
                 kwargs=kwargs,
             )
         )

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -166,7 +166,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             path = self._abspath(path)
         if not self._is_in_basedir(path):
             raise Exception(
-                f"Path {path!r} is not inside playlist dir {self._playlist_dir!r}"
+                f"Path {path!r} is not inside playlist dir {self._playlists_dir!r}"
             )
         if "w" in mode:
             return replace(path, mode, encoding=encoding, errors="replace")

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import contextlib
 import locale
 import logging
@@ -5,11 +7,15 @@ import operator
 import os
 import pathlib
 import tempfile
+from typing import TYPE_CHECKING
 
 from mopidy import backend
 from mopidy.internal import path
 
 from . import Extension, translator
+
+if TYPE_CHECKING:
+    from mopidy.models import Playlist
 
 logger = logging.getLogger(__name__)
 
@@ -127,7 +133,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
     def refresh(self):
         pass  # nothing to do
 
-    def save(self, playlist):
+    def save(self, playlist: Playlist) -> Playlist | None:
         path = translator.uri_to_path(playlist.uri)
         if not self._is_in_basedir(path):
             logger.debug("Ignoring path outside playlist dir: %s", playlist.uri)

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -1,6 +1,6 @@
 import os
 import pathlib
-import urllib
+import urllib.parse
 
 from mopidy import models
 from mopidy.internal import path

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+import pykka
+
 from mopidy import listener
 
 if TYPE_CHECKING:
@@ -159,3 +161,22 @@ class MixerListener(listener.Listener):
         :type mute: bool
         """
         pass
+
+
+if TYPE_CHECKING:
+    from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
+
+    class MixerActor(pykka.ThreadingActor, Mixer):
+        pass
+
+    class MixerProxy(ActorMemberMixin, pykka.ActorProxy[MixerActor]):
+        """Mixer wrapped in a Pykka actor proxy."""
+
+        name = proxy_field(MixerActor.name)
+        get_volume = proxy_method(MixerActor.get_volume)
+        set_volume = proxy_method(MixerActor.set_volume)
+        trigger_volume_changed = proxy_method(MixerActor.trigger_volume_changed)
+        get_mute = proxy_method(MixerActor.get_mute)
+        set_mute = proxy_method(MixerActor.set_mute)
+        trigger_mute_changed = proxy_method(MixerActor.trigger_mute_changed)
+        ping = proxy_method(MixerActor.ping)

--- a/mopidy/softwaremixer/mixer.py
+++ b/mopidy/softwaremixer/mixer.py
@@ -1,4 +1,5 @@
 import logging
+from typing import TYPE_CHECKING
 
 import pykka
 
@@ -55,3 +56,11 @@ class SoftwareMixer(pykka.ThreadingActor, mixer.Mixer):
             return False
         self._audio_mixer.set_mute(mute)
         return True
+
+
+if TYPE_CHECKING:
+    from pykka.typing import proxy_method
+
+    class SoftwareMixerProxy(mixer.MixerProxy):
+        setup = proxy_method(SoftwareMixer.setup)
+        teardown = proxy_method(SoftwareMixer.teardown)

--- a/mopidy/zeroconf.py
+++ b/mopidy/zeroconf.py
@@ -4,7 +4,7 @@ import string
 logger = logging.getLogger(__name__)
 
 try:
-    import dbus
+    import dbus  # pyright: ignore[reportMissingImports]
 except ImportError:
     dbus = None
 
@@ -22,6 +22,7 @@ def _is_loopback_address(host):
 
 
 def _convert_text_list_to_dbus_format(text_list):
+    assert dbus
     array = dbus.Array(signature="ay")
     for text in text_list:
         array.append([dbus.Byte(ord(c)) for c in text])
@@ -139,6 +140,7 @@ class Zeroconf:
 
         Call when your service shuts down.
         """
+        assert dbus
 
         if self.group:
             try:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,3 +15,15 @@ use_parentheses = true
 line_length = 80
 known_tests = "tests"
 sections = "FUTURE,STDLIB,THIRDPARTY,FIRSTPARTY,TESTS,LOCALFOLDER"
+
+
+[tool.pyright]
+pythonVersion = "3.9"
+# Use venv from parent directory, to share it with any extensions:
+venvPath = "../"
+venv = ".venv"
+typeCheckingMode = "basic"
+# Not all dependencies have type hints:
+reportMissingTypeStubs = false
+# Already covered by flake8-self:
+reportPrivateImportUsage = false

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ include_package_data = True
 packages = find:
 python_requires = >= 3.9
 install_requires =
-    Pykka >= 2.0.1
+    Pykka >= 4.0.0rc1
     requests >= 2.0
     setuptools
     tornado >= 4.4

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,18 +53,20 @@ lint =
     flake8-bugbear
     flake8-isort
     isort
-    mypy
     pep8-naming
-    types-requests
-    types-setuptools
 test =
     pytest
     pytest-cov
     responses
+typing =
+    pyright
+    types-requests
+    types-setuptools
 dev =
     %(docs)s
     %(lint)s
     %(test)s
+    %(typing)s
     tox
 
 
@@ -116,31 +118,3 @@ ignore =
     W503
     # B305: .next() is not a thing on Python 3 (used by playback controller)
     B305
-
-
-[mypy]
-warn_unused_configs = True
-
-[mypy-dbus.*]
-ignore_missing_imports = True
-
-[mypy-gi.*]
-ignore_missing_imports = True
-
-[mypy-pykka.*]
-ignore_missing_imports = True
-
-[mypy-mopidy.backend.*]
-disallow_untyped_defs = True
-
-[mypy-mopidy.ext.*]
-disallow_untyped_defs = True
-
-[mypy-mopidy.internal.log.*]
-disallow_untyped_defs = True
-
-[mypy-mopidy.internal.network.*]
-disallow_untyped_defs = True
-
-[mypy-mopidy.mixer.*]
-disallow_untyped_defs = True

--- a/setup.cfg
+++ b/setup.cfg
@@ -60,6 +60,7 @@ test =
     responses
 typing =
     pyright
+    pygobject-stubs
     types-requests
     types-setuptools
 dev =

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -99,7 +99,7 @@ class LoadConfigTest(unittest.TestCase):
 class ValidateTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
         self.schema = config.ConfigSchema("foo")
-        self.schema["bar"] = config.ConfigValue()
+        self.schema["bar"] = config.String()
 
     def test_empty_config_no_schemas(self):
         conf, errors = config._validate({}, [])

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -54,37 +54,6 @@ def test_encode_decode_invalid_utf8():
     assert result == data.decode(errors="surrogateescape")
 
 
-class TestConfigValue:
-    def test_deserialize_decodes_bytes(self):
-        cv = types.ConfigValue()
-
-        result = cv.deserialize(b"abc")
-
-        assert isinstance(result, str)
-
-    def test_serialize_conversion_to_string(self):
-        cv = types.ConfigValue()
-
-        result = cv.serialize(object())
-
-        assert isinstance(result, str)
-
-    def test_serialize_none(self):
-        cv = types.ConfigValue()
-
-        result = cv.serialize(None)
-
-        assert isinstance(result, str)
-        assert result == ""
-
-    def test_serialize_supports_display(self):
-        cv = types.ConfigValue()
-
-        result = cv.serialize(object(), display=True)
-
-        assert isinstance(result, str)
-
-
 class TestDeprecated:
     def test_deserialize_returns_deprecated_value(self):
         cv = types.Deprecated()

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -70,7 +70,11 @@ class CoreActorTest(unittest.TestCase):
             has_playlists=True,
         )
 
-        self.core = Core(mixer=None, backends=[self.backend1, self.backend2])
+        self.core = Core(
+            config={},
+            mixer=None,
+            backends=[self.backend1, self.backend2],
+        )
 
     def tearDown(self):  # noqa: N802
         pykka.ActorRegistry.stop_all()
@@ -102,7 +106,9 @@ class CoreActorTest(unittest.TestCase):
         )
 
         core = Core(
-            mixer=None, backends=[backend3, self.backend1, self.backend2]
+            config={},
+            mixer=None,
+            backends=[backend3, self.backend1, self.backend2],
         )
 
         assert core.backends == [self.backend1, self.backend2]
@@ -122,7 +128,9 @@ class CoreActorTest(unittest.TestCase):
         )
 
         core = Core(
-            mixer=None, backends=[self.backend1, backend3, self.backend2]
+            config={},
+            mixer=None,
+            backends=[self.backend1, backend3, self.backend2],
         )
 
         assert core.backends == [self.backend1, self.backend2]
@@ -139,6 +147,7 @@ class CoreActorTest(unittest.TestCase):
             "Cannot add URI scheme 'dummy1' for B2, "
             "it is already handled by B1",
             Core,
+            config={},
             mixer=None,
             backends=[self.backend1, self.backend2],
         )
@@ -174,7 +183,11 @@ class CoreActorSaveLoadStateTest(unittest.TestCase):
         }
 
         self.mixer = dummy_mixer.create_proxy()
-        self.core = Core(config=config, mixer=self.mixer, backends=[])
+        self.core = Core(
+            config=config,
+            mixer=self.mixer,
+            backends=[],
+        )
 
     def tearDown(self):  # noqa: N802
         pykka.ActorRegistry.stop_all()

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -36,7 +36,9 @@ class BaseCoreLibraryTest(unittest.TestCase):
         self.backend3.has_library_browse.return_value.get.return_value = False
 
         self.core = core.Core(
-            mixer=None, backends=[self.backend1, self.backend2, self.backend3]
+            config={},
+            mixer=None,
+            backends=[self.backend1, self.backend2, self.backend3],
         )
 
 
@@ -407,7 +409,7 @@ class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
         self.backend.actor_ref.actor_class.__name__ = "DummyBackend"
         self.backend.uri_schemes.get.return_value = ["dummy"]
         self.backend.library = mock.Mock(spec=backend.LibraryProvider)
-        self.core = core.Core(mixer=None, backends=[self.backend])
+        self.core = core.Core(config={}, mixer=None, backends=[self.backend])
 
     def test_core_search_call_backend_search_with_exact(self):
         self.core.library.search(query={"any": ["a"]})
@@ -439,7 +441,7 @@ class MockBackendCoreLibraryBase(unittest.TestCase):
         self.backend.uri_schemes.get.return_value = ["dummy"]
         self.backend.library = self.library
 
-        self.core = core.Core(mixer=None, backends=[self.backend])
+        self.core = core.Core(config={}, mixer=None, backends=[self.backend])
 
 
 @mock.patch("mopidy.core.library.logger")

--- a/tests/core/test_mixer.py
+++ b/tests/core/test_mixer.py
@@ -12,7 +12,11 @@ from tests import dummy_mixer
 class CoreMixerTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
         self.mixer = mock.Mock(spec=mixer.Mixer)
-        self.core = core.Core(mixer=self.mixer, backends=[])
+        self.core = core.Core(
+            config={},
+            mixer=self.mixer,
+            backends=[],
+        )
 
     def test_get_volume(self):
         self.mixer.get_volume.return_value.get.return_value = 30
@@ -41,7 +45,11 @@ class CoreMixerTest(unittest.TestCase):
 
 class CoreNoneMixerTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
-        self.core = core.Core(mixer=None, backends=[])
+        self.core = core.Core(
+            config={},
+            mixer=None,
+            backends=[],
+        )
 
     def test_get_volume_return_none_because_it_is_unknown(self):
         assert self.core.mixer.get_volume() is None
@@ -60,7 +68,11 @@ class CoreNoneMixerTest(unittest.TestCase):
 class CoreMixerListenerTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
         self.mixer = dummy_mixer.create_proxy()
-        self.core = core.Core(mixer=self.mixer, backends=[])
+        self.core = core.Core(
+            config={},
+            mixer=self.mixer,
+            backends=[],
+        )
 
     def tearDown(self):  # noqa: N802
         pykka.ActorRegistry.stop_all()
@@ -80,7 +92,11 @@ class CoreMixerListenerTest(unittest.TestCase):
 @mock.patch.object(mixer.MixerListener, "send")
 class CoreNoneMixerListenerTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
-        self.core = core.Core(mixer=None, backends=[])
+        self.core = core.Core(
+            config={},
+            mixer=None,
+            backends=[],
+        )
 
     def test_forwards_mixer_volume_changed_event_to_frontends(self, send):
         assert self.core.mixer.set_volume(volume=60) is False
@@ -95,7 +111,11 @@ class MockBackendCoreMixerBase(unittest.TestCase):
     def setUp(self):  # noqa: N802
         self.mixer = mock.Mock()
         self.mixer.actor_ref.actor_class.__name__ = "DummyMixer"
-        self.core = core.Core(mixer=self.mixer, backends=[])
+        self.core = core.Core(
+            config={},
+            mixer=None,
+            backends=[],
+        )
 
 
 class GetVolumeBadBackendTest(MockBackendCoreMixerBase):
@@ -149,7 +169,11 @@ class SetMuteBadBackendTest(MockBackendCoreMixerBase):
 class CoreMixerSaveLoadStateTest(unittest.TestCase):
     def setUp(self):  # noqa: N802
         self.mixer = dummy_mixer.create_proxy()
-        self.core = core.Core(mixer=self.mixer, backends=[])
+        self.core = core.Core(
+            config={},
+            mixer=self.mixer,
+            backends=[],
+        )
 
     def test_save_mute(self):
         volume = 32

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -48,7 +48,9 @@ class BasePlaylistsTest(unittest.TestCase):
         self.backend3.playlists = None
 
         self.core = core.Core(
-            mixer=None, backends=[self.backend3, self.backend1, self.backend2]
+            config={},
+            mixer=None,
+            backends=[self.backend3, self.backend1, self.backend2],
         )
 
 
@@ -265,7 +267,11 @@ class MockBackendCorePlaylistsBase(unittest.TestCase):
         self.backend.uri_schemes.get.return_value = ["dummy"]
         self.backend.playlists = self.playlists
 
-        self.core = core.Core(mixer=None, backends=[self.backend])
+        self.core = core.Core(
+            config={},
+            mixer=None,
+            backends=[self.backend],
+        )
 
 
 @mock.patch("mopidy.core.playlists.logger")

--- a/tests/file/test_browse.py
+++ b/tests/file/test_browse.py
@@ -17,7 +17,7 @@ from tests import path_to_data_dir
 )
 def test_file_browse(provider, uri, levelname, caplog):
     result = provider.browse(uri)
-    assert type(result) is list
+    assert isinstance(result, list)
     if levelname:
         assert len(result) == 0
         record = caplog.records[0]

--- a/tests/file/test_browse.py
+++ b/tests/file/test_browse.py
@@ -36,11 +36,9 @@ def test_file_browse(provider, uri, levelname, caplog):
         ([], None),
         ([str(path_to_data_dir("song1.wav"))], None),
         (["|" + str(path_to_data_dir(""))], False),
-        ([str(path_to_data_dir("$"))], None),
     ],
 )
 def test_file_root_directory(provider, expected):
-    """Test root_directory()"""
     ref = provider.root_directory
     if expected is None:
         assert not ref

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -52,7 +52,10 @@ class JsonRpcTestBase(unittest.TestCase):
         self.calc = Calculator()
 
         with deprecation.ignore():
-            self.core = core.Core.start(backends=[self.backend]).proxy()
+            self.core = core.Core.start(
+                config={},
+                backends=[self.backend],
+            ).proxy()
 
         self.jrw = jsonrpc.JsonRpcWrapper(
             objects={

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -201,9 +201,12 @@ class ExpandPathTest(unittest.TestCase):
         assert str(result) == expected
 
     def test_xdg_subsititution_unknown(self):
-        result = path.expand_path("/tmp/$XDG_INVALID_DIR/foo")
+        with pytest.raises(ValueError) as exc_info:
+            path.expand_path("/tmp/$XDG_INVALID_DIR/foo")
 
-        assert result is None
+        assert str(exc_info.value) == (
+            "Unexpanded '$...' in path '/tmp/$XDG_INVALID_DIR/foo'"
+        )
 
     def test_invalid_utf8_bytes(self):
         result = path.expand_path(b"ab\xc3\x12")

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -33,7 +33,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         audio = dummy_audio.create_proxy()
         backend = M3UBackend.start(config=self.config, audio=audio).proxy()
-        self.core = core.Core(backends=[backend])
+        self.core = core.Core(config=self.config, backends=[backend])
 
     def tearDown(self):  # noqa: N802
         pykka.ActorRegistry.stop_all()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, check-manifest, docs, flake8, mypy
+envlist = py39, py310, py311, check-manifest, docs, flake8, pyright
 
 [testenv]
 sitepackages = true
@@ -28,11 +28,11 @@ deps = .[docs]
 changedir = docs
 commands = python -m sphinx -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/html
 
-[testenv:mypy]
+[testenv:pyright]
 deps =
-    .[lint]
+    .[typing]
     tornado >= 6  # First version to ship type information
-commands = python -m mypy mopidy
+commands = python -m pyright mopidy
 
 [testenv:ci]
 deps =


### PR DESCRIPTION
This switches our type checker from mypy to pyright and improves our type hints enough to pass the `mopidy` directory on pyright's `basic` level. I think this exercise proves that type-checking in Python is now a useful tool, helping detect bugs and increase the speed you can understand and navigate a code base.

Future improvements:

- [ ] Pass type checking with pyright set to `strict` instead of `basic`.
- [ ] Pass type checking of the `tests` directory too.

---

A bit of background and discussion: https://mopidy.zulipchat.com/#narrow/stream/207265-mopidy-dev/topic/Better.20typing.20of.20Mopidy/near/375844880