### PR TITLE
docs: remove references to python 3.7.

### DIFF
--- a/docs/devenv.rst
+++ b/docs/devenv.rst
@@ -58,11 +58,11 @@ Most of us use the `virtualenvwrapper
 virtualenvs, so that's what we'll be using for the examples here. First,
 install and setup virtualenvwrapper as described in their docs.
 
-To create a virtualenv named ``mopidy`` which uses Python 3.7, allows access to
+To create a virtualenv named ``mopidy``, which allows access to
 system-wide packages like GStreamer, and uses the Mopidy workspace directory as
 the "project path", run::
 
-    mkvirtualenv -a ~/mopidy-dev --python $(which python3.7) \
+    mkvirtualenv -a ~/mopidy-dev --python $(which python3) \
       --system-site-packages mopidy
 
 Now, each time you open a terminal and want to activate the ``mopidy``

--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -495,7 +495,7 @@ an example of how to use it::
     ...     f'{mopidy_soundspot.Extension.dist_name}/'
     ...     f'{mopidy_soundspot.__version__}'
     ... )
-    'Mopidy-SoundSpot/2.0.0 Mopidy/3.0.0 Python/3.7.5'
+    'Mopidy-SoundSpot/2.0.0 Mopidy/3.0.0 Python/3.9.2'
 
 Example using Requests sessions
 -------------------------------


### PR DESCRIPTION
solve #2097 

If python 3.7 and 3.8 no longer are supported, the documentation should not reference it.