### PR TITLE
Set codecov threshold to 0.3% before failing.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,5 @@
+coverage:
+  status:
+    project:
+      default:
+        threshold: 0.3%


### PR DESCRIPTION
There are a number of false positives, where codecov claims the coverage have fallen 0,1% even though the code in reality have not been changed.

Adding codecov.yml allows to the threshold (and a world of other parameters) which the codecov action will then transmit.

This PR is tested on #2102, which turned green with this PR.