### PR TITLE
tox CI now uses pyright.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 .cache/
 .coverage
 .idea
-.mypy_cache/
 .noseids
 .pytest_cache/
 .tox

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -13,6 +13,7 @@ v3.5.0 (UNRELEASED)
 ===================
 
 - tox: added "tox -e ci", to allow easy CI check before "git push".
+- tox: changed from mypy to pyright
 
 Dependencies
 ------------

--- a/tox.ini
+++ b/tox.ini
@@ -39,9 +39,9 @@ deps =
     {[testenv]deps}
     {[testenv:check-manifest]deps}
     {[testenv:flake8]deps}
-    {[testenv:mypy]deps}
+    {[testenv:pyright]deps}
 commands =
     {[testenv]commands}
     {[testenv:check-manifest]commands}
     {[testenv:flake8]commands}
-    {[testenv:mypy]commands}
+    {[testenv:pyright]commands}


### PR DESCRIPTION
We have now activated pyright (even though I miss pyrightconfig.json), so "tox -e ci" should also be updated.