### PR TITLE
deps.py and ext.py 100% coverage.

### DIFF
--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -1,28 +1,23 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, NamedTuple, Union
+from collections.abc import Iterator, Mapping
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
 
 import pkg_resources
 
 from mopidy import config as config_lib
 from mopidy import exceptions
+from mopidy.commands import Command
+from mopidy.config import ConfigSchema
 from mopidy.internal import path
 
 if TYPE_CHECKING:
-    from collections.abc import Iterator
-    from pathlib import Path
-    from typing import Any, Optional
-
     from typing_extensions import TypeAlias
-
-    from mopidy.commands import Command
-    from mopidy.config import ConfigSchema
 
     Config = dict[str, dict[str, Any]]
     RegistryEntry: TypeAlias = Union[type[Any], dict[str, Any]]
-
 
 logger = logging.getLogger(__name__)
 
@@ -84,9 +79,11 @@ class Extension:
         :param config: the Mopidy config object
         :return: pathlib.Path
         """
-        if cls.ext_name is None:
-            raise AssertionError
-        cache_dir_path = path.expand_path(config["core"]["cache_dir"]) / cls.ext_name
+        if not hasattr(cls, "ext_name") or cls.ext_name is None:
+            raise AttributeError(f"{cls} not an extension or ext_name missing!")
+        cache_dir_path = (
+            path.expand_path(config["core"]["cache_dir"]) / cls.ext_name
+        )
         path.get_or_create_dir(cache_dir_path)
         return cache_dir_path
 
@@ -97,9 +94,11 @@ class Extension:
         :param config: the Mopidy config object
         :return: pathlib.Path
         """
-        if cls.ext_name is None:
-            raise AssertionError
-        config_dir_path = path.expand_path(config["core"]["config_dir"]) / cls.ext_name
+        if not hasattr(cls, "ext_name") or cls.ext_name is None:
+            raise AttributeError(f"{cls} not an extension or ext_name missing!")
+        config_dir_path = (
+            path.expand_path(config["core"]["config_dir"]) / cls.ext_name
+        )
         path.get_or_create_dir(config_dir_path)
         return config_dir_path
 
@@ -112,9 +111,11 @@ class Extension:
         :param config: the Mopidy config object
         :returns: pathlib.Path
         """
-        if cls.ext_name is None:
-            raise AssertionError
-        data_dir_path = path.expand_path(config["core"]["data_dir"]) / cls.ext_name
+        if not hasattr(cls, "ext_name") or cls.ext_name is None:
+            raise AttributeError(f"{cls} not an extension or ext_name missing!")
+        data_dir_path = (
+            path.expand_path(config["core"]["data_dir"]) / cls.ext_name
+        )
         path.get_or_create_dir(data_dir_path)
         return data_dir_path
 

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -1,9 +1,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Iterator, Mapping
-from pathlib import Path
-from typing import TYPE_CHECKING, Any, NamedTuple, Optional, Union
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, NamedTuple, Union
 
 import pkg_resources
 
@@ -14,7 +13,10 @@ from mopidy.config import ConfigSchema
 from mopidy.internal import path
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+    from pathlib import Path
     from typing_extensions import TypeAlias
+    from typing import Any, Optional
 
     Config = dict[str, dict[str, Any]]
     RegistryEntry: TypeAlias = Union[type[Any], dict[str, Any]]
@@ -81,9 +83,7 @@ class Extension:
         """
         if not hasattr(cls, "ext_name") or cls.ext_name is None:
             raise AttributeError(f"{cls} not an extension or ext_name missing!")
-        cache_dir_path = (
-            path.expand_path(config["core"]["cache_dir"]) / cls.ext_name
-        )
+        cache_dir_path = path.expand_path(config["core"]["cache_dir"]) / cls.ext_name
         path.get_or_create_dir(cache_dir_path)
         return cache_dir_path
 
