### PR TITLE
tox -e flake8 failure solved.

### DIFF
--- a/tests/file/test_browse.py
+++ b/tests/file/test_browse.py
@@ -17,7 +17,7 @@ from tests import path_to_data_dir
 )
 def test_file_browse(provider, uri, levelname, caplog):
     result = provider.browse(uri)
-    assert type(result) == list
+    assert type(result) is list
     if levelname:
         assert len(result) == 0
         record = caplog.records[0]


### PR DESCRIPTION
Running "tox -e flake8" on Mac flagged this error.