### PR TITLE
add "tox -e ci", to test before pushing.

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,12 +12,15 @@ For older releases, see :ref:`history`.
 v3.5.0 (UNRELEASED)
 ===================
 
+- tox: added "tox -e ci", to allow easy CI check before "git push".
+
 Dependencies
 ------------
 
 - Python >= 3.9 is now required. Python 3.7 and 3.8 are no longer supported.
 
 - GStreamer >= 1.18.0 is now required.
+
 
 
 v3.4.1 (2022-12-07)

--- a/tox.ini
+++ b/tox.ini
@@ -33,3 +33,15 @@ deps =
     .[lint]
     tornado >= 6  # First version to ship type information
 commands = python -m mypy mopidy
+
+[testenv:ci]
+deps =
+    {[testenv]deps}
+    {[testenv:check-manifest]deps}
+    {[testenv:flake8]deps}
+    {[testenv:mypy]deps}
+commands =
+    {[testenv]commands}
+    {[testenv:check-manifest]commands}
+    {[testenv:flake8]commands}
+    {[testenv:mypy]commands}


### PR DESCRIPTION
This allows to run a limited CI locally before pushing a PR.

It is limited in the sense that:
- all steps run with the installed python
- CodeQL is not run
- Coverage is not run
- "tox -e docs" is not run

It runs:
- pytest
- check-manifest
- flake8
- mypy
which covers programming errors.

Update changelog.rst to reflect this new possibility (not sure if that is correct).