@@ -96,9 +96,7 @@ class Extension:
         """
         if not hasattr(cls, "ext_name") or cls.ext_name is None:
             raise AttributeError(f"{cls} not an extension or ext_name missing!")
-        config_dir_path = (
-            path.expand_path(config["core"]["config_dir"]) / cls.ext_name
-        )
+        config_dir_path = path.expand_path(config["core"]["config_dir"]) / cls.ext_name
         path.get_or_create_dir(config_dir_path)
         return config_dir_path
 
@@ -113,9 +111,7 @@ class Extension:
         """
         if not hasattr(cls, "ext_name") or cls.ext_name is None:
             raise AttributeError(f"{cls} not an extension or ext_name missing!")
-        data_dir_path = (
-            path.expand_path(config["core"]["data_dir"]) / cls.ext_name
-        )
+        data_dir_path = path.expand_path(config["core"]["data_dir"]) / cls.ext_name
         path.get_or_create_dir(data_dir_path)
         return data_dir_path
 

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -78,6 +78,7 @@ class TestDeps:
         assert gi.__version__ in result["other"]
         assert "Relevant elements:" in result["other"]
 
+    def test_gstreamer_check_elements(self):
         with mock.patch(
             "mopidy.internal.deps._gstreamer_check_elements",
             return_val=("test1", True),

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -12,6 +12,7 @@ class DummyExtension(ext.Extension):
     dist_name = "Mopidy-Foobar"
     ext_name = "foobar"
     version = "1.2.3"
+    location = __file__
 
     def get_default_config(self):
         return "[foobar]\nenabled = true"
@@ -79,16 +80,17 @@ class TestLoadExtensions:
         yield iter_entry_points
         patcher.stop()
 
+    @pytest.fixture
+    def mock_entry_point(self, iter_entry_points_mock):
+        entry_point = mock.Mock()
+        entry_point.resolve.return_value = DummyExtension
+        iter_entry_points_mock.return_value = [entry_point]
+        return entry_point
+
     def test_no_extensions(self, iter_entry_points_mock):
-        iter_entry_points_mock.return_value = []
         assert ext.load_extensions() == []
 
-    def test_load_extensions(self, iter_entry_points_mock):
-        mock_entry_point = mock.Mock()
-        mock_entry_point.resolve.return_value = DummyExtension
-
-        iter_entry_points_mock.return_value = [mock_entry_point]
-
+    def test_load_extensions(self, mock_entry_point):
         expected = ext.ExtensionData(
             any_testextension,
             mock_entry_point,
@@ -96,69 +98,49 @@ class TestLoadExtensions:
             any_unicode,
             None,
         )
-
         assert ext.load_extensions() == [expected]
 
-    def test_gets_wrong_class(self, iter_entry_points_mock):
+    def test_load_extensions_exception(self, mock_entry_point, caplog):
+        mock_entry_point.resolve.side_effect = Exception("test")
+        ext.load_extensions()
+        assert "Failed to load extension" in caplog.records[0].message
+
+    def test_load_extensions_real(self):
+        installed_extensions = ext.load_extensions()
+        assert len(installed_extensions)
+
+    def test_gets_wrong_class(self, mock_entry_point):
         class WrongClass:
             pass
 
-        mock_entry_point = mock.Mock()
         mock_entry_point.resolve.return_value = WrongClass
-
-        iter_entry_points_mock.return_value = [mock_entry_point]
-
         assert ext.load_extensions() == []
 
-    def test_gets_instance(self, iter_entry_points_mock):
-        mock_entry_point = mock.Mock()
+    def test_gets_instance(self, mock_entry_point):
         mock_entry_point.resolve.return_value = DummyExtension()
-
-        iter_entry_points_mock.return_value = [mock_entry_point]
-
         assert ext.load_extensions() == []
 
-    def test_creating_instance_fails(self, iter_entry_points_mock):
+    def test_creating_instance_fails(self, mock_entry_point):
         mock_extension = mock.Mock(spec=ext.Extension)
         mock_extension.side_effect = Exception
-
-        mock_entry_point = mock.Mock()
         mock_entry_point.resolve.return_value = mock_extension
-
-        iter_entry_points_mock.return_value = [mock_entry_point]
-
         assert ext.load_extensions() == []
 
-    def test_get_config_schema_fails(self, iter_entry_points_mock):
-        mock_entry_point = mock.Mock()
-        mock_entry_point.resolve.return_value = DummyExtension
-
-        iter_entry_points_mock.return_value = [mock_entry_point]
-
+    def test_get_config_schema_fails(self, mock_entry_point):
         with mock.patch.object(DummyExtension, "get_config_schema") as get:
             get.side_effect = Exception
 
             assert ext.load_extensions() == []
             get.assert_called_once_with()
 
-    def test_get_default_config_fails(self, iter_entry_points_mock):
-        mock_entry_point = mock.Mock()
-        mock_entry_point.resolve.return_value = DummyExtension
-
-        iter_entry_points_mock.return_value = [mock_entry_point]
-
+    def test_get_default_config_fails(self, mock_entry_point):
         with mock.patch.object(DummyExtension, "get_default_config") as get:
             get.side_effect = Exception
 
             assert ext.load_extensions() == []
             get.assert_called_once_with()
 
-    def test_get_command_fails(self, iter_entry_points_mock):
-        mock_entry_point = mock.Mock()
-        mock_entry_point.resolve.return_value = DummyExtension
-
-        iter_entry_points_mock.return_value = [mock_entry_point]
-
+    def test_get_command_fails(self, mock_entry_point):
         with mock.patch.object(DummyExtension, "get_command") as get:
             get.side_effect = Exception
 
@@ -180,6 +162,9 @@ class TestValidateExtensionData:
 
         return ext.ExtensionData(extension, entry_point, schema, defaults, command)
 
+    def test_ok(self, ext_data):
+        assert ext.validate_extension_data(ext_data)
+
     def test_name_mismatch(self, ext_data):
         ext_data.entry_point.name = "barfoo"
         assert not ext.validate_extension_data(ext_data)
@@ -191,6 +176,11 @@ class TestValidateExtensionData:
 
     def test_version_conflict(self, ext_data):
         error = pkg_resources.VersionConflict
+        ext_data.entry_point.require.side_effect = error
+        assert not ext.validate_extension_data(ext_data)
+        error = pkg_resources.VersionConflict(
+            ext_data.extension, "test_expected"
+        )
         ext_data.entry_point.require.side_effect = error
         assert not ext.validate_extension_data(ext_data)
 
@@ -270,3 +260,13 @@ class TestValidateExtensionData:
 
         expected = pathlib.Path(core_data_dir).resolve() / extension.ext_name
         assert data_dir == expected
+
+
+class TestRegistry:
+    def test_registry(self):
+        reg = ext.Registry()
+        assert not len(reg)
+
+        # __iter__ is implemented
+        for _entry in reg:
+            pass

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -178,9 +178,7 @@ class TestValidateExtensionData:
         error = pkg_resources.VersionConflict
         ext_data.entry_point.require.side_effect = error
         assert not ext.validate_extension_data(ext_data)
-        error = pkg_resources.VersionConflict(
-            ext_data.extension, "test_expected"
-        )
+        error = pkg_resources.VersionConflict(ext_data.extension, "test_expected")
         ext_data.entry_point.require.side_effect = error
         assert not ext.validate_extension_data(ext_data)
 


### PR DESCRIPTION
I found a couple of smaller problems in dept.py and ext.py, and of course in order to test it 100% test coverage was added.

Basically added a number of hasattr() to ensure extensions have added attributes.

This is a part of a bigger change to get rid of pkg_resources, which is out_dated and are causing problems for me. But before I remove something I like to have 100% coverage of the existing version, making it easier to see changes.