### PR TITLE
Replace flake8 and isort with ruff

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,12 +26,12 @@ jobs:
           - name: "Lint: check-manifest"
             python: "3.11"
             tox: check-manifest
-          - name: "Lint: flake8"
-            python: "3.11"
-            tox: flake8
           - name: "Lint: pyright"
             python: "3.11"
             tox: pyright
+          - name: "Lint: ruff"
+            python: "3.11"
+            tox: ruff
           - name: "Docs"
             python: "3.11"
             tox: docs

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,24 @@
+# Run `pre-commit install` to install the pre-commit hooks.
+#
+# Run `pre-commit autoupdate` to update all the plugins here.
+#
+# See https://pre-commit.com for more information.
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.4.0
+    hooks:
+      - id: trailing-whitespace
+      - id: check-toml
+  - repo: local
+    hooks:
+      - id: ruff
+        name: ruff
+        entry: ruff
+        language: system
+        types: [python]
+      - id: black
+        name: black
+        entry: black
+        language: system
+        types: [python]

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,6 +2,7 @@ include *.py
 include *.rst
 include *.toml
 include .mailmap
+include .pre-commit-config.yaml
 include .readthedocs.yml
 include AUTHORS
 include AUTHORS.update

--- a/docs/codestyle.rst
+++ b/docs/codestyle.rst
@@ -6,19 +6,13 @@ Code style
 
 All projects in the Mopidy organization follows the following code style:
 
-- Automatically format all code with `Black <https://black.readthedocs.io/>`_.
-  Use Black's string normalization, which prefers ``"`` quotes over ``'``,
-  unless the string contains ``"``.
+- Automatically format all code with `Black <https://black.readthedocs.io/>`_,
+  using the default configuration.
 
-- Automatically sort imports using `isort <https://timothycrosley.github.io/isort>`_.
-  
-- Follow :pep:`8`.
-  Run `flake8 <https://pypi.org/project/flake8>`_  to check your code
-  against the guidelines.
+- Automatically sort imports using `Ruff <https://github.com/astral-sh/ruff>`_.
 
-The strict adherence to Black and flake8 are enforced by our CI setup.
+- As far as reasonable and possible, comply with the lint warnings produced by
+  Ruff.
+
+The strict adherence to Black and Ruff are enforced by our CI setup.
 Pull requests that do not pass these checks will not be merged.
-
-For more general advise,
-take a look at :pep:`20` for a nice peek into a general mindset
-useful for Python coding.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,10 +30,9 @@ class Mock:
     def __getattr__(cls, name):
         if name == "get_system_config_dirs":  # GLib.get_system_config_dirs()
             return list
-        elif name == "get_user_config_dir":  # GLib.get_user_config_dir()
+        if name == "get_user_config_dir":  # GLib.get_user_config_dir()
             return str
-        else:
-            return Mock()
+        return Mock()
 
 
 MOCK_MODULES = [

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ class Mock:
         return Mock()
 
     def __mro_entries__(self, bases):
-        return tuple()
+        return ()
 
     @classmethod
     def __getattr__(cls, name):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,8 +7,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + "/../"))
 
-from mopidy.internal.versioning import get_version  # isort:skip
-
+from mopidy.internal.versioning import get_version  # noqa: E402
 
 # -- Workarounds to have autodoc generate API docs ----------------------------
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,11 +1,11 @@
 """Mopidy documentation build configuration file"""
 
 
-import os
 import sys
+from pathlib import Path
 
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
-sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + "/../"))
+sys.path.insert(0, str(Path(__file__).parent.resolve()))
+sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
 
 from mopidy.internal.versioning import get_version  # noqa: E402
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -77,7 +77,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 project = "Mopidy"
-copyright = "2009-2023, Stein Magnus Jodal and contributors"
+copyright = "2009-2023, Stein Magnus Jodal and contributors"  # noqa: A001
 
 
 release = get_version()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -17,7 +17,7 @@ class Mock:
     def __init__(self, *args, **kwargs):
         pass
 
-    def __call__(self, *args, **kwargs):
+    def __call__(self, *_args, **_kwargs):
         return Mock()
 
     def __or__(self, other):

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -7,7 +7,7 @@ import sys
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__) + "/../"))
 
-from mopidy.internal.versioning import get_version  # isort:skip  # noqa
+from mopidy.internal.versioning import get_version  # isort:skip
 
 
 # -- Workarounds to have autodoc generate API docs ----------------------------

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -86,8 +86,8 @@ Pull request guidelines
      ``docs/add-ext-mopidy-spotify-tunigo``.
 
 #. Follow the :ref:`code style <codestyle>`, especially make sure the
-   ``flake8`` linter does not complain about anything. Our CI setup will
-   check that your pull request is "flake8 clean". See :ref:`code-linting`.
+   ``ruff`` linter does not complain about anything. Our CI setup will
+   check that your pull request is "ruff clean". See :ref:`code-linting`.
 
 #. Include tests for any new feature or substantial bug fix. See
    :ref:`running-tests`.

--- a/docs/devenv.rst
+++ b/docs/devenv.rst
@@ -257,7 +257,7 @@ is all you need to know. Always run this command before pushing your changes to
 GitHub.
 
 If you take a look at the tox config file, :file:`tox.ini`, you'll see that tox
-runs tests in multiple environments, including a ``flake8`` environment that
+runs tests in multiple environments, including a ``ruff`` environment that
 lints the source code for issues and a ``docs`` environment that tests that the
 documentation can be built. You can also limit tox to just test specific
 environments using the ``-e`` option, e.g. to run just unit tests::
@@ -341,26 +341,26 @@ Style checking and linting
 We're quite pedantic about :ref:`codestyle` and try hard to keep the Mopidy
 code base a very clean and nice place to work in.
 
-Luckily, you can get very far by using the `flake8
-<https://flake8.pycqa.org/en/latest/>`_ linter to check your code for issues before
-submitting a pull request. Mopidy passes all of flake8's checks, with only a
-very few exceptions configured in :file:`setup.cfg`. You can either run the
-``flake8`` tox environment, like our CI setup will do on your pull request::
+Luckily, you can get very far by using the `ruff
+<https://github.com/astral-sh/ruff>`_ linter to check your code for issues before
+submitting a pull request. Mopidy's ruff rules are configured in :file:`pyproject.toml`.
+You can either run the ``ruff`` tox environment, like our CI setup will do on
+your pull request::
 
-    tox -e flake8
+    tox -e ruff
 
-Or you can run flake8 directly::
+Or you can run ruff directly::
 
-    flake8
+    ruff .
 
 If successful, the command will not print anything at all.
 
 .. note::
 
-    In some rare cases it doesn't make sense to listen to flake8's warnings. In
+    In some rare cases it doesn't make sense to listen to ruff's warnings. In
     those cases, ignore the check by appending ``# noqa: <warning code>`` to
     the source line that triggers the warning. The ``# noqa`` part will make
-    flake8 skip all checks on the line, while the warning code will help other
+    ruff skip all checks on the line, while the warning code will help other
     developers lookup what you are ignoring.
 
 
@@ -410,8 +410,8 @@ Working on extensions
 
 Much of the above also applies to Mopidy extensions, though they're often a bit
 simpler. They don't have documentation sites and their test suites are either
-small and fast, or sadly missing entirely. Most of them use tox and flake8, and
-pytest can be used to run their test suites.
+small and fast, or sadly missing entirely. Most of them use tox to run various
+linters, and pytest can be used to run their test suites.
 
 .. contents::
    :local:

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -168,8 +168,7 @@ def create_core_dirs(config):
 
 
 def create_initial_config_file(args, extensions_data):
-    """Initialize whatever the last config file is with defaults"""
-
+    """Initialize whatever the last config file is with defaults."""
     config_file = path.expand_path(args.config_files[-1])
 
     if config_file.exists():

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -11,7 +11,7 @@ from mopidy import commands
 from mopidy import config as config_lib
 from mopidy import ext
 from mopidy.internal import log, path, process, versioning
-from mopidy.internal.gi import Gst  # noqa: F401
+from mopidy.internal.gi import Gst
 
 try:
     # Make GLib's mainloop the event loop for python-dbus

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -7,9 +7,8 @@ from typing import TYPE_CHECKING, TypedDict
 
 import pykka.debug
 
-from mopidy import commands
+from mopidy import commands, ext
 from mopidy import config as config_lib
-from mopidy import ext
 from mopidy.internal import log, path, process, versioning
 from mopidy.internal.gi import Gst
 
@@ -114,7 +113,7 @@ def main():
         if args.command == config_cmd:
             schemas = [d.config_schema for d in extensions_data]
             return args.command.run(config, config_errors, schemas)
-        elif args.command == deps_cmd:
+        if args.command == deps_cmd:
             return args.command.run()
 
         check_config_errors(config, config_errors, extensions_status)

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -150,7 +150,7 @@ def main():
         try:
             return args.command.run(args, proxied_config)
         except NotImplementedError:
-            print(root_cmd.format_help())
+            print(root_cmd.format_help())  # noqa: T201
             return 1
 
     except KeyboardInterrupt:

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -198,14 +198,14 @@ def log_extension_info(all_extensions, enabled_extensions):
 def check_config_errors(
     config: config_lib.Config,
     errors: config_lib.ConfigErrors,
-    extensions,
+    extensions_status: ExtensionsStatus,
 ) -> None:
     fatal_errors = []
     extension_names = {}
     all_extension_names = set()
 
-    for state in extensions:
-        extension_names[state] = {e.ext_name for e in extensions[state]}
+    for state in extensions_status:
+        extension_names[state] = {e.ext_name for e in extensions_status[state]}
         all_extension_names.update(extension_names[state])
 
     for section in sorted(errors):
@@ -227,7 +227,7 @@ def check_config_errors(
         for field, msg in errors[section].items():
             logger.warning(f"  {section}/{field} {msg}")
 
-    if extensions["config"]:
+    if extensions_status["config"]:
         logger.warning(
             "Please fix the extension configuration errors or "
             "disable the extensions to silence these messages."

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -33,7 +33,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def main():
+def main() -> int:  # noqa: C901, PLR0912, PLR0915
     log.bootstrap_delayed_logging()
     logger.info(f"Starting Mopidy {versioning.get_version()}")
 
@@ -154,7 +154,7 @@ def main():
             return 1
 
     except KeyboardInterrupt:
-        pass
+        return 0
     except Exception:
         logger.exception("Unhandled exception")
         raise

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -10,7 +10,7 @@ import pykka.debug
 from mopidy import commands, ext
 from mopidy import config as config_lib
 from mopidy.internal import log, path, process, versioning
-from mopidy.internal.gi import Gst
+from mopidy.internal.gi import Gst  # noqa: F401 (imported to test GStreamer presence)
 
 try:
     # Make GLib's mainloop the event loop for python-dbus

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -116,7 +116,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
         if args.command == deps_cmd:
             return args.command.run()
 
-        check_config_errors(config, config_errors, extensions_status)
+        check_config_errors(config_errors, extensions_status)
 
         if not extensions_status["enabled"]:
             logger.error("No extension enabled, exiting...")
@@ -196,7 +196,6 @@ def log_extension_info(all_extensions, enabled_extensions):
 
 
 def check_config_errors(
-    config: config_lib.Config,
     errors: config_lib.ConfigErrors,
     extensions_status: ExtensionsStatus,
 ) -> None:

--- a/mopidy/__main__.py
+++ b/mopidy/__main__.py
@@ -155,8 +155,8 @@ def main():
 
     except KeyboardInterrupt:
         pass
-    except Exception as ex:
-        logger.exception(ex)
+    except Exception:
+        logger.exception("Unhandled exception")
         raise
 
 

--- a/mopidy/audio/__init__.py
+++ b/mopidy/audio/__init__.py
@@ -1,4 +1,5 @@
-# flake8: noqa
+# ruff: noqa
+
 from typing import TYPE_CHECKING
 
 from .actor import Audio

--- a/mopidy/audio/__init__.py
+++ b/mopidy/audio/__init__.py
@@ -1,11 +1,12 @@
-# ruff: noqa
-
-from typing import TYPE_CHECKING
-
-from .actor import Audio
+from .actor import Audio, AudioProxy
 from .constants import PlaybackState
 from .listener import AudioListener
 from .utils import supported_uri_schemes
 
-if TYPE_CHECKING:
-    from .actor import AudioProxy
+__all__ = [
+    "Audio",
+    "AudioProxy",
+    "PlaybackState",
+    "AudioListener",
+    "supported_uri_schemes",
+]

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -246,7 +246,7 @@ class _Handler:
             self._pad.remove_probe(self._event_handler_id)
         self._event_handler_id = None
 
-    def on_message(self, _bus, msg):
+    def on_message(self, _bus, msg) -> None:  # noqa: C901
         if msg.type == Gst.MessageType.STATE_CHANGED:
             if msg.src != self._element:
                 return

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -154,7 +154,9 @@ class _Outputs(Gst.Bin):
             )
         except GLib.Error as exc:
             logger.error('Failed to create audio output "%s": %s', description, exc)
-            raise exceptions.AudioException(exc)
+            raise exceptions.AudioException(
+                f"Failed to create audio output {description!r}"
+            ) from exc
 
         self._add(output)
         logger.info('Audio output set to "%s"', description)
@@ -502,8 +504,8 @@ class Audio(pykka.ThreadingActor):
             self._setup_playbin()
             self._setup_outputs()
             self._setup_audio_sink()
-        except GLib.Error as exc:
-            logger.exception(exc)
+        except GLib.Error:
+            logger.exception("Unknown GLib error on audio startup.")
             process.exit_process()
 
     def on_stop(self) -> None:

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -657,7 +657,7 @@ class Audio(pykka.ThreadingActor):
         if self._live_stream and hasattr(source.props, "is_live"):
             gst_logger.debug("Enabling live stream mode")
             # TODO(typing): Once pygobject-stubs includes GstApp, cast to AppSrc:
-            # source = cast(GstApp.AppSrc, source)
+            # source = cast(GstApp.AppSrc, source)  # noqa: ERA001
             source.set_live(True)  # pyright: ignore[reportGeneralTypeIssues]
 
         utils.setup_proxy(source, self._config["proxy"])

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -113,9 +113,9 @@ class _Appsrc:
             gst_logger.debug("Sending appsrc end-of-stream event.")
             result = self._source.emit("end-of-stream")
             return result == Gst.FlowReturn.OK
-        else:
-            result = self._source.emit("push-buffer", buffer_)
-            return result == Gst.FlowReturn.OK
+
+        result = self._source.emit("push-buffer", buffer_)
+        return result == Gst.FlowReturn.OK
 
     def _on_signal(self, element, clocktime, func) -> bool:
         # This shim is used to ensure we always return true, and also handles
@@ -813,10 +813,9 @@ class Audio(pykka.ThreadingActor):
         # duplicate seek events making it to appsrc. Since elements are not
         # allowed to act on the seek event, only modify it, this should be safe
         # to do.
-        result = self._queue.seek_simple(
+        return self._queue.seek_simple(
             Gst.Format.TIME, Gst.SeekFlags.FLUSH, gst_position
         )
-        return result
 
     def start_playback(self) -> bool:
         """Notify GStreamer that it should start playback.

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -680,10 +680,7 @@ class Audio(pykka.ThreadingActor):
 
         # XXX: Hack to workaround issue on Mac OS X where volume level
         # does not persist between track changes. mopidy/mopidy#886
-        if self.mixer is not None:
-            current_volume = self.mixer.get_volume()
-        else:
-            current_volume = None
+        current_volume = self.mixer.get_volume() if self.mixer is not None else None
 
         flags = _GST_PLAY_FLAGS_AUDIO
         if download:

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -118,7 +118,7 @@ class _Appsrc:
         result = self._source.emit("push-buffer", buffer_)
         return result == Gst.FlowReturn.OK
 
-    def _on_signal(self, element, clocktime, func) -> bool:
+    def _on_signal(self, _element, clocktime, func) -> bool:
         # This shim is used to ensure we always return true, and also handles
         # that not all the callbacks have a time argument.
         if clocktime is None:
@@ -244,7 +244,7 @@ class _Handler:
             self._pad.remove_probe(self._event_handler_id)
         self._event_handler_id = None
 
-    def on_message(self, bus, msg):
+    def on_message(self, _bus, msg):
         if msg.type == Gst.MessageType.STATE_CHANGED:
             if msg.src != self._element:
                 return
@@ -271,7 +271,7 @@ class _Handler:
         elif msg.type == Gst.MessageType.STREAM_START:
             self.on_stream_start()
 
-    def on_pad_event(self, pad, pad_probe_info):
+    def on_pad_event(self, _pad, pad_probe_info):
         event = pad_probe_info.get_event()
         if event.type == Gst.EventType.SEGMENT:
             self.on_segment(event.parse_segment())
@@ -616,7 +616,7 @@ class Audio(pykka.ThreadingActor):
         if self.mixer:
             self.mixer.teardown()
 
-    def _on_about_to_finish(self, element: Gst.Element) -> None:
+    def _on_about_to_finish(self, _element: Gst.Element) -> None:
         if self._thread == threading.current_thread():
             logger.error("about-to-finish in actor, aborting to avoid deadlock.")
             return
@@ -628,7 +628,7 @@ class Audio(pykka.ThreadingActor):
 
     def _on_source_setup(
         self,
-        element: Gst.Element,
+        _element: Gst.Element,
         source: Gst.Element,
     ) -> None:
         gst_logger.debug(

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -15,12 +15,12 @@ from mopidy.audio.constants import PlaybackState
 from mopidy.audio.listener import AudioListener
 from mopidy.internal import process
 from mopidy.internal.gi import GLib, GObject, Gst, GstPbutils
-from mopidy.softwaremixer.mixer import SoftwareMixerProxy
 
 if TYPE_CHECKING:
     from mopidy.config import Config
     from mopidy.mixer import MixerProxy
     from mopidy.models import Track
+    from mopidy.softwaremixer.mixer import SoftwareMixerProxy
 
 logger = logging.getLogger(__name__)
 
@@ -490,6 +490,8 @@ class Audio(pykka.ThreadingActor):
         self._signals = utils.Signals()
 
         if mixer and self._config["audio"]["mixer"] == "software":
+            from mopidy.softwaremixer.mixer import SoftwareMixerProxy
+
             mixer = cast(SoftwareMixerProxy, mixer)
             self.mixer = pykka.traversable(SoftwareMixerAdapter(mixer))
 

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -410,7 +410,7 @@ class _Handler:
         logger.warning("Could not find a %s to handle media.", desc)
         if GstPbutils.install_plugins_supported():
             logger.info(
-                "You might be able to fix this by running: " 'gst-installer "%s"',
+                "You might be able to fix this by running: 'gst-installer \"%s\"'",
                 debug,
             )
         # TODO: store the missing plugins installer info in a file so we can

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -6,6 +6,7 @@ import threading
 from typing import TYPE_CHECKING, Any, Callable, Optional, cast
 
 import pykka
+from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
 
 from mopidy import exceptions
 from mopidy.audio import tags as tags_lib
@@ -14,12 +15,12 @@ from mopidy.audio.constants import PlaybackState
 from mopidy.audio.listener import AudioListener
 from mopidy.internal import process
 from mopidy.internal.gi import GLib, GObject, Gst, GstPbutils
+from mopidy.softwaremixer.mixer import SoftwareMixerProxy
 
 if TYPE_CHECKING:
     from mopidy.config import Config
     from mopidy.mixer import MixerProxy
     from mopidy.models import Track
-    from mopidy.softwaremixer.mixer import SoftwareMixerProxy
 
 logger = logging.getLogger(__name__)
 
@@ -977,25 +978,22 @@ class Audio(pykka.ThreadingActor):
         return self._tags
 
 
-if TYPE_CHECKING:
-    from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
+class AudioProxy(ActorMemberMixin, pykka.ActorProxy[Audio]):
+    """Audio layer wrapped in a Pykka actor proxy."""
 
-    class AudioProxy(ActorMemberMixin, pykka.ActorProxy[Audio]):
-        """Audio layer wrapped in a Pykka actor proxy."""
-
-        state = proxy_field(Audio.state)
-        set_uri = proxy_method(Audio.set_uri)
-        set_appsrc = proxy_method(Audio.set_appsrc)
-        emit_data = proxy_method(Audio.emit_data)
-        set_source_setup_callback = proxy_method(Audio.set_source_setup_callback)
-        set_about_to_finish_callback = proxy_method(Audio.set_about_to_finish_callback)
-        get_position = proxy_method(Audio.get_position)
-        set_position = proxy_method(Audio.set_position)
-        start_playback = proxy_method(Audio.start_playback)
-        pause_playback = proxy_method(Audio.pause_playback)
-        prepare_change = proxy_method(Audio.prepare_change)
-        stop_playback = proxy_method(Audio.stop_playback)
-        wait_for_state_change = proxy_method(Audio.wait_for_state_change)
-        enable_sync_handler = proxy_method(Audio.enable_sync_handler)
-        set_metadata = proxy_method(Audio.set_metadata)
-        get_current_tags = proxy_method(Audio.get_current_tags)
+    state = proxy_field(Audio.state)
+    set_uri = proxy_method(Audio.set_uri)
+    set_appsrc = proxy_method(Audio.set_appsrc)
+    emit_data = proxy_method(Audio.emit_data)
+    set_source_setup_callback = proxy_method(Audio.set_source_setup_callback)
+    set_about_to_finish_callback = proxy_method(Audio.set_about_to_finish_callback)
+    get_position = proxy_method(Audio.get_position)
+    set_position = proxy_method(Audio.set_position)
+    start_playback = proxy_method(Audio.start_playback)
+    pause_playback = proxy_method(Audio.pause_playback)
+    prepare_change = proxy_method(Audio.prepare_change)
+    stop_playback = proxy_method(Audio.stop_playback)
+    wait_for_state_change = proxy_method(Audio.wait_for_state_change)
+    enable_sync_handler = proxy_method(Audio.enable_sync_handler)
+    set_metadata = proxy_method(Audio.set_metadata)
+    get_current_tags = proxy_method(Audio.get_current_tags)

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -40,7 +40,6 @@ _GST_STATE_MAPPING: dict[Gst.State, PlaybackState] = {
 
 # TODO: expose this as a property on audio?
 class _Appsrc:
-
     """Helper class for dealing with appsrc based playback."""
 
     def __init__(self) -> None:
@@ -455,10 +454,7 @@ class _Handler:
 
 # TODO: create a player class which replaces the actors internals
 class Audio(pykka.ThreadingActor):
-
-    """
-    Audio output through `GStreamer <https://gstreamer.freedesktop.org/>`_.
-    """
+    """Audio output through `GStreamer <https://gstreamer.freedesktop.org/>`_."""
 
     #: The GStreamer state mapped to :class:`mopidy.audio.PlaybackState`
     state: PlaybackState = PlaybackState.STOPPED
@@ -667,8 +663,7 @@ class Audio(pykka.ThreadingActor):
         live_stream: bool = False,
         download: bool = False,
     ) -> None:
-        """
-        Set URI of audio to be played.
+        """Set URI of audio to be played.
 
         You *MUST* call :meth:`prepare_change` before calling this method.
 
@@ -716,8 +711,7 @@ class Audio(pykka.ThreadingActor):
         enough_data: Optional[Callable] = None,
         seek_data: Optional[Callable] = None,
     ) -> None:
-        """
-        Switch to using appsrc for getting audio to be played.
+        """Switch to using appsrc for getting audio to be played.
 
         You *MUST* call :meth:`prepare_change` before calling this method.
 
@@ -747,8 +741,7 @@ class Audio(pykka.ThreadingActor):
         self._playbin.set_property("uri", uri)
 
     def emit_data(self, buffer_: Optional[Gst.Buffer]) -> bool:
-        """
-        Call this to deliver raw audio data to be played.
+        """Call this to deliver raw audio data to be played.
 
         If the buffer is :class:`None`, the end-of-stream token is put on the
         playbin. We will get a GStreamer message when the stream playback
@@ -765,8 +758,7 @@ class Audio(pykka.ThreadingActor):
         return self._appsrc.push(buffer_)
 
     def set_source_setup_callback(self, callback: Callable) -> None:
-        """
-        Configure audio to use a source-setup callback.
+        """Configure audio to use a source-setup callback.
 
         This should be used to modify source-specific properties such as login
         details.
@@ -776,8 +768,7 @@ class Audio(pykka.ThreadingActor):
         self._source_setup_callback = callback
 
     def set_about_to_finish_callback(self, callback: Callable) -> None:
-        """
-        Configure audio to use an about-to-finish callback.
+        """Configure audio to use an about-to-finish callback.
 
         This should be used to achieve gapless playback. For this to work the
         callback *MUST* call :meth:`set_uri` with the new URI to play and
@@ -789,8 +780,7 @@ class Audio(pykka.ThreadingActor):
         self._about_to_finish_callback = callback
 
     def get_position(self) -> int:
-        """
-        Get position in milliseconds.
+        """Get position in milliseconds.
 
         :rtype: int
         """
@@ -807,8 +797,7 @@ class Audio(pykka.ThreadingActor):
         return utils.clocktime_to_millisecond(position)
 
     def set_position(self, position: int) -> bool:
-        """
-        Set position in milliseconds.
+        """Set position in milliseconds.
 
         :param position: the position in milliseconds
         :type position: int
@@ -830,24 +819,21 @@ class Audio(pykka.ThreadingActor):
         return result
 
     def start_playback(self) -> bool:
-        """
-        Notify GStreamer that it should start playback.
+        """Notify GStreamer that it should start playback.
 
         :rtype: :class:`True` if successfull, else :class:`False`
         """
         return self._set_state(Gst.State.PLAYING)
 
     def pause_playback(self) -> bool:
-        """
-        Notify GStreamer that it should pause playback.
+        """Notify GStreamer that it should pause playback.
 
         :rtype: :class:`True` if successfull, else :class:`False`
         """
         return self._set_state(Gst.State.PAUSED)
 
     def prepare_change(self) -> bool:
-        """
-        Notify GStreamer that we are about to change state of playback.
+        """Notify GStreamer that we are about to change state of playback.
 
         This function *MUST* be called before changing URIs or doing
         changes like updating data that is being pushed. The reason for this
@@ -857,8 +843,7 @@ class Audio(pykka.ThreadingActor):
         return self._set_state(Gst.State.READY)
 
     def stop_playback(self) -> bool:
-        """
-        Notify GStreamer that is should stop playback.
+        """Notify GStreamer that is should stop playback.
 
         :rtype: :class:`True` if successfull, else :class:`False`
         """
@@ -891,8 +876,7 @@ class Audio(pykka.ThreadingActor):
         bus.set_sync_handler(sync_handler)
 
     def _set_state(self, state: Gst.State) -> bool:
-        """
-        Internal method for setting the raw GStreamer state.
+        """Internal method for setting the raw GStreamer state.
 
         .. digraph:: gst_state_transitions
 
@@ -933,8 +917,7 @@ class Audio(pykka.ThreadingActor):
 
     # TODO: bake this into setup appsrc perhaps?
     def set_metadata(self, track: Track) -> None:
-        """
-        Set track metadata for currently playing song.
+        """Set track metadata for currently playing song.
 
         Only needs to be called by sources such as ``appsrc`` which do not
         already inject tags in playbin, e.g. when using :meth:`emit_data` to
@@ -980,8 +963,7 @@ class Audio(pykka.ThreadingActor):
             self._playbin.send_event(event)
 
     def get_current_tags(self) -> dict[str, list[Any]]:
-        """
-        Get the currently playing media's tags.
+        """Get the currently playing media's tags.
 
         If no tags have been found, or nothing is playing this returns an empty
         dictionary. For each set of tags we collect a tags_changed event is

--- a/mopidy/audio/constants.py
+++ b/mopidy/audio/constants.py
@@ -2,10 +2,7 @@ from enum import Enum
 
 
 class PlaybackState(str, Enum):
-
-    """
-    Enum of playback states.
-    """
+    """Enum of playback states."""
 
     #: Constant representing the paused state.
     PAUSED = "paused"

--- a/mopidy/audio/listener.py
+++ b/mopidy/audio/listener.py
@@ -21,7 +21,6 @@ class AudioListener(listener.Listener):
 
         *MAY* be implemented by actor.
         """
-        pass
 
     def stream_changed(self, uri):
         """Called whenever the audio stream changes.
@@ -30,7 +29,6 @@ class AudioListener(listener.Listener):
 
         :param string uri: URI the stream has started playing.
         """
-        pass
 
     def position_changed(self, position):
         """Called whenever the position of the stream changes.
@@ -39,7 +37,6 @@ class AudioListener(listener.Listener):
 
         :param int position: Position in milliseconds.
         """
-        pass
 
     def state_changed(self, old_state, new_state, target_state):
         """Called after the playback state have changed.
@@ -67,7 +64,6 @@ class AudioListener(listener.Listener):
         :type target_state: string from :class:`mopidy.core.PlaybackState`
             field or :class:`None` if this is a final state.
         """
-        pass
 
     def tags_changed(self, tags):
         """Called whenever the current audio stream's tags change.
@@ -84,4 +80,3 @@ class AudioListener(listener.Listener):
         :param tags: The tags that have just been updated.
         :type tags: :class:`set` of strings
         """
-        pass

--- a/mopidy/audio/listener.py
+++ b/mopidy/audio/listener.py
@@ -2,9 +2,7 @@ from mopidy import listener
 
 
 class AudioListener(listener.Listener):
-
-    """
-    Marker interface for recipients of events sent by the audio actor.
+    """Marker interface for recipients of events sent by the audio actor.
 
     Any Pykka actor that mixes in this class will receive calls to the methods
     defined here when the corresponding events happen in the core actor. This
@@ -15,20 +13,18 @@ class AudioListener(listener.Listener):
 
     @staticmethod
     def send(event, **kwargs):
-        """Helper to allow calling of audio listener events"""
+        """Helper to allow calling of audio listener events."""
         listener.send(AudioListener, event, **kwargs)
 
     def reached_end_of_stream(self):
-        """
-        Called whenever the end of the audio stream is reached.
+        """Called whenever the end of the audio stream is reached.
 
         *MAY* be implemented by actor.
         """
         pass
 
     def stream_changed(self, uri):
-        """
-        Called whenever the audio stream changes.
+        """Called whenever the audio stream changes.
 
         *MAY* be implemented by actor.
 
@@ -37,8 +33,7 @@ class AudioListener(listener.Listener):
         pass
 
     def position_changed(self, position):
-        """
-        Called whenever the position of the stream changes.
+        """Called whenever the position of the stream changes.
 
         *MAY* be implemented by actor.
 
@@ -47,8 +42,7 @@ class AudioListener(listener.Listener):
         pass
 
     def state_changed(self, old_state, new_state, target_state):
-        """
-        Called after the playback state have changed.
+        """Called after the playback state have changed.
 
         Will be called for both immediate and async state changes in GStreamer.
 
@@ -76,8 +70,7 @@ class AudioListener(listener.Listener):
         pass
 
     def tags_changed(self, tags):
-        """
-        Called whenever the current audio stream's tags change.
+        """Called whenever the current audio stream's tags change.
 
         This event signals that some track metadata has been updated. This can
         be metadata such as artists, titles, organization, or details about the

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -307,10 +307,14 @@ def _process(
                 have_audio = True
         elif msg.type == Gst.MessageType.ERROR:
             error, _debug = msg.parse_error()
-            if missing_message and not mime and (
-                (structure := missing_message.get_structure())
-                and (caps := structure.get_value("detail"))
-                and (mime := caps.get_structure(0).get_name())
+            if (
+                missing_message
+                and not mime
+                and (
+                    (structure := missing_message.get_structure())
+                    and (caps := structure.get_value("detail"))
+                    and (mime := caps.get_structure(0).get_name())
+                )
             ):
                 return tags, mime, have_audio, duration
             raise exceptions.ScannerError(str(error))

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -2,6 +2,7 @@ import collections
 import logging
 import time
 from enum import IntEnum
+from pathlib import Path
 from typing import Any, Optional, cast
 
 from mopidy import exceptions
@@ -356,7 +357,6 @@ def _process(
 
 
 if __name__ == "__main__":
-    import os
     import sys
 
     from mopidy.internal import path
@@ -369,7 +369,7 @@ if __name__ == "__main__":
     scanner = Scanner(5000)
     for uri in sys.argv[1:]:
         if not Gst.uri_is_valid(uri):
-            uri = path.path_to_uri(os.path.abspath(uri))
+            uri = path.path_to_uri(Path(uri).resolve())
         try:
             result = scanner.scan(uri)
             for key in ("uri", "mime", "duration", "playable", "seekable"):

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -374,12 +374,12 @@ if __name__ == "__main__":
             result = scanner.scan(uri)
             for key in ("uri", "mime", "duration", "playable", "seekable"):
                 value = getattr(result, key)
-                print(f"{key:<20}   {value}")
-            print("tags")
+                print(f"{key:<20}   {value}")  # noqa: T201
+            print("tags")  # noqa: T201
             for tag, value in result.tags.items():
                 line = f"{tag:<20}   {value}"
                 if len(line) > 77:
                     line = line[:77] + "..."
-                print(line)
+                print(line)  # noqa: T201
         except exceptions.ScannerError as error:
-            print(f"{uri}: {error}")
+            print(f"{uri}: {error}")  # noqa: T201

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -38,9 +38,7 @@ def _trace(*args, **kwargs):
 
 # TODO: replace with a scan(uri, timeout=1000, proxy_config=None)?
 class Scanner:
-
-    """
-    Helper to get tags and other relevant info from URIs.
+    """Helper to get tags and other relevant info from URIs.
 
     :param timeout: timeout for scanning a URI in ms
     :param proxy_config: dictionary containing proxy config strings.
@@ -52,8 +50,7 @@ class Scanner:
         self._proxy_config = proxy_config or {}
 
     def scan(self, uri, timeout=None):
-        """
-        Scan the given uri collecting relevant metadata.
+        """Scan the given uri collecting relevant metadata.
 
         :param uri: URI of the resource to scan.
         :type uri: string

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -117,9 +117,11 @@ def _has_src_pads(element):
 
 def _has_dynamic_src_pad(element):
     for template in element.get_pad_template_list():
-        if template.direction == Gst.PadDirection.SRC:
-            if template.presence == Gst.PadPresence.SOMETIMES:
-                return True
+        if (
+            template.direction == Gst.PadDirection.SRC
+            and template.presence == Gst.PadPresence.SOMETIMES
+        ):
+            return True
     return False
 
 

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -146,7 +146,7 @@ def _setup_decodebin(element, pad, pipeline, signals):
 
 def _have_type(
     element: Gst.Element,
-    probability: int,
+    _probability: int,
     caps: Gst.Caps,
     decodebin: Gst.Bin,
 ) -> None:
@@ -204,8 +204,8 @@ def _pad_added(
 
 def _autoplug_select(
     element: Gst.Element,
-    pad: Gst.Pad,
-    caps: Gst.Caps,
+    _pad: Gst.Pad,
+    _caps: Gst.Caps,
     factory: Gst.ElementFactory,
 ) -> GstAutoplugSelectResult:
     if factory.list_is_type(

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -255,7 +255,7 @@ def _query_seekable(pipeline: Gst.Pipeline) -> bool:
     return query.parse_seeking()[1]
 
 
-def _process(
+def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
     pipeline: Gst.Pipeline,
     timeout_ms: int,
 ) -> tuple[dict[str, Any], Optional[str], bool, Optional[int]]:

--- a/mopidy/audio/scan.py
+++ b/mopidy/audio/scan.py
@@ -307,13 +307,12 @@ def _process(
                 have_audio = True
         elif msg.type == Gst.MessageType.ERROR:
             error, _debug = msg.parse_error()
-            if missing_message and not mime:
-                if (
-                    (structure := missing_message.get_structure())
-                    and (caps := structure.get_value("detail"))
-                    and (mime := caps.get_structure(0).get_name())
-                ):
-                    return tags, mime, have_audio, duration
+            if missing_message and not mime and (
+                (structure := missing_message.get_structure())
+                and (caps := structure.get_value("detail"))
+                and (mime := caps.get_structure(0).get_name())
+            ):
+                return tags, mime, have_audio, duration
             raise exceptions.ScannerError(str(error))
         elif msg.type == Gst.MessageType.EOS:
             return tags, mime, have_audio, duration

--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -111,7 +111,7 @@ def _extract_buffer_data(buf):
     success, info = mem.map(Gst.MapFlags.READ)
     if not success:
         return None
-    if isinstance(info.data, memoryview):
+    if isinstance(info.data, memoryview):  # noqa: SIM108
         # We need to copy the data as the memoryview is released
         # when we call mem.unmap()
         data = bytes(info.data)

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -55,8 +55,7 @@ def setup_proxy(element: Gst.Element, config: ProxyConfig) -> None:
 
 
 class Signals:
-
-    """Helper for tracking gobject signal registrations"""
+    """Helper for tracking gobject signal registrations."""
 
     def __init__(self) -> None:
         self._ids: dict[tuple[Gst.Element, str], int] = {}

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -6,6 +6,8 @@ from mopidy import httpclient
 from mopidy.internal.gi import Gst
 
 if TYPE_CHECKING:
+    from collections.abc import Iterable
+
     from mopidy.config import ProxyConfig
 
 

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, Callable, cast
 
 from mopidy import httpclient

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, Iterable, cast
+from collections.abc import Iterable
+from typing import TYPE_CHECKING, Any, Callable, cast
 
 from mopidy import httpclient
 from mopidy.internal.gi import Gst

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, Union
 
 import pykka
+from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
 
 from mopidy import listener
 
@@ -487,54 +488,55 @@ class BackendListener(listener.Listener):
         """
 
 
-if TYPE_CHECKING:
-    from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
+class BackendActor(pykka.ThreadingActor, Backend):
+    pass
 
-    class BackendActor(pykka.ThreadingActor, Backend):
-        pass
 
-    class BackendProxy(ActorMemberMixin, pykka.ActorProxy[BackendActor]):
-        """Backend wrapped in a Pykka actor proxy."""
+class BackendProxy(ActorMemberMixin, pykka.ActorProxy[BackendActor]):
+    """Backend wrapped in a Pykka actor proxy."""
 
-        audio = proxy_field(BackendActor.audio)
-        library: LibraryProviderProxy
-        playback: PlaybackProviderProxy
-        playlists: PlaylistsProviderProxy
-        uri_schemes = proxy_field(BackendActor.uri_schemes)
-        has_library = proxy_method(BackendActor.has_library)
-        has_library_browse = proxy_method(BackendActor.has_library_browse)
-        has_playback = proxy_method(BackendActor.has_playback)
-        has_playlists = proxy_method(BackendActor.has_playlists)
-        ping = proxy_method(BackendActor.ping)
+    audio = proxy_field(BackendActor.audio)
+    library: LibraryProviderProxy
+    playback: PlaybackProviderProxy
+    playlists: PlaylistsProviderProxy
+    uri_schemes = proxy_field(BackendActor.uri_schemes)
+    has_library = proxy_method(BackendActor.has_library)
+    has_library_browse = proxy_method(BackendActor.has_library_browse)
+    has_playback = proxy_method(BackendActor.has_playback)
+    has_playlists = proxy_method(BackendActor.has_playlists)
+    ping = proxy_method(BackendActor.ping)
 
-    class LibraryProviderProxy:
-        root_directory = proxy_field(LibraryProvider.root_directory)
-        browse = proxy_method(LibraryProvider.browse)
-        get_distinct = proxy_method(LibraryProvider.get_distinct)
-        get_images = proxy_method(LibraryProvider.get_images)
-        lookup = proxy_method(LibraryProvider.lookup)
-        refresh = proxy_method(LibraryProvider.refresh)
-        search = proxy_method(LibraryProvider.search)
 
-    class PlaybackProviderProxy:
-        pause = proxy_method(PlaybackProvider.pause)
-        play = proxy_method(PlaybackProvider.play)
-        prepare_change = proxy_method(PlaybackProvider.prepare_change)
-        translate_uri = proxy_method(PlaybackProvider.translate_uri)
-        is_live = proxy_method(PlaybackProvider.is_live)
-        should_download = proxy_method(PlaybackProvider.should_download)
-        on_source_setup = proxy_method(PlaybackProvider.on_source_setup)
-        change_track = proxy_method(PlaybackProvider.change_track)
-        resume = proxy_method(PlaybackProvider.resume)
-        seek = proxy_method(PlaybackProvider.seek)
-        stop = proxy_method(PlaybackProvider.stop)
-        get_time_position = proxy_method(PlaybackProvider.get_time_position)
+class LibraryProviderProxy:
+    root_directory = proxy_field(LibraryProvider.root_directory)
+    browse = proxy_method(LibraryProvider.browse)
+    get_distinct = proxy_method(LibraryProvider.get_distinct)
+    get_images = proxy_method(LibraryProvider.get_images)
+    lookup = proxy_method(LibraryProvider.lookup)
+    refresh = proxy_method(LibraryProvider.refresh)
+    search = proxy_method(LibraryProvider.search)
 
-    class PlaylistsProviderProxy:
-        as_list = proxy_method(PlaylistsProvider.as_list)
-        get_items = proxy_method(PlaylistsProvider.get_items)
-        create = proxy_method(PlaylistsProvider.create)
-        delete = proxy_method(PlaylistsProvider.delete)
-        lookup = proxy_method(PlaylistsProvider.lookup)
-        refresh = proxy_method(PlaylistsProvider.refresh)
-        save = proxy_method(PlaylistsProvider.save)
+
+class PlaybackProviderProxy:
+    pause = proxy_method(PlaybackProvider.pause)
+    play = proxy_method(PlaybackProvider.play)
+    prepare_change = proxy_method(PlaybackProvider.prepare_change)
+    translate_uri = proxy_method(PlaybackProvider.translate_uri)
+    is_live = proxy_method(PlaybackProvider.is_live)
+    should_download = proxy_method(PlaybackProvider.should_download)
+    on_source_setup = proxy_method(PlaybackProvider.on_source_setup)
+    change_track = proxy_method(PlaybackProvider.change_track)
+    resume = proxy_method(PlaybackProvider.resume)
+    seek = proxy_method(PlaybackProvider.seek)
+    stop = proxy_method(PlaybackProvider.stop)
+    get_time_position = proxy_method(PlaybackProvider.get_time_position)
+
+
+class PlaylistsProviderProxy:
+    as_list = proxy_method(PlaylistsProvider.as_list)
+    get_items = proxy_method(PlaylistsProvider.get_items)
+    create = proxy_method(PlaylistsProvider.create)
+    delete = proxy_method(PlaylistsProvider.delete)
+    lookup = proxy_method(PlaylistsProvider.lookup)
+    refresh = proxy_method(PlaylistsProvider.refresh)
+    save = proxy_method(PlaylistsProvider.save)

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -85,7 +85,7 @@ class Backend:
     playlists: Optional[PlaylistsProvider] = None
 
     #: List of URI schemes this backend can handle.
-    uri_schemes: list[UriScheme] = []
+    uri_schemes: list[UriScheme] = []  # noqa: RUF012
 
     # Because the providers is marked as pykka.traversable(), we can't get()
     # them from another actor, and need helper methods to check if the

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ARG002
+
 from __future__ import annotations
 
 import logging

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -497,7 +497,6 @@ class BackendActor(pykka.ThreadingActor, Backend):
 class BackendProxy(ActorMemberMixin, pykka.ActorProxy[BackendActor]):
     """Backend wrapped in a Pykka actor proxy."""
 
-    audio = proxy_field(BackendActor.audio)
     library: LibraryProviderProxy
     playback: PlaybackProviderProxy
     playlists: PlaylistsProviderProxy

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -169,7 +169,6 @@ class LibraryProvider:
 
         *MAY be implemented by subclass.*
         """
-        pass
 
     def search(
         self,
@@ -283,7 +282,6 @@ class PlaybackProvider:
 
         .. versionadded:: 3.4
         """
-        pass
 
     def change_track(self, track: Track) -> bool:
         """Switch to provided track.
@@ -487,7 +485,6 @@ class BackendListener(listener.Listener):
 
         *MAY* be implemented by actor.
         """
-        pass
 
 
 if TYPE_CHECKING:

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -47,8 +47,7 @@ logger = logging.getLogger(__name__)
 
 
 class Backend:
-
-    """Backend API
+    """Backend API.
 
     If the backend has problems during initialization it should raise
     :exc:`mopidy.exceptions.BackendError` with a descriptive error message.
@@ -108,9 +107,7 @@ class Backend:
 
 @pykka.traversable
 class LibraryProvider:
-
-    """
-    :param backend: backend the controller is a part of
+    """:param backend: backend the controller is a part of
     :type backend: :class:`mopidy.backend.Backend`
     """
 
@@ -128,8 +125,7 @@ class LibraryProvider:
         self.backend = backend
 
     def browse(self, uri: Uri) -> list[Ref]:
-        """
-        See :meth:`mopidy.core.LibraryController.browse`.
+        """See :meth:`mopidy.core.LibraryController.browse`.
 
         If you implement this method, make sure to also set
         :attr:`root_directory`.
@@ -141,8 +137,7 @@ class LibraryProvider:
     def get_distinct(
         self, field: DistinctField, query: Optional[Query[DistinctField]] = None
     ) -> set[str]:
-        """
-        See :meth:`mopidy.core.LibraryController.get_distinct`.
+        """See :meth:`mopidy.core.LibraryController.get_distinct`.
 
         *MAY be implemented by subclass.*
 
@@ -154,8 +149,7 @@ class LibraryProvider:
         return set()
 
     def get_images(self, uris: list[Uri]) -> dict[Uri, list[Image]]:
-        """
-        See :meth:`mopidy.core.LibraryController.get_images`.
+        """See :meth:`mopidy.core.LibraryController.get_images`.
 
         *MAY be implemented by subclass.*
 
@@ -164,16 +158,14 @@ class LibraryProvider:
         return {}
 
     def lookup(self, uri: Uri) -> dict[Uri, list[Track]]:
-        """
-        See :meth:`mopidy.core.LibraryController.lookup`.
+        """See :meth:`mopidy.core.LibraryController.lookup`.
 
         *MUST be implemented by subclass.*
         """
         raise NotImplementedError
 
     def refresh(self, uri: Optional[Uri] = None) -> None:
-        """
-        See :meth:`mopidy.core.LibraryController.refresh`.
+        """See :meth:`mopidy.core.LibraryController.refresh`.
 
         *MAY be implemented by subclass.*
         """
@@ -185,8 +177,7 @@ class LibraryProvider:
         uris: Optional[list[Uri]] = None,
         exact: bool = False,
     ) -> list[SearchResult]:
-        """
-        See :meth:`mopidy.core.LibraryController.search`.
+        """See :meth:`mopidy.core.LibraryController.search`.
 
         *MAY be implemented by subclass.*
 
@@ -198,9 +189,7 @@ class LibraryProvider:
 
 @pykka.traversable
 class PlaybackProvider:
-
-    """
-    :param audio: the audio actor
+    """:param audio: the audio actor
     :type audio: actor proxy to an instance of :class:`mopidy.audio.Audio`
     :param backend: the backend
     :type backend: :class:`mopidy.backend.Backend`
@@ -211,8 +200,7 @@ class PlaybackProvider:
         self.backend = backend
 
     def pause(self) -> bool:
-        """
-        Pause playback.
+        """Pause playback.
 
         *MAY be reimplemented by subclass.*
 
@@ -221,8 +209,7 @@ class PlaybackProvider:
         return self.audio.pause_playback().get()
 
     def play(self) -> bool:
-        """
-        Start playback.
+        """Start playback.
 
         *MAY be reimplemented by subclass.*
 
@@ -231,8 +218,7 @@ class PlaybackProvider:
         return self.audio.start_playback().get()
 
     def prepare_change(self) -> None:
-        """
-        Indicate that an URI change is about to happen.
+        """Indicate that an URI change is about to happen.
 
         *MAY be reimplemented by subclass.*
 
@@ -243,8 +229,7 @@ class PlaybackProvider:
         self.audio.prepare_change().get()
 
     def translate_uri(self, uri: Uri) -> Optional[Uri]:
-        """
-        Convert custom URI scheme to real playable URI.
+        """Convert custom URI scheme to real playable URI.
 
         *MAY be reimplemented by subclass.*
 
@@ -260,8 +245,7 @@ class PlaybackProvider:
         return uri
 
     def is_live(self, uri: Uri) -> bool:
-        """
-        Decide if the URI should be treated as a live stream or not.
+        """Decide if the URI should be treated as a live stream or not.
 
         *MAY be reimplemented by subclass.*
 
@@ -275,8 +259,7 @@ class PlaybackProvider:
         return False
 
     def should_download(self, uri: Uri) -> bool:
-        """
-        Attempt progressive download buffering for the URI or not.
+        """Attempt progressive download buffering for the URI or not.
 
         *MAY be reimplemented by subclass.*
 
@@ -290,8 +273,7 @@ class PlaybackProvider:
         return False
 
     def on_source_setup(self, source: Gst.Element) -> None:
-        """
-        Called when a new GStreamer source is created, allowing us to configure
+        """Called when a new GStreamer source is created, allowing us to configure
         the source. This runs in the audio thread so should not block.
 
         *MAY be reimplemented by subclass.*
@@ -304,8 +286,7 @@ class PlaybackProvider:
         pass
 
     def change_track(self, track: Track) -> bool:
-        """
-        Switch to provided track.
+        """Switch to provided track.
 
         *MAY be reimplemented by subclass.*
 
@@ -334,8 +315,7 @@ class PlaybackProvider:
         return True
 
     def resume(self) -> bool:
-        """
-        Resume playback at the same time position playback was paused.
+        """Resume playback at the same time position playback was paused.
 
         *MAY be reimplemented by subclass.*
 
@@ -344,8 +324,7 @@ class PlaybackProvider:
         return self.audio.start_playback().get()
 
     def seek(self, time_position: int) -> bool:
-        """
-        Seek to a given time position.
+        """Seek to a given time position.
 
         *MAY be reimplemented by subclass.*
 
@@ -356,8 +335,7 @@ class PlaybackProvider:
         return self.audio.set_position(time_position).get()
 
     def stop(self) -> bool:
-        """
-        Stop playback.
+        """Stop playback.
 
         *MAY be reimplemented by subclass.*
 
@@ -369,8 +347,7 @@ class PlaybackProvider:
         return self.audio.stop_playback().get()
 
     def get_time_position(self) -> int:
-        """
-        Get the current time position in milliseconds.
+        """Get the current time position in milliseconds.
 
         *MAY be reimplemented by subclass.*
 
@@ -381,9 +358,7 @@ class PlaybackProvider:
 
 @pykka.traversable
 class PlaylistsProvider:
-
-    """
-    A playlist provider exposes a collection of playlists, methods to
+    """A playlist provider exposes a collection of playlists, methods to
     create/change/delete playlists in this collection, and lookup of any
     playlist the backend knows about.
 
@@ -395,8 +370,7 @@ class PlaylistsProvider:
         self.backend = backend
 
     def as_list(self) -> list[Ref]:
-        """
-        Get a list of the currently available playlists.
+        """Get a list of the currently available playlists.
 
         Returns a list of :class:`~mopidy.models.Ref` objects referring to the
         playlists. In other words, no information about the playlists' content
@@ -409,8 +383,7 @@ class PlaylistsProvider:
         raise NotImplementedError
 
     def get_items(self, uri: Uri) -> Optional[list[Ref]]:
-        """
-        Get the items in a playlist specified by ``uri``.
+        """Get the items in a playlist specified by ``uri``.
 
         Returns a list of :class:`~mopidy.models.Ref` objects referring to the
         playlist's items.
@@ -425,8 +398,7 @@ class PlaylistsProvider:
         raise NotImplementedError
 
     def create(self, name: str) -> Optional[Playlist]:
-        """
-        Create a new empty playlist with the given name.
+        """Create a new empty playlist with the given name.
 
         Returns a new playlist with the given name and an URI, or :class:`None`
         on failure.
@@ -440,8 +412,7 @@ class PlaylistsProvider:
         raise NotImplementedError
 
     def delete(self, uri: Uri) -> bool:
-        """
-        Delete playlist identified by the URI.
+        """Delete playlist identified by the URI.
 
         Returns :class:`True` if deleted, :class:`False` otherwise.
 
@@ -457,8 +428,7 @@ class PlaylistsProvider:
         raise NotImplementedError
 
     def lookup(self, uri: Uri) -> Optional[Playlist]:
-        """
-        Lookup playlist with given URI in both the set of playlists and in any
+        """Lookup playlist with given URI in both the set of playlists and in any
         other playlist source.
 
         Returns the playlists or :class:`None` if not found.
@@ -472,16 +442,14 @@ class PlaylistsProvider:
         raise NotImplementedError
 
     def refresh(self) -> None:
-        """
-        Refresh the playlists in :attr:`playlists`.
+        """Refresh the playlists in :attr:`playlists`.
 
         *MUST be implemented by subclass.*
         """
         raise NotImplementedError
 
     def save(self, playlist: Playlist) -> Optional[Playlist]:
-        """
-        Save the given playlist.
+        """Save the given playlist.
 
         The playlist must have an ``uri`` attribute set. To create a new
         playlist with an URI, use :meth:`create`.
@@ -498,9 +466,7 @@ class PlaylistsProvider:
 
 
 class BackendListener(listener.Listener):
-
-    """
-    Marker interface for recipients of events sent by the backend actors.
+    """Marker interface for recipients of events sent by the backend actors.
 
     Any Pykka actor that mixes in this class will receive calls to the methods
     defined here when the corresponding events happen in a backend actor. This
@@ -513,12 +479,11 @@ class BackendListener(listener.Listener):
 
     @staticmethod
     def send(event: str, **kwargs: Any) -> None:
-        """Helper to allow calling of backend listener events"""
+        """Helper to allow calling of backend listener events."""
         listener.send(BackendListener, event, **kwargs)
 
     def playlists_loaded(self) -> None:
-        """
-        Called when playlists are loaded or refreshed.
+        """Called when playlists are loaded or refreshed.
 
         *MAY* be implemented by actor.
         """

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -101,7 +101,6 @@ class _HelpAction(argparse.Action):
 
 
 class Command:
-
     """Command parser and runner for building trees of commands.
 
     This class provides a wraper around :class:`argparse.ArgumentParser`

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -4,10 +4,9 @@ import argparse
 import collections
 import contextlib
 import logging
-import os
-import pathlib
 import signal
 import sys
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -34,8 +33,8 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_default_config: list[pathlib.Path] = [
-    (pathlib.Path(base) / "mopidy" / "mopidy.conf").resolve()
+_default_config: list[Path] = [
+    (Path(base) / "mopidy" / "mopidy.conf").resolve()
     for base in GLib.get_system_config_dirs() + [GLib.get_user_config_dir()]
 ]
 DEFAULT_CONFIG = ":".join(map(str, _default_config))
@@ -155,7 +154,7 @@ class Command:
     def format_usage(self, prog: Optional[str] = None) -> str:
         """Format usage for current parser."""
         actions = self._build()[1]
-        prog = prog or os.path.basename(sys.argv[0])
+        prog = prog or Path(sys.argv[0]).name
         return self._usage(actions, prog) + "\n"
 
     def _usage(self, actions: Iterable[argparse.Action], prog) -> str:
@@ -166,7 +165,7 @@ class Command:
     def format_help(self, prog: Optional[str] = None) -> str:
         """Format help for current parser and children."""
         actions = self._build()[1]
-        prog = prog or os.path.basename(sys.argv[0])
+        prog = prog or Path(sys.argv[0]).name
 
         formatter = argparse.HelpFormatter(prog)
         formatter.add_usage(None, actions, [])
@@ -221,7 +220,7 @@ class Command:
         :type prog: string
         :rtype: :class:`argparse.Namespace`
         """
-        prog = prog or os.path.basename(sys.argv[0])
+        prog = prog or Path(sys.argv[0]).name
         try:
             return self._parse(
                 args,

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -35,7 +35,7 @@ logger = logging.getLogger(__name__)
 
 _default_config: list[Path] = [
     (Path(base) / "mopidy" / "mopidy.conf").resolve()
-    for base in GLib.get_system_config_dirs() + [GLib.get_user_config_dir()]
+    for base in [*GLib.get_system_config_dirs(), GLib.get_user_config_dir()]
 ]
 DEFAULT_CONFIG = ":".join(map(str, _default_config))
 

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -9,7 +9,6 @@ import pathlib
 import signal
 import sys
 from typing import (
-    TYPE_CHECKING,
     Any,
     Generator,
     Iterable,
@@ -25,17 +24,12 @@ from pykka.messages import ProxyCall
 
 from mopidy import config as config_lib
 from mopidy import exceptions
-from mopidy.audio import Audio
-from mopidy.core import Core
+from mopidy.audio import Audio, AudioProxy
+from mopidy.backend import BackendActor, BackendProxy
+from mopidy.core import Core, CoreProxy
 from mopidy.internal import deps, process, timer, versioning
 from mopidy.internal.gi import GLib
-
-if TYPE_CHECKING:
-    from mopidy.audio import AudioProxy
-    from mopidy.backend import BackendActor, BackendProxy
-    from mopidy.core import CoreProxy
-    from mopidy.mixer import MixerActor, MixerProxy
-
+from mopidy.mixer import MixerActor, MixerProxy
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -149,7 +149,7 @@ class Command:
         usage: Optional[str] = None,
     ) -> NoReturn:
         """Optionally print a message and exit."""
-        print("\n\n".join(m for m in (usage, message) if m))
+        print("\n\n".join(m for m in (usage, message) if m))  # noqa: T201
         sys.exit(status_code)
 
     def format_usage(self, prog: Optional[str] = None) -> str:
@@ -553,7 +553,7 @@ class ConfigCommand(Command):
         # Throw away all bytes that are not valid UTF-8 before printing
         data = data.encode(errors="surrogateescape").decode(errors="replace")
 
-        print(data)
+        print(data)  # noqa: T201
         return 0
 
 
@@ -565,5 +565,5 @@ class DepsCommand(Command):
         self.set(base_verbosity_level=-1)
 
     def run(self) -> int:
-        print(deps.format_dependency_list())
+        print(deps.format_dependency_list())  # noqa: T201
         return 0

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -49,10 +49,10 @@ def config_override_type(value: str) -> tuple[str, str, str]:
         section, remainder = value.split("/", 1)
         key, value = remainder.split("=", 1)
         return (section.strip(), key.strip(), value.strip())
-    except ValueError:
+    except ValueError as exc:
         raise argparse.ArgumentTypeError(
             f"{value} must have the format section/key=value"
-        )
+        ) from exc
 
 
 class _ParserError(Exception):
@@ -418,9 +418,10 @@ class RootCommand(Command):
             mixer = cast(MixerProxy, mixer_class.start(config=config).proxy())
             try:
                 mixer.ping().get()
-                return mixer
             except pykka.ActorDeadError as exc:
                 logger.error("Actor died: %s", exc)
+            else:
+                return mixer
         return None
 
     def configure_mixer(

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -457,13 +457,14 @@ class RootCommand(Command):
 
         backends = []
         for backend_class in backend_classes:
-            with _actor_error_handling(backend_class.__name__):
-                with timer.time_logger(backend_class.__name__):
-                    backend = cast(
-                        BackendProxy,
-                        backend_class.start(config=config, audio=audio).proxy(),
-                    )
-                    backends.append(backend)
+            with _actor_error_handling(backend_class.__name__), timer.time_logger(
+                backend_class.__name__
+            ):
+                backend = cast(
+                    BackendProxy,
+                    backend_class.start(config=config, audio=audio).proxy(),
+                )
+                backends.append(backend)
 
         # Block until all on_starts have finished, letting them run in parallel
         for backend in backends[:]:
@@ -505,9 +506,10 @@ class RootCommand(Command):
         )
 
         for frontend_class in frontend_classes:
-            with _actor_error_handling(frontend_class.__name__):
-                with timer.time_logger(frontend_class.__name__):
-                    frontend_class.start(config=config, core=core)
+            with _actor_error_handling(frontend_class.__name__), timer.time_logger(
+                frontend_class.__name__
+            ):
+                frontend_class.start(config=config, core=core)
 
     def stop_frontends(self, frontend_classes: list[type[ThreadingActor]]) -> None:
         logger.info("Stopping Mopidy frontends")

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -87,7 +87,7 @@ class _HelpAction(argparse.Action):
     def __call__(
         self, parser, namespace, values, option_string=None  # noqa: ARG002
     ) -> NoReturn:
-        raise _HelpError()
+        raise _HelpError
 
 
 class Command:

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -86,11 +86,7 @@ class _HelpAction(argparse.Action):
         )
 
     def __call__(
-        self,
-        parser,
-        namespace,
-        values,
-        option_string=None,
+        self, parser, namespace, values, option_string=None  # noqa: ARG002
     ) -> NoReturn:
         raise _HelpError()
 

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -9,12 +9,10 @@ import pathlib
 import signal
 import sys
 from typing import (
+    TYPE_CHECKING,
     Any,
-    Generator,
-    Iterable,
     NoReturn,
     Optional,
-    Sequence,
     cast,
 )
 
@@ -30,6 +28,9 @@ from mopidy.core import Core, CoreProxy
 from mopidy.internal import deps, process, timer, versioning
 from mopidy.internal.gi import GLib
 from mopidy.mixer import MixerActor, MixerProxy
+
+if TYPE_CHECKING:
+    from collections.abc import Generator, Iterable, Sequence
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -209,7 +209,7 @@ def format_initial(extensions_data: list[ExtensionData]) -> str:
 def _load(
     files: list[os.PathLike],
     defaults: list[str],
-    overrides: list[str],
+    overrides: list[tuple[str, str, Any]],
 ) -> RawConfig:
     parser = configparser.RawConfigParser(inline_comment_prefixes=(";",))
 

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -355,8 +355,9 @@ def _preprocess(config_string: str) -> str:
     def comments(match) -> Optional[str]:
         if match.group(1) == "#":
             return f"__HASH{next(counter):d}__ ="
-        elif match.group(1) == ";":
+        if match.group(1) == ";":
             return f"__SEMICOLON{next(counter):d}__ ="
+        return None
 
     def inlinecomments(match) -> str:
         return f"\n__INLINE{next(counter):d}__ ="
@@ -381,8 +382,7 @@ def _postprocess(config_string: str) -> str:
     result = re.sub(r"^__HASH\d+__ =(.*)$", r"#\g<1>", result, flags=flags)
     result = re.sub(r"^__SEMICOLON\d+__ =(.*)$", r";\g<1>", result, flags=flags)
     result = re.sub(r"\n__SECTION\d+__ =(.*)$", r"\g<1>", result, flags=flags)
-    result = re.sub(r"^__BLANK\d+__ =$", "", result, flags=flags)
-    return result
+    return re.sub(r"^__BLANK\d+__ =$", "", result, flags=flags)
 
 
 class Proxy(Mapping):

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -155,7 +155,7 @@ _INITIAL_HELP = """
 
 
 def read(config_file: str | os.PathLike[str]) -> str:
-    """Helper to load config defaults in same way across core and extensions"""
+    """Helper to load config defaults in same way across core and extensions."""
     return pathlib.Path(config_file).read_text(errors="surrogateescape")
 
 

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -129,9 +129,6 @@ _proxy_schema["port"] = Port(optional=True)
 _proxy_schema["username"] = String(optional=True)
 _proxy_schema["password"] = Secret(optional=True)
 
-# NOTE: if multiple outputs ever comes something like LogLevelConfigSchema
-# _outputs_schema = config.AudioOutputConfigSchema()
-
 _schemas: ConfigSchemas = [
     _core_schema,
     _logging_schema,

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -349,7 +349,7 @@ def _preprocess(config_string: str) -> str:
     comment_re = re.compile(r"^(#|;)")
     inline_comment_re = re.compile(r" ;")
 
-    def newlines(match) -> str:
+    def newlines(_match) -> str:
         return f"__BLANK{next(counter):d}__ ="
 
     def comments(match) -> Optional[str]:
@@ -359,7 +359,7 @@ def _preprocess(config_string: str) -> str:
             return f"__SEMICOLON{next(counter):d}__ ="
         return None
 
-    def inlinecomments(match) -> str:
+    def inlinecomments(_match) -> str:
         return f"\n__INLINE{next(counter):d}__ ="
 
     def sections(match) -> str:

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -29,12 +29,12 @@ from mopidy.config.types import (
     String,
 )
 from mopidy.internal import path, versioning
-from mopidy.internal.log import LogColorName, LogLevelName
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
 
     from mopidy.ext import ExtensionData
+    from mopidy.internal.log import LogColorName, LogLevelName
 
     ConfigErrors: TypeAlias = dict[str, dict[str, Any]]
     ConfigSchemas: TypeAlias = list[Union[ConfigSchema, MapConfigSchema]]

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -6,8 +6,8 @@ import logging
 import os
 import pathlib
 import re
-from collections.abc import Mapping
-from typing import TYPE_CHECKING, Any, Iterator, Optional, TypedDict, Union, cast
+from collections.abc import Iterator, Mapping
+from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union, cast
 
 from mopidy.config import keyring
 from mopidy.config.schemas import ConfigSchema, MapConfigSchema

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -251,7 +251,7 @@ def _load_file(
 ) -> None:
     if not file_path.exists():
         logger.debug(
-            f"Loading config from {file_path.as_uri()} failed; " f"it does not exist"
+            f"Loading config from {file_path.as_uri()} failed; it does not exist"
         )
         return
     if not os.access(str(file_path), os.R_OK):

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -175,7 +175,7 @@ def load(
     return _validate(raw_config, schemas)
 
 
-def format(
+def format(  # noqa: A001
     config: Config,
     ext_schemas: ConfigSchemas,
     comments: Optional[dict] = None,

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -154,7 +154,7 @@ _INITIAL_HELP = """
 """
 
 
-def read(config_file: str | os.PathLike[str]) -> str:
+def read(config_file: Union[str, os.PathLike[str]]) -> str:
     """Helper to load config defaults in same way across core and extensions."""
     return pathlib.Path(config_file).read_text(errors="surrogateescape")
 

--- a/mopidy/config/keyring.py
+++ b/mopidy/config/keyring.py
@@ -150,9 +150,10 @@ def _collection_exists(bus, path):
     try:
         item = _interface(bus, path, "org.freedesktop.DBus.Properties")
         item.Get("org.freedesktop.Secret.Collection", "Label")
-        return True
     except dbus.exceptions.DBusException:
         return False
+    else:
+        return True
 
 
 # NOTE: We could call prompt.Prompt('') to unlock the keyring when it is not

--- a/mopidy/config/keyring.py
+++ b/mopidy/config/keyring.py
@@ -1,4 +1,5 @@
 import logging
+from typing import Union
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +21,7 @@ FETCH_ERROR = (
 )
 
 
-def fetch():
+def fetch() -> list[tuple[str, str, bytes]]:  # noqa: PLR0911
     if not dbus:
         logger.debug("%s (dbus not installed)", FETCH_ERROR)
         return []
@@ -64,7 +65,11 @@ def fetch():
     return result
 
 
-def set(section, key, value):  # noqa: A001
+def set(  # noqa: A001, PLR0911
+    section: str,
+    key: str,
+    value: Union[str, bytes],
+) -> bool:
     """Store a secret config value for a given section/key.
 
     Indicates if storage failed or succeeded.

--- a/mopidy/config/keyring.py
+++ b/mopidy/config/keyring.py
@@ -11,10 +11,7 @@ except ImportError:
 # XXX: Hack to workaround introspection bug caused by gnome-keyring, should be
 # fixed by version 3.5 per:
 # https://git.gnome.org/browse/gnome-keyring/commit/?id=5dccbe88eb94eea9934e2b7
-if dbus:
-    EMPTY_STRING = dbus.String("", variant_level=1)
-else:
-    EMPTY_STRING = ""
+EMPTY_STRING = dbus.String("", variant_level=1) if dbus else ""
 
 
 FETCH_ERROR = (

--- a/mopidy/config/keyring.py
+++ b/mopidy/config/keyring.py
@@ -64,7 +64,7 @@ def fetch():
     return result
 
 
-def set(section, key, value):
+def set(section, key, value):  # noqa: A001
     """Store a secret config value for a given section/key.
 
     Indicates if storage failed or succeeded.

--- a/mopidy/config/schemas.py
+++ b/mopidy/config/schemas.py
@@ -37,7 +37,6 @@ def _levenshtein(a, b):
 
 
 class ConfigSchema(collections.OrderedDict):
-
     """Logical group of config values that correspond to a config section.
 
     Schemas are set up by assigning config keys with config values to
@@ -104,7 +103,6 @@ class ConfigSchema(collections.OrderedDict):
 
 
 class MapConfigSchema:
-
     """Schema for handling multiple unknown keys with the same type.
 
     Does not sub-class :class:`ConfigSchema`, but implements the same

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -5,11 +5,11 @@ import re
 import socket
 from abc import ABC, abstractmethod
 from typing import (
+    TYPE_CHECKING,
     Any,
     AnyStr,
     Callable,
     Generic,
-    Iterable,
     Literal,
     Optional,
     TypeVar,
@@ -19,6 +19,9 @@ from typing import (
 
 from mopidy.config import validators
 from mopidy.internal import log, path
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 T = TypeVar("T")
 K = TypeVar("K", bound="ConfigValue")

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -109,9 +109,9 @@ class Deprecated(ConfigValue[Any]):
 
 
 class String(ConfigValue[str]):
-    """String value.
+    r"""String value.
 
-    Is decoded as utf-8 and \\n \\t escapes should work and be preserved.
+    Is decoded as utf-8, and \n and \t escapes should work and be preserved.
     """
 
     def __init__(
@@ -149,9 +149,9 @@ class String(ConfigValue[str]):
 
 
 class Secret(String):
-    """Secret string value.
+    r"""Secret string value.
 
-    Is decoded as utf-8 and \\n \\t escapes should work and be preserved.
+    Is decoded as utf-8, and \n and \t escapes should work and be preserved.
 
     Should be used for passwords, auth tokens etc. Will mask value when being
     displayed.

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ARG002
+
 from __future__ import annotations
 
 import logging
@@ -55,10 +57,10 @@ class DeprecatedValue:
 
 
 class _TransformedValue(str):
-    def __new__(cls, original, transformed):
+    def __new__(cls, _original, transformed):
         return super().__new__(cls, transformed)
 
-    def __init__(self, original, transformed):
+    def __init__(self, original, _transformed):
         self.original = original
 
 

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -280,7 +280,7 @@ class Pair(ConfigValue[tuple[K, V]]):
         optional: bool = False,
         optional_pair: bool = False,
         separator: str = "|",
-        subtypes: tuple[K, V] = (String(), String()),
+        subtypes: tuple[K, V] = (String(), String()),  # noqa: B008
     ) -> None:
         self._required = not optional
         self._optional_pair = optional_pair
@@ -343,7 +343,7 @@ class List(ConfigValue[V]):
         self,
         optional: bool = False,
         unique: bool = False,
-        subtype: V = String(),
+        subtype: V = String(),  # noqa: B008
     ) -> None:
         self._required = not optional
         self._unique = unique

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -449,8 +449,8 @@ class Hostname(ConfigValue):
 
         try:
             socket.getaddrinfo(value, None)
-        except OSError:
-            raise ValueError("must be a resolveable hostname or valid IP")
+        except OSError as exc:
+            raise ValueError("must be a resolveable hostname or valid IP") from exc
 
         return value
 

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -321,11 +321,7 @@ class Pair(ConfigValue[tuple[K, V]]):
         ):
             return serialized_first_value
 
-        return "{}{}{}".format(
-            serialized_first_value,
-            self._separator,
-            serialized_second_value,
-        )
+        return f"{serialized_first_value}{self._separator}{serialized_second_value}"
 
 
 class List(ConfigValue[V]):

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -275,7 +275,7 @@ class Pair(ConfigValue[tuple[K, V]]):
         optional: bool = False,
         optional_pair: bool = False,
         separator: str = "|",
-        subtypes: tuple[K, V] = (String(), String()),  # noqa: B008
+        subtypes: tuple[K, V] = (String(), String()),
     ) -> None:
         self._required = not optional
         self._optional_pair = optional_pair
@@ -338,7 +338,7 @@ class List(ConfigValue[V]):
         self,
         optional: bool = False,
         unique: bool = False,
-        subtype: V = String(),  # noqa: B008
+        subtype: V = String(),
     ) -> None:
         self._required = not optional
         self._unique = unique

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -357,10 +357,7 @@ class List(ConfigValue[V]):
         subtype: ConfigValue = getattr(self, "_subtype", String())
 
         values_iter = (subtype.deserialize(s.strip()) for s in strings if s.strip())
-        if self._unique:
-            values = frozenset(values_iter)
-        else:
-            values = tuple(values_iter)
+        values = frozenset(values_iter) if self._unique else tuple(values_iter)
 
         validators.validate_required(values, self._required)
         return cast(Union[tuple[V, ...], frozenset[V]], values)

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -261,7 +261,7 @@ class Boolean(ConfigValue[bool]):
 
 
 class Pair(ConfigValue[tuple[K, V]]):
-    """Pair value
+    """Pair value.
 
     The value is expected to be a pair of elements, separated by a specified delimiter.
     Values can optionally not be a pair, in which case the whole input is provided for

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -11,6 +11,7 @@ from typing import (
     Any,
     AnyStr,
     Callable,
+    ClassVar,
     Generic,
     Literal,
     Optional,
@@ -407,7 +408,7 @@ class LogLevel(ConfigValue[log.LogLevelName]):
     ``trace``, or ``all``, with any casing.
     """
 
-    levels: dict[str, int] = {
+    levels: ClassVar[dict[str, int]] = {
         "critical": logging.CRITICAL,
         "error": logging.ERROR,
         "warning": logging.WARNING,

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -243,7 +243,7 @@ class Boolean(ConfigValue[bool]):
             return None
         if result.lower() in self.true_values:
             return True
-        elif result.lower() in self.false_values:
+        if result.lower() in self.false_values:
             return False
         raise ValueError(f"invalid value for boolean: {result!r}")
 
@@ -254,10 +254,9 @@ class Boolean(ConfigValue[bool]):
     ) -> Literal["true", "false"]:
         if value is True:
             return "true"
-        elif value in (False, None):
+        if value in (False, None):
             return "false"
-        else:
-            raise ValueError(f"{value!r} is not a boolean")
+        raise ValueError(f"{value!r} is not a boolean")
 
 
 class Pair(ConfigValue[tuple[K, V]]):
@@ -315,12 +314,12 @@ class Pair(ConfigValue[tuple[K, V]]):
             and serialized_first_value == serialized_second_value
         ):
             return serialized_first_value
-        else:
-            return "{}{}{}".format(
-                serialized_first_value,
-                self._separator,
-                serialized_second_value,
-            )
+
+        return "{}{}{}".format(
+            serialized_first_value,
+            self._separator,
+            serialized_second_value,
+        )
 
 
 class List(ConfigValue[V]):

--- a/mopidy/config/validators.py
+++ b/mopidy/config/validators.py
@@ -18,7 +18,7 @@ if TYPE_CHECKING:
 
 
 def validate_required(value: Any, required: bool) -> None:
-    """Validate that ``value`` is set if ``required``
+    """Validate that ``value`` is set if ``required``.
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize` on
     the raw string, _not_ the converted value.
@@ -28,7 +28,7 @@ def validate_required(value: Any, required: bool) -> None:
 
 
 def validate_choice(value: T, choices: Optional[Iterable[T]]) -> None:
-    """Validate that ``value`` is one of the ``choices``
+    """Validate that ``value`` is one of the ``choices``.
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
     """
@@ -38,7 +38,7 @@ def validate_choice(value: T, choices: Optional[Iterable[T]]) -> None:
 
 
 def validate_minimum(value: CT, minimum: Optional[CT]) -> None:
-    """Validate that ``value`` is at least ``minimum``
+    """Validate that ``value`` is at least ``minimum``.
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
     """
@@ -47,7 +47,7 @@ def validate_minimum(value: CT, minimum: Optional[CT]) -> None:
 
 
 def validate_maximum(value: CT, maximum: Optional[CT]) -> None:
-    """Validate that ``value`` is at most ``maximum``
+    """Validate that ``value`` is at most ``maximum``.
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
     """

--- a/mopidy/config/validators.py
+++ b/mopidy/config/validators.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
-from abc import abstractmethod
-from typing import TYPE_CHECKING, Any, Iterable, Optional, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Optional, Protocol, TypeVar
 
 if TYPE_CHECKING:
+    from abc import abstractmethod
+    from collections.abc import Iterable
 
     class Comparable(Protocol):
         @abstractmethod

--- a/mopidy/core/__init__.py
+++ b/mopidy/core/__init__.py
@@ -1,4 +1,5 @@
-# flake8: noqa
+# ruff: noqa
+
 from typing import TYPE_CHECKING
 
 from .actor import Core

--- a/mopidy/core/__init__.py
+++ b/mopidy/core/__init__.py
@@ -1,8 +1,4 @@
-# ruff: noqa
-
-from typing import TYPE_CHECKING
-
-from .actor import Core
+from .actor import Core, CoreProxy
 from .history import HistoryController
 from .library import LibraryController
 from .listener import CoreListener
@@ -11,5 +7,15 @@ from .playback import PlaybackController, PlaybackState
 from .playlists import PlaylistsController
 from .tracklist import TracklistController
 
-if TYPE_CHECKING:
-    from .actor import CoreProxy
+__all__ = [
+    "Core",
+    "CoreListener",
+    "CoreProxy",
+    "HistoryController",
+    "LibraryController",
+    "MixerController",
+    "PlaybackController",
+    "PlaybackState",
+    "PlaylistsController",
+    "TracklistController",
+]

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -5,6 +5,7 @@ import logging
 from typing import TYPE_CHECKING, Optional
 
 import pykka
+from pykka.typing import ActorMemberMixin, proxy_method
 
 import mopidy
 from mopidy import audio, backend, mixer
@@ -290,23 +291,20 @@ class Backends(list):
                     self.with_playlists[scheme] = b
 
 
-if TYPE_CHECKING:
-    from pykka.typing import ActorMemberMixin, proxy_method
-
-    class CoreProxy(ActorMemberMixin, pykka.ActorProxy[Core]):
-        library: LibraryControllerProxy
-        history: HistoryControllerProxy
-        mixer: MixerControllerProxy
-        playback: PlaybackControllerProxy
-        playlists: PlaylistsControllerProxy
-        tracklist: TracklistControllerProxy
-        get_uri_schemes = proxy_method(Core.get_uri_schemes)
-        get_version = proxy_method(Core.get_version)
-        reached_end_of_stream = proxy_method(Core.reached_end_of_stream)
-        stream_changed = proxy_method(Core.stream_changed)
-        position_changed = proxy_method(Core.position_changed)
-        state_changed = proxy_method(Core.state_changed)
-        playlists_loaded = proxy_method(Core.playlists_loaded)
-        volume_changed = proxy_method(Core.volume_changed)
-        mute_changed = proxy_method(Core.mute_changed)
-        tags_changed = proxy_method(Core.tags_changed)
+class CoreProxy(ActorMemberMixin, pykka.ActorProxy[Core]):
+    library: LibraryControllerProxy
+    history: HistoryControllerProxy
+    mixer: MixerControllerProxy
+    playback: PlaybackControllerProxy
+    playlists: PlaylistsControllerProxy
+    tracklist: TracklistControllerProxy
+    get_uri_schemes = proxy_method(Core.get_uri_schemes)
+    get_version = proxy_method(Core.get_version)
+    reached_end_of_stream = proxy_method(Core.reached_end_of_stream)
+    stream_changed = proxy_method(Core.stream_changed)
+    position_changed = proxy_method(Core.position_changed)
+    state_changed = proxy_method(Core.state_changed)
+    playlists_loaded = proxy_method(Core.playlists_loaded)
+    volume_changed = proxy_method(Core.volume_changed)
+    mute_changed = proxy_method(Core.mute_changed)
+    tags_changed = proxy_method(Core.tags_changed)

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ARG002
+
 from __future__ import annotations
 
 import itertools

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -164,15 +164,18 @@ class Core(
         """Do not call this function. It is for internal use at startup."""
         try:
             coverage = []
-            if self._config and "restore_state" in self._config["core"]:
-                if self._config["core"]["restore_state"]:
-                    coverage = [
-                        "tracklist",
-                        "mode",
-                        "play-last",
-                        "mixer",
-                        "history",
-                    ]
+            if (
+                self._config
+                and "restore_state" in self._config["core"]
+                and self._config["core"]["restore_state"]
+            ):
+                coverage = [
+                    "tracklist",
+                    "mode",
+                    "play-last",
+                    "mixer",
+                    "history",
+                ]
             if len(coverage):
                 self._load_state(coverage)
         except Exception as e:
@@ -181,9 +184,12 @@ class Core(
     def _teardown(self):
         """Do not call this function. It is for internal use at shutdown."""
         try:
-            if self._config and "restore_state" in self._config["core"]:
-                if self._config["core"]["restore_state"]:
-                    self._save_state()
+            if (
+                self._config
+                and "restore_state" in self._config["core"]
+                and self._config["core"]["restore_state"]
+            ):
+                self._save_state()
         except Exception as e:
             logger.warning("Unexpected error while saving state: %s", str(e))
 

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -85,14 +85,14 @@ class Core(
         self.audio = audio
 
     def get_uri_schemes(self) -> list[backend.UriScheme]:
-        """Get list of URI schemes we can handle"""
+        """Get list of URI schemes we can handle."""
         futures = [b.uri_schemes for b in self.backends]
         results = pykka.get_all(futures)
         uri_schemes = itertools.chain(*results)
         return sorted(uri_schemes)
 
     def get_version(self) -> str:
-        """Get version of the Mopidy core API"""
+        """Get version of the Mopidy core API."""
         return versioning.get_version()
 
     def reached_end_of_stream(self) -> None:
@@ -194,10 +194,7 @@ class Core(
         return self._get_data_dir() / "state.json.gz"
 
     def _save_state(self):
-        """
-        Save current state to disk.
-        """
-
+        """Save current state to disk."""
         state_file = self._get_state_file()
         logger.info("Saving state to %s", state_file)
 
@@ -213,8 +210,7 @@ class Core(
         logger.debug("Saving state done")
 
     def _load_state(self, coverage):
-        """
-        Restore state from disk.
+        """Restore state from disk.
 
         Load state from disk and restore it. Parameter ``coverage``
         limits the amount of data to restore. Possible
@@ -229,7 +225,6 @@ class Core(
         :param coverage: amount of data to restore
         :type coverage: list of strings
         """
-
         state_file = self._get_state_file()
         logger.info("Loading state from %s", state_file)
 

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -59,8 +59,7 @@ class LibraryController:
         return backends_to_uris
 
     def browse(self, uri):
-        """
-        Browse directories and tracks at the given ``uri``.
+        """Browse directories and tracks at the given ``uri``.
 
         ``uri`` is a string which represents some directory belonging to a
         backend. To get the intial root directories for backends pass
@@ -124,8 +123,7 @@ class LibraryController:
         return []
 
     def get_distinct(self, field, query=None):
-        """
-        List distinct values for a given field from the library.
+        """List distinct values for a given field from the library.
 
         This has mainly been added to support the list commands the MPD
         protocol supports in a more sane fashion. Other frontends are not
@@ -171,7 +169,7 @@ class LibraryController:
         return result
 
     def get_images(self, uris):
-        """Lookup the images for the given URIs
+        """Lookup the images for the given URIs.
 
         Backends can use this to return image URIs for any URI they know about
         be it tracks, albums, playlists. The lookup result is a dictionary
@@ -210,8 +208,7 @@ class LibraryController:
         return results
 
     def lookup(self, uris):
-        """
-        Lookup the given URIs.
+        """Lookup the given URIs.
 
         If the URI expands to multiple tracks, the returned list will contain
         them all.
@@ -243,8 +240,7 @@ class LibraryController:
         return results
 
     def refresh(self, uri: Optional[str] = None):
-        """
-        Refresh library. Limit to URI and below if an URI is given.
+        """Refresh library. Limit to URI and below if an URI is given.
 
         :param uri: directory or track URI
         :type uri: string
@@ -268,8 +264,7 @@ class LibraryController:
                 future.get()
 
     def search(self, query, uris=None, exact=False):
-        """
-        Search the library for tracks where ``field`` contains ``values``.
+        """Search the library for tracks where ``field`` contains ``values``.
 
         ``field`` can be one of ``uri``, ``track_name``, ``album``, ``artist``,
         ``albumartist``, ``composer``, ``performer``, ``track_no``, ``genre``,

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -92,7 +92,7 @@ class LibraryController:
         """
         if uri is None:
             return self._roots()
-        elif not uri.strip():
+        if not uri.strip():
             return []
         validation.check_uri(uri)
         return self._browse(uri)

--- a/mopidy/core/listener.py
+++ b/mopidy/core/listener.py
@@ -39,7 +39,6 @@ class CoreListener(listener.Listener):
         :param time_position: the time position in milliseconds
         :type time_position: int
         """
-        pass
 
     def track_playback_resumed(self, tl_track, time_position):
         """Called whenever track playback is resumed.
@@ -51,7 +50,6 @@ class CoreListener(listener.Listener):
         :param time_position: the time position in milliseconds
         :type time_position: int
         """
-        pass
 
     def track_playback_started(self, tl_track):
         """Called whenever a new track starts playing.
@@ -61,7 +59,6 @@ class CoreListener(listener.Listener):
         :param tl_track: the track that just started playing
         :type tl_track: :class:`mopidy.models.TlTrack`
         """
-        pass
 
     def track_playback_ended(self, tl_track, time_position):
         """Called whenever playback of a track ends.
@@ -73,7 +70,6 @@ class CoreListener(listener.Listener):
         :param time_position: the time position in milliseconds
         :type time_position: int
         """
-        pass
 
     def playback_state_changed(self, old_state, new_state):
         """Called whenever playback state is changed.
@@ -85,21 +81,18 @@ class CoreListener(listener.Listener):
         :param new_state: the state after the change
         :type new_state: string from :class:`mopidy.core.PlaybackState` field
         """
-        pass
 
     def tracklist_changed(self):
         """Called whenever the tracklist is changed.
 
         *MAY* be implemented by actor.
         """
-        pass
 
     def playlists_loaded(self):
         """Called when playlists are loaded or refreshed.
 
         *MAY* be implemented by actor.
         """
-        pass
 
     def playlist_changed(self, playlist):
         """Called whenever a playlist is changed.
@@ -109,7 +102,6 @@ class CoreListener(listener.Listener):
         :param playlist: the changed playlist
         :type playlist: :class:`mopidy.models.Playlist`
         """
-        pass
 
     def playlist_deleted(self, uri):
         """Called whenever a playlist is deleted.
@@ -119,14 +111,12 @@ class CoreListener(listener.Listener):
         :param uri: the URI of the deleted playlist
         :type uri: string
         """
-        pass
 
     def options_changed(self):
         """Called whenever an option is changed.
 
         *MAY* be implemented by actor.
         """
-        pass
 
     def volume_changed(self, volume):
         """Called whenever the volume is changed.
@@ -136,7 +126,6 @@ class CoreListener(listener.Listener):
         :param volume: the new volume in the range [0..100]
         :type volume: int
         """
-        pass
 
     def mute_changed(self, mute):
         """Called whenever the mute state is changed.
@@ -146,7 +135,6 @@ class CoreListener(listener.Listener):
         :param mute: the new mute state
         :type mute: boolean
         """
-        pass
 
     def seeked(self, time_position):
         """Called whenever the time position changes by an unexpected amount, e.g.
@@ -157,7 +145,6 @@ class CoreListener(listener.Listener):
         :param time_position: the position that was seeked to in milliseconds
         :type time_position: int
         """
-        pass
 
     def stream_title_changed(self, title):
         """Called whenever the currently playing stream title changes.
@@ -167,4 +154,3 @@ class CoreListener(listener.Listener):
         :param title: the new stream title
         :type title: string
         """
-        pass

--- a/mopidy/core/listener.py
+++ b/mopidy/core/listener.py
@@ -2,9 +2,7 @@ from mopidy import listener
 
 
 class CoreListener(listener.Listener):
-
-    """
-    Marker interface for recipients of events sent by the core actor.
+    """Marker interface for recipients of events sent by the core actor.
 
     Any Pykka actor that mixes in this class will receive calls to the methods
     defined here when the corresponding events happen in the core actor. This
@@ -15,12 +13,11 @@ class CoreListener(listener.Listener):
 
     @staticmethod
     def send(event, **kwargs):
-        """Helper to allow calling of core listener events"""
+        """Helper to allow calling of core listener events."""
         listener.send(CoreListener, event, **kwargs)
 
     def on_event(self, event, **kwargs):
-        """
-        Called on all events.
+        """Called on all events.
 
         *MAY* be implemented by actor. By default, this method forwards the
         event to the specific event methods.
@@ -33,8 +30,7 @@ class CoreListener(listener.Listener):
         super().on_event(event, **kwargs)
 
     def track_playback_paused(self, tl_track, time_position):
-        """
-        Called whenever track playback is paused.
+        """Called whenever track playback is paused.
 
         *MAY* be implemented by actor.
 
@@ -46,8 +42,7 @@ class CoreListener(listener.Listener):
         pass
 
     def track_playback_resumed(self, tl_track, time_position):
-        """
-        Called whenever track playback is resumed.
+        """Called whenever track playback is resumed.
 
         *MAY* be implemented by actor.
 
@@ -59,8 +54,7 @@ class CoreListener(listener.Listener):
         pass
 
     def track_playback_started(self, tl_track):
-        """
-        Called whenever a new track starts playing.
+        """Called whenever a new track starts playing.
 
         *MAY* be implemented by actor.
 
@@ -70,8 +64,7 @@ class CoreListener(listener.Listener):
         pass
 
     def track_playback_ended(self, tl_track, time_position):
-        """
-        Called whenever playback of a track ends.
+        """Called whenever playback of a track ends.
 
         *MAY* be implemented by actor.
 
@@ -83,8 +76,7 @@ class CoreListener(listener.Listener):
         pass
 
     def playback_state_changed(self, old_state, new_state):
-        """
-        Called whenever playback state is changed.
+        """Called whenever playback state is changed.
 
         *MAY* be implemented by actor.
 
@@ -96,24 +88,21 @@ class CoreListener(listener.Listener):
         pass
 
     def tracklist_changed(self):
-        """
-        Called whenever the tracklist is changed.
+        """Called whenever the tracklist is changed.
 
         *MAY* be implemented by actor.
         """
         pass
 
     def playlists_loaded(self):
-        """
-        Called when playlists are loaded or refreshed.
+        """Called when playlists are loaded or refreshed.
 
         *MAY* be implemented by actor.
         """
         pass
 
     def playlist_changed(self, playlist):
-        """
-        Called whenever a playlist is changed.
+        """Called whenever a playlist is changed.
 
         *MAY* be implemented by actor.
 
@@ -123,8 +112,7 @@ class CoreListener(listener.Listener):
         pass
 
     def playlist_deleted(self, uri):
-        """
-        Called whenever a playlist is deleted.
+        """Called whenever a playlist is deleted.
 
         *MAY* be implemented by actor.
 
@@ -134,16 +122,14 @@ class CoreListener(listener.Listener):
         pass
 
     def options_changed(self):
-        """
-        Called whenever an option is changed.
+        """Called whenever an option is changed.
 
         *MAY* be implemented by actor.
         """
         pass
 
     def volume_changed(self, volume):
-        """
-        Called whenever the volume is changed.
+        """Called whenever the volume is changed.
 
         *MAY* be implemented by actor.
 
@@ -153,8 +139,7 @@ class CoreListener(listener.Listener):
         pass
 
     def mute_changed(self, mute):
-        """
-        Called whenever the mute state is changed.
+        """Called whenever the mute state is changed.
 
         *MAY* be implemented by actor.
 
@@ -164,8 +149,7 @@ class CoreListener(listener.Listener):
         pass
 
     def seeked(self, time_position):
-        """
-        Called whenever the time position changes by an unexpected amount, e.g.
+        """Called whenever the time position changes by an unexpected amount, e.g.
         at seek to a new time position.
 
         *MAY* be implemented by actor.
@@ -176,8 +160,7 @@ class CoreListener(listener.Listener):
         pass
 
     def stream_title_changed(self, title):
-        """
-        Called whenever the currently playing stream title changes.
+        """Called whenever the currently playing stream title changes.
 
         *MAY* be implemented by actor.
 

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -278,7 +278,7 @@ class PlaybackController:
             self.set_state(PlaybackState.PAUSED)
             self._trigger_track_playback_paused()
 
-    def play(self, tl_track=None, tlid=None):
+    def play(self, tl_track=None, tlid=None) -> None:  # noqa: C901, PLR0912
         """Play the given track, or if the given tl_track and tlid is
         :class:`None`, play the currently active track.
 

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -10,11 +10,11 @@ from mopidy.audio import PlaybackState
 from mopidy.core import listener
 from mopidy.exceptions import CoreError
 from mopidy.internal import deprecation, models, validation
-from mopidy.models import TlTrack
 
 if TYPE_CHECKING:
     from mopidy.audio.actor import AudioProxy
     from mopidy.core.actor import Backends, Core
+    from mopidy.models import TlTrack
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -376,7 +376,7 @@ class PlaybackController:
                 # TODO: check by binding against underlying play method using
                 # inspect and otherwise re-raise?
                 logger.error(
-                    "%s needs to be updated to work with this " "version of Mopidy.",
+                    "%s needs to be updated to work with this version of Mopidy.",
                     backend,
                 )
                 return False

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -123,11 +123,10 @@ class PlaybackController:
         if self._pending_position is not None:
             return self._pending_position
         backend = self._get_backend(self.get_current_tl_track())
-        if backend:
-            # TODO: Wrap backend call in error handling.
-            return backend.playback.get_time_position().get()
-        else:
+        if not backend:
             return 0
+        # TODO: Wrap backend call in error handling.
+        return backend.playback.get_time_position().get()
 
     def _on_end_of_stream(self):
         self.set_state(PlaybackState.STOPPED)
@@ -255,8 +254,7 @@ class PlaybackController:
             pending = self.core.tracklist.next_track(current)
             if self._change(pending, state):
                 break
-            else:
-                self.core.tracklist._mark_unplayable(pending)
+            self.core.tracklist._mark_unplayable(pending)
             # TODO: this could be needed to prevent a loop in rare cases
             # if current == pending:
             #     break
@@ -328,8 +326,7 @@ class PlaybackController:
         while pending:
             if self._change(pending, PlaybackState.PLAYING):
                 break
-            else:
-                self.core.tracklist._mark_unplayable(pending)
+            self.core.tracklist._mark_unplayable(pending)
             current = pending
             pending = self.core.tracklist.next_track(current)
             count -= 1
@@ -407,8 +404,7 @@ class PlaybackController:
             pending = self.core.tracklist.previous_track(current)
             if self._change(pending, state):
                 break
-            else:
-                self.core.tracklist._mark_unplayable(pending)
+            self.core.tracklist._mark_unplayable(pending)
             # TODO: this could be needed to prevent a loop in rare cases
             # if current == pending:
             #     break
@@ -474,9 +470,9 @@ class PlaybackController:
         # have a pending track.
         if self._current_tl_track and self._pending_tl_track:
             return self._change(self._current_tl_track, self.get_state())
-        else:
-            # TODO: Avoid returning False here when STOPPED (seek is deferred)?
-            return self._seek(time_position)
+
+        # TODO: Avoid returning False here when STOPPED (seek is deferred)?
+        return self._seek(time_position)
 
     def _seek(self, time_position):
         backend = self._get_backend(self.get_current_tl_track())
@@ -521,7 +517,7 @@ class PlaybackController:
         logger.debug("Triggering track playback started event")
         tl_track = self.get_current_tl_track()
         if tl_track is None:
-            return None
+            return
         self.core.tracklist._mark_playing(tl_track)
         self.core.history._add_track(tl_track.track)
         listener.CoreListener.send("track_playback_started", tl_track=tl_track)

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -256,9 +256,6 @@ class PlaybackController:
             if self._change(pending, state):
                 break
             self.core.tracklist._mark_unplayable(pending)
-            # TODO: this could be needed to prevent a loop in rare cases
-            # if current == pending:
-            #     break
             current = pending
             count -= 1
             if not count:
@@ -272,9 +269,6 @@ class PlaybackController:
         backend = self._get_backend(self.get_current_tl_track())
         # TODO: Wrap backend call in error handling.
         if not backend or backend.playback.pause().get():
-            # TODO: switch to:
-            # backend.track(pause)
-            # wait for state change?
             self.set_state(PlaybackState.PAUSED)
             self._trigger_track_playback_paused()
 
@@ -410,9 +404,6 @@ class PlaybackController:
             if self._change(pending, state):
                 break
             self.core.tracklist._mark_unplayable(pending)
-            # TODO: this could be needed to prevent a loop in rare cases
-            # if current == pending:
-            #     break
             current = pending
             count -= 1
             if not count:
@@ -431,9 +422,6 @@ class PlaybackController:
             self.set_state(PlaybackState.PLAYING)
             # TODO: trigger via gst messages
             self._trigger_track_playback_resumed()
-        # TODO: switch to:
-        # backend.resume()
-        # wait for state change?
 
     def seek(self, time_position: int) -> bool:
         """Seeks to time position given in milliseconds.

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -134,7 +134,7 @@ class PlaybackController:
             self._trigger_track_playback_ended(self.get_time_position())
         self._set_current_tl_track(None)
 
-    def _on_stream_changed(self, uri):
+    def _on_stream_changed(self, _uri):
         if self._last_position is None:
             position = self.get_time_position()
         else:
@@ -164,7 +164,7 @@ class PlaybackController:
                 self.set_state(PlaybackState.PLAYING)
                 self._trigger_track_playback_started()
 
-    def _on_position_changed(self, position):
+    def _on_position_changed(self, _position):
         if self._pending_position is not None:
             self._trigger_seeked(self._pending_position)
             self._pending_position = None

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -8,6 +8,7 @@ from pykka.messages import ProxyCall
 
 from mopidy.audio import PlaybackState
 from mopidy.core import listener
+from mopidy.exceptions import CoreError
 from mopidy.internal import deprecation, models, validation
 from mopidy.models import TlTrack
 
@@ -385,7 +386,7 @@ class PlaybackController:
             self._pending_tl_track = None
             return True
 
-        raise Exception(f"Unknown state: {state}")
+        raise CoreError(f"Unknown playback state: {state}")
 
     def previous(self):
         """Change to the previous track.

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -67,8 +67,7 @@ class PlaybackController:
         self._current_tl_track = value
 
     def get_current_track(self):
-        """
-        Get the currently playing or selected track.
+        """Get the currently playing or selected track.
 
         Extracted from :meth:`get_current_tl_track` for convenience.
 
@@ -77,8 +76,7 @@ class PlaybackController:
         return getattr(self.get_current_tl_track(), "track", None)
 
     def get_current_tlid(self):
-        """
-        Get the currently playing or selected TLID.
+        """Get the currently playing or selected TLID.
 
         Extracted from :meth:`get_current_tl_track` for convenience.
 
@@ -94,7 +92,6 @@ class PlaybackController:
 
     def get_state(self):
         """Get The playback state."""
-
         return self._state
 
     def set_state(self, new_state):
@@ -231,8 +228,7 @@ class PlaybackController:
                 break
 
     def _on_tracklist_change(self):
-        """
-        Tell the playback controller that the current playlist has changed.
+        """Tell the playback controller that the current playlist has changed.
 
         Used by :class:`mopidy.core.TracklistController`.
         """
@@ -244,8 +240,7 @@ class PlaybackController:
             self._set_current_tl_track(None)
 
     def next(self):
-        """
-        Change to the next track.
+        """Change to the next track.
 
         The current playback state will be kept. If it was playing, playing
         will continue. If it was paused, it will still be paused, etc.
@@ -285,8 +280,7 @@ class PlaybackController:
             self._trigger_track_playback_paused()
 
     def play(self, tl_track=None, tlid=None):
-        """
-        Play the given track, or if the given tl_track and tlid is
+        """Play the given track, or if the given tl_track and tlid is
         :class:`None`, play the currently active track.
 
         Note that the track **must** already be in the tracklist.
@@ -397,8 +391,7 @@ class PlaybackController:
         raise Exception(f"Unknown state: {state}")
 
     def previous(self):
-        """
-        Change to the previous track.
+        """Change to the previous track.
 
         The current playback state will be kept. If it was playing, playing
         will continue. If it was paused, it will still be paused, etc.
@@ -442,8 +435,7 @@ class PlaybackController:
         # wait for state change?
 
     def seek(self, time_position: int) -> bool:
-        """
-        Seeks to time position given in milliseconds.
+        """Seeks to time position given in milliseconds.
 
         :param time_position: time position in milliseconds
         :type time_position: int

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -337,7 +337,11 @@ class PlaybackController:
 
         # TODO return result?
 
-    def _change(self, pending_tl_track, state):
+    def _change(  # noqa: PLR0911
+        self,
+        pending_tl_track: Optional[TlTrack],
+        state: PlaybackState,
+    ) -> bool:
         self._pending_tl_track = pending_tl_track
 
         if not pending_tl_track:

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -254,7 +254,7 @@ class PlaylistsController:
         validation.check_instance(playlist, Playlist)
 
         if playlist.uri is None:
-            return  # TODO: log this problem?
+            return None  # TODO: log this problem?
 
         uri_scheme = urllib.parse.urlparse(playlist.uri).scheme
         backend = self.backends.with_playlists.get(uri_scheme, None)

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -42,7 +42,7 @@ class PlaylistsController:
 
         .. versionadded:: 2.0
         """
-        return list(sorted(self.backends.with_playlists.keys()))
+        return sorted(self.backends.with_playlists.keys())
 
     def as_list(self):
         """Get a list of the currently available playlists.

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -36,8 +36,7 @@ class PlaylistsController:
         self.core = core
 
     def get_uri_schemes(self):
-        """
-        Get the list of URI schemes that support playlists.
+        """Get the list of URI schemes that support playlists.
 
         :rtype: list of string
 
@@ -46,8 +45,7 @@ class PlaylistsController:
         return list(sorted(self.backends.with_playlists.keys()))
 
     def as_list(self):
-        """
-        Get a list of the currently available playlists.
+        """Get a list of the currently available playlists.
 
         Returns a list of :class:`~mopidy.models.Ref` objects referring to the
         playlists. In other words, no information about the playlists' content
@@ -80,8 +78,7 @@ class PlaylistsController:
         return results
 
     def get_items(self, uri):
-        """
-        Get the items in a playlist specified by ``uri``.
+        """Get the items in a playlist specified by ``uri``.
 
         Returns a list of :class:`~mopidy.models.Ref` objects referring to the
         playlist's items.
@@ -110,8 +107,7 @@ class PlaylistsController:
         return None
 
     def create(self, name, uri_scheme=None):
-        """
-        Create a new playlist.
+        """Create a new playlist.
 
         If ``uri_scheme`` matches an URI scheme handled by a current backend,
         that backend is asked to create the playlist. If ``uri_scheme`` is
@@ -144,8 +140,7 @@ class PlaylistsController:
         return None
 
     def delete(self, uri):
-        """
-        Delete playlist identified by the URI.
+        """Delete playlist identified by the URI.
 
         If the URI doesn't match the URI schemes handled by the current
         backends, nothing happens.
@@ -181,8 +176,7 @@ class PlaylistsController:
         return success
 
     def lookup(self, uri):
-        """
-        Lookup playlist with given URI in both the set of playlists and in any
+        """Lookup playlist with given URI in both the set of playlists and in any
         other playlist sources. Returns :class:`None` if not found.
 
         :param uri: playlist URI
@@ -205,8 +199,7 @@ class PlaylistsController:
     # TODO: there is an inconsistency between library.refresh(uri) and this
     # call, not sure how to sort this out.
     def refresh(self, uri_scheme=None):
-        """
-        Refresh the playlists in :attr:`playlists`.
+        """Refresh the playlists in :attr:`playlists`.
 
         If ``uri_scheme`` is :class:`None`, all backends are asked to refresh.
         If ``uri_scheme`` is an URI scheme handled by a backend, only that
@@ -238,8 +231,7 @@ class PlaylistsController:
             listener.CoreListener.send("playlists_loaded")
 
     def save(self, playlist):
-        """
-        Save the playlist.
+        """Save the playlist.
 
         For a playlist to be saveable, it must have the ``uri`` attribute set.
         You must not set the ``uri`` atribute yourself, but use playlist

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -213,7 +213,7 @@ class TracklistController:
             validation.check_instance(tl_track, TlTrack)
         if self.get_single() and self.get_repeat():
             return tl_track
-        elif self.get_single():
+        if self.get_single():
             return None
 
         # Current difference between next and EOT handling is that EOT needs to
@@ -284,8 +284,7 @@ class TracklistController:
         if self.get_repeat():
             if self.get_consume() and len(self._tl_tracks) == 1:
                 return None
-            else:
-                next_index %= len(self._tl_tracks)
+            next_index %= len(self._tl_tracks)
         elif next_index >= len(self._tl_tracks):
             return None
 

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -37,8 +37,7 @@ class TracklistController:
         return len(self._tl_tracks)
 
     def get_version(self):
-        """
-        Get the tracklist version.
+        """Get the tracklist version.
 
         Integer which is increased every time the tracklist is changed. Is not
         reset before Mopidy is restarted.
@@ -100,8 +99,7 @@ class TracklistController:
         self._random = value
 
     def get_repeat(self):
-        """
-        Get repeat mode.
+        """Get repeat mode.
 
         :class:`True`
             The tracklist is played repeatedly.
@@ -111,8 +109,7 @@ class TracklistController:
         return self._repeat
 
     def set_repeat(self, value):
-        """
-        Set repeat mode.
+        """Set repeat mode.
 
         To repeat a single track, set both ``repeat`` and ``single``.
 
@@ -127,8 +124,7 @@ class TracklistController:
         self._repeat = value
 
     def get_single(self):
-        """
-        Get single mode.
+        """Get single mode.
 
         :class:`True`
             Playback is stopped after current song, unless in ``repeat`` mode.
@@ -138,8 +134,7 @@ class TracklistController:
         return self._single
 
     def set_single(self, value):
-        """
-        Set single mode.
+        """Set single mode.
 
         :class:`True`
             Playback is stopped after current song, unless in ``repeat`` mode.
@@ -152,8 +147,7 @@ class TracklistController:
         self._single = value
 
     def index(self, tl_track=None, tlid=None):
-        """
-        The position of the given track in the tracklist.
+        """The position of the given track in the tracklist.
 
         If neither *tl_track* or *tlid* is given we return the index of
         the currently playing track.
@@ -187,8 +181,7 @@ class TracklistController:
         return None
 
     def get_eot_tlid(self):
-        """
-        The TLID of the track that will be played after the current track.
+        """The TLID of the track that will be played after the current track.
 
         Not necessarily the same TLID as returned by :meth:`get_next_tlid`.
 
@@ -196,7 +189,6 @@ class TracklistController:
 
         .. versionadded:: 1.1
         """
-
         current_tl_track = self.core.playback.get_current_tl_track()
 
         with deprecation.ignore("core.tracklist.eot_track"):
@@ -205,8 +197,7 @@ class TracklistController:
         return getattr(eot_tl_track, "tlid", None)
 
     def eot_track(self, tl_track):
-        """
-        The track that will be played after the given track.
+        """The track that will be played after the given track.
 
         Not necessarily the same track as :meth:`next_track`.
 
@@ -231,8 +222,7 @@ class TracklistController:
         return self.next_track(tl_track)
 
     def get_next_tlid(self):
-        """
-        The tlid of the track that will be played if calling
+        """The tlid of the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.next()`.
 
         For normal playback this is the next track in the tracklist. If repeat
@@ -252,8 +242,7 @@ class TracklistController:
         return getattr(next_tl_track, "tlid", None)
 
     def next_track(self, tl_track):
-        """
-        The track that will be played if calling
+        """The track that will be played if calling
         :meth:`mopidy.core.PlaybackController.next()`.
 
         For normal playback this is the next track in the tracklist. If repeat
@@ -303,8 +292,7 @@ class TracklistController:
         return self._tl_tracks[next_index]
 
     def get_previous_tlid(self):
-        """
-        Returns the TLID of the track that will be played if calling
+        """Returns the TLID of the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.previous()`.
 
         For normal playback this is the previous track in the tracklist. If
@@ -323,8 +311,7 @@ class TracklistController:
         return getattr(previous_tl_track, "tlid", None)
 
     def previous_track(self, tl_track):
-        """
-        Returns the track that will be played if calling
+        """Returns the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.previous()`.
 
         For normal playback this is the previous track in the tracklist. If
@@ -355,8 +342,7 @@ class TracklistController:
         return self._tl_tracks[position - 1]
 
     def add(self, tracks=None, at_position=None, uris=None):
-        """
-        Add tracks to the tracklist.
+        """Add tracks to the tracklist.
 
         If ``uris`` is given instead of ``tracks``, the URIs are
         looked up in the library and the resulting tracks are added to the
@@ -425,8 +411,7 @@ class TracklistController:
         return tl_tracks
 
     def clear(self):
-        """
-        Clear the tracklist.
+        """Clear the tracklist.
 
         Triggers the :meth:`mopidy.core.CoreListener.tracklist_changed` event.
         """
@@ -434,8 +419,7 @@ class TracklistController:
         self._increase_version()
 
     def filter(self, criteria):
-        """
-        Filter the tracklist by the given criteria.
+        """Filter the tracklist by the given criteria.
 
         Each rule in the criteria consists of a model field and a list of
         values to compare it against. If the model field matches any of the
@@ -471,8 +455,7 @@ class TracklistController:
         return matches
 
     def move(self, start, end, to_position):
-        """
-        Move the tracks in the slice ``[start:end]`` to ``to_position``.
+        """Move the tracks in the slice ``[start:end]`` to ``to_position``.
 
         Triggers the :meth:`mopidy.core.CoreListener.tracklist_changed` event.
 
@@ -508,8 +491,7 @@ class TracklistController:
         self._increase_version()
 
     def remove(self, criteria):
-        """
-        Remove the matching tracks from the tracklist.
+        """Remove the matching tracks from the tracklist.
 
         Uses :meth:`filter()` to lookup the tracks to remove.
 
@@ -527,8 +509,7 @@ class TracklistController:
         return tl_tracks
 
     def shuffle(self, start=None, end=None):
-        """
-        Shuffles the entire tracklist. If ``start`` and ``end`` is given only
+        """Shuffles the entire tracklist. If ``start`` and ``end`` is given only
         shuffles the slice ``[start:end]``.
 
         Triggers the :meth:`mopidy.core.CoreListener.tracklist_changed` event.
@@ -561,8 +542,7 @@ class TracklistController:
         self._increase_version()
 
     def slice(self, start, end):
-        """
-        Returns a slice of the tracklist, limited by the given start and end
+        """Returns a slice of the tracklist, limited by the given start and end
         positions.
 
         :param start: position of first track to include in slice

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -264,11 +264,14 @@ class TracklistController:
         if not self._tl_tracks:
             return None
 
-        if self.get_random() and not self._shuffled:
-            if self.get_repeat() or not tl_track:
-                logger.debug("Shuffling tracks")
-                self._shuffled = self._tl_tracks[:]
-                random.shuffle(self._shuffled)
+        if (
+            self.get_random()
+            and not self._shuffled
+            and (self.get_repeat() or not tl_track)
+        ):
+            logger.debug("Shuffling tracks")
+            self._shuffled = self._tl_tracks[:]
+            random.shuffle(self._shuffled)
 
         if self.get_random():
             if self._shuffled:

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -1,6 +1,6 @@
 import logging
 import random
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from mopidy import exceptions
 from mopidy.core import listener
@@ -241,7 +241,7 @@ class TracklistController:
 
         return getattr(next_tl_track, "tlid", None)
 
-    def next_track(self, tl_track):
+    def next_track(self, tl_track) -> Optional[TlTrack]:
         """The track that will be played if calling
         :meth:`mopidy.core.PlaybackController.next()`.
 
@@ -340,7 +340,12 @@ class TracklistController:
         # 1 - len(tracks) Thus 'position - 1' will always be within the list.
         return self._tl_tracks[position - 1]
 
-    def add(self, tracks=None, at_position=None, uris=None):
+    def add(  # noqa: C901
+        self,
+        tracks=None,
+        at_position=None,
+        uris=None,
+    ) -> list[TlTrack]:
         """Add tracks to the tracklist.
 
         If ``uris`` is given instead of ``tracks``, the URIs are

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -521,17 +521,14 @@ class TracklistController:
         tl_tracks = self._tl_tracks
 
         # TOOD: use validation helpers?
-        if start is not None and end is not None:
-            if start >= end:
-                raise AssertionError("start must be smaller than end")
+        if start is not None and end is not None and start >= end:
+            raise AssertionError("start must be smaller than end")
 
-        if start is not None:
-            if start < 0:
-                raise AssertionError("start must be at least zero")
+        if start is not None and start < 0:
+            raise AssertionError("start must be at least zero")
 
-        if end is not None:
-            if end > len(tl_tracks):
-                raise AssertionError("end can not be larger than " + "tracklist length")
+        if end is not None and end > len(tl_tracks):
+            raise AssertionError("end can not be larger than " + "tracklist length")
 
         before = tl_tracks[: start or 0]
         shuffled = tl_tracks[start:end]

--- a/mopidy/exceptions.py
+++ b/mopidy/exceptions.py
@@ -1,4 +1,4 @@
-class MopidyException(Exception):
+class MopidyException(Exception):  # noqa: N818
     def __init__(self, message, *args, **kwargs):
         super().__init__(message, *args, **kwargs)
         self._message = message
@@ -39,7 +39,7 @@ class ScannerError(MopidyException):
     pass
 
 
-class TracklistFull(CoreError):
+class TracklistFull(CoreError):  # noqa: N818
     def __init__(self, message, errno=None):
         super().__init__(message, errno)
         self.errno = errno

--- a/mopidy/exceptions.py
+++ b/mopidy/exceptions.py
@@ -5,7 +5,7 @@ class MopidyException(Exception):  # noqa: N818
 
     @property
     def message(self):
-        """Reimplement message field that was deprecated in Python 2.6"""
+        """Reimplement message field that was deprecated in Python 2.6."""
         return self._message
 
     @message.setter  # noqa

--- a/mopidy/exceptions.py
+++ b/mopidy/exceptions.py
@@ -1,4 +1,4 @@
-class MopidyException(Exception):  # noqa: N818
+class MopidyException(Exception):
     def __init__(self, message, *args, **kwargs):
         super().__init__(message, *args, **kwargs)
         self._message = message
@@ -8,7 +8,7 @@ class MopidyException(Exception):  # noqa: N818
         """Reimplement message field that was deprecated in Python 2.6."""
         return self._message
 
-    @message.setter  # noqa
+    @message.setter
     def message(self, message):
         self._message = message
 
@@ -39,13 +39,13 @@ class ScannerError(MopidyException):
     pass
 
 
-class TracklistFull(CoreError):  # noqa: N818
+class TracklistFull(CoreError):
     def __init__(self, message, errno=None):
         super().__init__(message, errno)
         self.errno = errno
 
 
-class AudioException(MopidyException):  # noqa: N818
+class AudioException(MopidyException):
     pass
 
 

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -38,8 +38,7 @@ class ExtensionData(NamedTuple):
 
 
 class Extension:
-
-    """Base class for Mopidy extensions"""
+    """Base class for Mopidy extensions."""
 
     dist_name: str
     """The extension's distribution name, as registered on PyPI
@@ -69,7 +68,7 @@ class Extension:
         raise NotImplementedError('Add at least a config section with "enabled = true"')
 
     def get_config_schema(self) -> ConfigSchema:
-        """The extension's config validation schema
+        """The extension's config validation schema.
 
         :returns: :class:`~mopidy.config.schemas.ConfigSchema`
         """
@@ -146,8 +145,7 @@ class Extension:
         pass
 
     def setup(self, registry: Registry) -> None:
-        """
-        Register the extension's components in the extension :class:`Registry`.
+        """Register the extension's components in the extension :class:`Registry`.
 
         For example, to register a backend::
 
@@ -169,7 +167,6 @@ class Extension:
 
 
 class Registry(Mapping):
-
     """Registry of components provided by Mopidy extensions.
 
     Passed to the :meth:`~Extension.setup` method of all extensions. The
@@ -213,7 +210,6 @@ def load_extensions() -> list[ExtensionData]:
 
     :returns: list of installed extensions
     """
-
     installed_extensions = []
 
     for entry_point in metadata.entry_points(group="mopidy.ext"):
@@ -270,7 +266,6 @@ def validate_extension_data(data: ExtensionData) -> bool:
     :param extensions: an extension to check
     :returns: if extension should be run
     """
-
     logger.debug("Validating extension: %s", data.extension.ext_name)
 
     if data.extension.ext_name != data.entry_point.name:

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -259,7 +259,7 @@ def load_extensions() -> list[ExtensionData]:
     return installed_extensions
 
 
-def validate_extension_data(data: ExtensionData) -> bool:
+def validate_extension_data(data: ExtensionData) -> bool:  # noqa: PLR0911
     """Verify extension's dependencies and environment.
 
     :param extensions: an extension to check

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -304,7 +304,8 @@ def validate_extension_data(data: ExtensionData) -> bool:
             data.extension.ext_name,
         )
         return False
-    elif not isinstance(data.config_schema.get("enabled"), config_lib.Boolean):
+
+    if not isinstance(data.config_schema.get("enabled"), config_lib.Boolean):
         logger.error(
             'Extension %s does not have the required "enabled" config'
             " option, disabling.",

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -223,7 +223,7 @@ def load_extensions() -> list[ExtensionData]:
                 raise TypeError  # issubclass raises TypeError on non-class
         except TypeError:
             logger.error(
-                "Entry point %s did not contain a valid extension" "class: %r",
+                "Entry point %s did not contain a valid extensionclass: %r",
                 entry_point.name,
                 extension_class,
             )
@@ -244,7 +244,7 @@ def load_extensions() -> list[ExtensionData]:
             )
         except Exception:
             logger.exception(
-                "Setup of extension from entry point %s failed, " "ignoring extension.",
+                "Setup of extension from entry point %s failed, ignoring extension.",
                 entry_point.name,
             )
             continue

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -215,13 +215,13 @@ def load_extensions() -> list[ExtensionData]:
         logger.debug("Loading entry point: %s", entry_point)
         try:
             extension_class = entry_point.load()
-        except Exception as exc:
-            logger.exception(f"Failed to load extension {entry_point.name}: {exc}")
+        except Exception:
+            logger.exception(f"Failed to load extension {entry_point.name}.")
             continue
 
         try:
             if not issubclass(extension_class, Extension):
-                raise TypeError  # issubclass raises TypeError on non-class
+                raise TypeError  # noqa: TRY301
         except TypeError:
             logger.error(
                 "Entry point %s did not contain a valid extensionclass: %r",

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -12,8 +12,6 @@ else:
 
 from mopidy import config as config_lib
 from mopidy import exceptions
-from mopidy.commands import Command
-from mopidy.config import ConfigSchema
 from mopidy.internal import path
 
 if TYPE_CHECKING:
@@ -22,6 +20,9 @@ if TYPE_CHECKING:
     from typing import Any, Optional
 
     from typing_extensions import TypeAlias
+
+    from mopidy.commands import Command
+    from mopidy.config import ConfigSchema
 
     Config = dict[str, dict[str, Any]]
     RegistryEntry: TypeAlias = Union[type[Any], dict[str, Any]]

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -128,7 +128,6 @@ class Extension:
         :returns:
           Instance of a :class:`~mopidy.commands.Command` class.
         """
-        pass
 
     def validate_environment(self) -> None:
         """Checks if the extension can run in the current environment.
@@ -142,7 +141,6 @@ class Extension:
         :raises: :exc:`~mopidy.exceptions.ExtensionError`
         :returns: :class:`None`
         """
-        pass
 
     def setup(self, registry: Registry) -> None:
         """Register the extension's components in the extension :class:`Registry`.

--- a/mopidy/file/__init__.py
+++ b/mopidy/file/__init__.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 import mopidy
 from mopidy import config, ext
@@ -13,8 +13,7 @@ class Extension(ext.Extension):
     version = mopidy.__version__
 
     def get_default_config(self):
-        conf_file = os.path.join(os.path.dirname(__file__), "ext.conf")
-        return config.read(conf_file)
+        return config.read(Path(__file__).parent / "ext.conf")
 
     def get_config_schema(self):
         schema = super().get_config_schema()

--- a/mopidy/file/backend.py
+++ b/mopidy/file/backend.py
@@ -1,4 +1,5 @@
 import logging
+from typing import ClassVar
 
 import pykka
 
@@ -9,7 +10,7 @@ logger = logging.getLogger(__name__)
 
 
 class FileBackend(pykka.ThreadingActor, backend.Backend):
-    uri_schemes = ["file"]
+    uri_schemes: ClassVar[list[str]] = ["file"]
 
     def __init__(self, config, audio):
         super().__init__()

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -35,7 +35,7 @@ class FileLibraryProvider(backend.LibraryProvider):
 
         self._scanner = scan.Scanner(timeout=config["file"]["metadata_timeout"])
 
-    def browse(self, uri):
+    def browse(self, uri) -> list[models.Ref]:  # noqa: C901
         logger.debug("Browsing files at: %s", uri)
         result = []
         local_path = path.uri_to_path(uri)

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -113,7 +113,7 @@ class FileLibraryProvider(backend.LibraryProvider):
 
             if local_path is None:
                 logger.debug(
-                    "Failed expanding path (%s) from file/media_dirs config " "value.",
+                    "Failed expanding path (%s) from file/media_dirs config value.",
                     media_dir_split[0],
                 )
                 continue

--- a/mopidy/file/library.py
+++ b/mopidy/file/library.py
@@ -18,7 +18,7 @@ class FileLibraryProvider(backend.LibraryProvider):
     def root_directory(self):
         if not self._media_dirs:
             return None
-        elif len(self._media_dirs) == 1:
+        if len(self._media_dirs) == 1:
             uri = path.path_to_uri(self._media_dirs[0]["path"])
         else:
             uri = "file:root"

--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -1,5 +1,6 @@
 import logging
 from pathlib import Path
+from typing import cast
 
 import mopidy
 from mopidy import config, exceptions, ext
@@ -37,11 +38,11 @@ class Extension(ext.Extension):
             raise exceptions.ExtensionError("tornado library not found") from exc
 
     def setup(self, registry):
-        from .actor import HttpFrontend
+        from .actor import HttpApp, HttpFrontend, HttpStatic
         from .handlers import make_mopidy_app_factory
 
-        HttpFrontend.apps = registry["http:app"]
-        HttpFrontend.statics = registry["http:static"]
+        HttpFrontend.apps = cast(list[HttpApp], registry["http:app"])
+        HttpFrontend.statics = cast(list[HttpStatic], registry["http:static"])
 
         registry.add("frontend", HttpFrontend)
         registry.add(

--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -1,9 +1,8 @@
 import logging
-import os
+from pathlib import Path
 
 import mopidy
-from mopidy import config as config_lib
-from mopidy import exceptions, ext
+from mopidy import config, exceptions, ext
 
 logger = logging.getLogger(__name__)
 
@@ -14,22 +13,21 @@ class Extension(ext.Extension):
     version = mopidy.__version__
 
     def get_default_config(self):
-        conf_file = os.path.join(os.path.dirname(__file__), "ext.conf")
-        return config_lib.read(conf_file)
+        return config.read(Path(__file__).parent / "ext.conf")
 
     def get_config_schema(self):
         schema = super().get_config_schema()
-        schema["hostname"] = config_lib.Hostname()
-        schema["port"] = config_lib.Port()
-        schema["static_dir"] = config_lib.Deprecated()
-        schema["zeroconf"] = config_lib.String(optional=True)
-        schema["allowed_origins"] = config_lib.List(
+        schema["hostname"] = config.Hostname()
+        schema["port"] = config.Port()
+        schema["static_dir"] = config.Deprecated()
+        schema["zeroconf"] = config.String(optional=True)
+        schema["allowed_origins"] = config.List(
             optional=True,
             unique=True,
-            subtype=config_lib.String(transformer=lambda x: x.lower()),
+            subtype=config.String(transformer=lambda x: x.lower()),
         )
-        schema["csrf_protection"] = config_lib.Boolean(optional=True)
-        schema["default_app"] = config_lib.String(optional=True)
+        schema["csrf_protection"] = config.Boolean(optional=True)
+        schema["default_app"] = config.String(optional=True)
         return schema
 
     def validate_environment(self):

--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -33,8 +33,8 @@ class Extension(ext.Extension):
     def validate_environment(self):
         try:
             import tornado.web  # noqa: F401 (Imported to test if available)
-        except ImportError as e:
-            raise exceptions.ExtensionError("tornado library not found", e)
+        except ImportError as exc:
+            raise exceptions.ExtensionError("tornado library not found") from exc
 
     def setup(self, registry):
         from .actor import HttpFrontend

--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -34,7 +34,7 @@ class Extension(ext.Extension):
 
     def validate_environment(self):
         try:
-            import tornado.web  # noqa
+            import tornado.web
         except ImportError as e:
             raise exceptions.ExtensionError("tornado library not found", e)
 

--- a/mopidy/http/__init__.py
+++ b/mopidy/http/__init__.py
@@ -32,7 +32,7 @@ class Extension(ext.Extension):
 
     def validate_environment(self):
         try:
-            import tornado.web
+            import tornado.web  # noqa: F401 (Imported to test if available)
         except ImportError as e:
             raise exceptions.ExtensionError("tornado library not found", e)
 

--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -55,7 +55,7 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
                 statics=self.statics,
             )
         except OSError as exc:
-            raise exceptions.FrontendError(f"HTTP server startup failed: {exc}")
+            raise exceptions.FrontendError("HTTP server startup failed.") from exc
 
         self.zeroconf_name = config["http"]["zeroconf"]
         self.zeroconf_http = None

--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import secrets
@@ -18,11 +19,6 @@ from mopidy import exceptions, models, zeroconf
 from mopidy.core import CoreListener
 from mopidy.http import Extension, handlers
 from mopidy.internal import formatting, network
-
-try:
-    import asyncio
-except ImportError:
-    asyncio = None  # type: ignore
 
 if TYPE_CHECKING:
     from mopidy.core.actor import CoreProxy
@@ -121,11 +117,9 @@ class HttpServer(threading.Thread):
         self.io_loop = None
 
     def run(self):
-        if asyncio:
-            # If asyncio is available, Tornado uses it as its IO loop. Since we
-            # start Tornado in a another thread than the main thread, we must
-            # explicitly create an asyncio loop for the current thread.
-            asyncio.set_event_loop(asyncio.new_event_loop())
+        # Since we start Tornado in a another thread than the main thread,
+        # we must explicitly create an asyncio loop for the current thread.
+        asyncio.set_event_loop(asyncio.new_event_loop())
 
         self.app = tornado.web.Application(
             self._get_request_handlers(),

--- a/mopidy/http/actor.py
+++ b/mopidy/http/actor.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import json
 import logging
 import secrets
+import socket
 import threading
 from typing import TYPE_CHECKING, ClassVar
 
@@ -99,7 +100,14 @@ def on_event(name, io_loop, **data):
 class HttpServer(threading.Thread):
     name = "HttpServer"
 
-    def __init__(self, config, core, sockets, apps, statics):
+    def __init__(  # noqa: PLR0913
+        self,
+        config: Config,
+        core: CoreProxy,
+        sockets: list[socket.socket],
+        apps: list[RegistryEntry],
+        statics: list[RegistryEntry],
+    ) -> None:
         super().__init__()
 
         self.config = config

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -271,7 +271,7 @@ class ClientListHandler(tornado.web.RequestHandler):
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
-    def set_extra_headers(self, path):
+    def set_extra_headers(self, _path):
         set_mopidy_headers(self)
 
 

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -267,7 +267,7 @@ class ClientListHandler(tornado.web.RequestHandler):
             names.add(static["name"])
         names.discard("mopidy")
 
-        self.render("data/clients.html", apps=sorted(list(names)))
+        self.render("data/clients.html", apps=sorted(names))
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -2,8 +2,8 @@ from __future__ import annotations
 
 import functools
 import logging
-import os
 import urllib.parse
+from pathlib import Path
 from typing import TYPE_CHECKING
 
 import tornado.escape
@@ -49,7 +49,7 @@ def make_mopidy_app_factory(apps, statics):
             (
                 r"/(.+)",
                 StaticFileHandler,
-                {"path": os.path.join(os.path.dirname(__file__), "data")},
+                {"path": str(Path(__file__).parent / "data")},
             ),
             (r"/", ClientListHandler, {"apps": apps, "statics": statics}),
         ]
@@ -255,7 +255,7 @@ class ClientListHandler(tornado.web.RequestHandler):
         self.statics = statics
 
     def get_template_path(self):
-        return os.path.dirname(__file__)
+        return str(Path(__file__).parent)
 
     def get(self):
         set_mopidy_headers(self)

--- a/mopidy/httpclient.py
+++ b/mopidy/httpclient.py
@@ -35,8 +35,8 @@ def format_proxy(proxy_config: ProxyConfig, auth: bool = True) -> Optional[str]:
 
     if username and password and auth:
         return f"{scheme}://{username}:{password}@{hostname}:{port}"
-    else:
-        return f"{scheme}://{hostname}:{port}"
+
+    return f"{scheme}://{hostname}:{port}"
 
 
 def format_user_agent(name: Optional[str] = None) -> str:

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -34,10 +34,7 @@ _MESSAGES = {
 
 
 def warn(msg_id, pending=False):
-    if pending:
-        category = PendingDeprecationWarning
-    else:
-        category = DeprecationWarning
+    category = PendingDeprecationWarning if pending else DeprecationWarning
     warnings.warn(_MESSAGES.get(msg_id, msg_id), category, stacklevel=2)
 
 

--- a/mopidy/internal/deprecation.py
+++ b/mopidy/internal/deprecation.py
@@ -15,7 +15,7 @@ _MESSAGES = {
         'tracklist.add() "tracks" argument is deprecated'
     ),
     "core.tracklist.eot_track": (
-        "tracklist.eot_track() is pending deprecation, use " "tracklist.get_eot_tlid()"
+        "tracklist.eot_track() is pending deprecation, use tracklist.get_eot_tlid()"
     ),
     "core.tracklist.next_track": (
         "tracklist.next_track() is pending deprecation, use "

--- a/mopidy/internal/deps.py
+++ b/mopidy/internal/deps.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import functools
-import os
 import platform
 import re
 import sys
+from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Optional, TypedDict
 
 if sys.version_info < (3, 10):
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
     class DepInfo(TypedDict, total=False):
         name: str
         version: str
-        path: str
+        path: Path
         dependencies: list[DepInfo]
         other: str
 
@@ -92,7 +92,7 @@ def python_info() -> DepInfo:
     return {
         "name": "Python",
         "version": (f"{platform.python_implementation()} {platform.python_version()}"),
-        "path": os.path.dirname(platform.__file__),
+        "path": Path(platform.__file__).parent,
     }
 
 
@@ -125,7 +125,7 @@ def pkg_info(
         return {
             "name": project_name,
             "version": distribution.version,
-            "path": str(distribution.locate_file(".")),
+            "path": distribution.locate_file("."),
             "dependencies": dependencies,
         }
     except metadata.PackageNotFoundError:
@@ -161,7 +161,7 @@ def gstreamer_info() -> DepInfo:
     return {
         "name": "GStreamer",
         "version": ".".join(map(str, Gst.version())),
-        "path": os.path.dirname(gi.__file__),
+        "path": Path(gi.__file__).parent,
         "other": "\n".join(other),
     }
 

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -9,7 +9,7 @@ try:
     gi.require_version("Gst", "1.0")
     from gi.repository import GLib, GObject, Gst
 except ImportError:
-    print(
+    print(  # noqa: T201
         textwrap.dedent(
             """
         ERROR: A GObject based library was not found.

--- a/mopidy/internal/http.py
+++ b/mopidy/internal/http.py
@@ -34,7 +34,7 @@ def download(session, uri, timeout=1.0, chunk_size=4096):
         response = session.get(uri, stream=True, timeout=timeout)
     except requests.exceptions.Timeout:
         logger.warning(
-            "Download of %r failed due to connection timeout after " "%.3fs",
+            "Download of %r failed due to connection timeout after %.3fs",
             uri,
             timeout,
         )
@@ -53,7 +53,7 @@ def download(session, uri, timeout=1.0, chunk_size=4096):
         content.append(chunk)
         if time.time() > deadline:
             logger.warning(
-                "Download of %r failed due to download taking more " "than %.3fs",
+                "Download of %r failed due to download taking more than %.3fs",
                 uri,
                 timeout,
             )

--- a/mopidy/internal/jsonrpc.py
+++ b/mopidy/internal/jsonrpc.py
@@ -53,7 +53,7 @@ class JsonRpcWrapper:
     """
 
     def __init__(self, objects, decoders=None, encoders=None):
-        if "" in objects.keys():
+        if "" in objects:
             raise AttributeError("The empty string is not allowed as an object mount")
         self.objects = objects
         self.decoder = get_combined_json_decoder(decoders or [])
@@ -304,7 +304,7 @@ class JsonRpcInspector:
     """
 
     def __init__(self, objects):
-        if "" in objects.keys():
+        if "" in objects:
             raise AttributeError("The empty string is not allowed as an object mount")
         self.objects = objects
 

--- a/mopidy/internal/jsonrpc.py
+++ b/mopidy/internal/jsonrpc.py
@@ -93,8 +93,7 @@ class JsonRpcWrapper:
         """
         if isinstance(request, list):
             return self._handle_batch(request)
-        else:
-            return self._handle_single_request(request)
+        return self._handle_single_request(request)
 
     def _handle_batch(self, requests):
         if not requests:
@@ -172,12 +171,11 @@ class JsonRpcWrapper:
         params = request["params"]
         if isinstance(params, list):
             return params, {}
-        elif isinstance(params, dict):
+        if isinstance(params, dict):
             return [], params
-        else:
-            raise JsonRpcInvalidRequestError(
-                data="'params', if given, must be an array or an object"
-            )
+        raise JsonRpcInvalidRequestError(
+            data="'params', if given, must be an array or an object"
+        )
 
     def _get_method(self, method_path):
         if callable(self.objects.get(method_path, None)):

--- a/mopidy/internal/jsonrpc.py
+++ b/mopidy/internal/jsonrpc.py
@@ -113,8 +113,8 @@ class JsonRpcWrapper:
         try:
             self._validate_request(request)
             args, kwargs = self._get_params(request)
-        except JsonRpcInvalidRequestError as error:
-            return error.get_response()
+        except JsonRpcInvalidRequestError as exc:
+            return exc.get_response()
 
         try:
             method = self._get_method(request["method"])
@@ -132,26 +132,26 @@ class JsonRpcWrapper:
                     "id": request["id"],
                     "result": result,
                 }
-            except TypeError as error:
+            except TypeError as exc:
                 raise JsonRpcInvalidParamsError(
                     data={
-                        "type": error.__class__.__name__,
-                        "message": str(error),
+                        "type": exc.__class__.__name__,
+                        "message": str(exc),
                         "traceback": traceback.format_exc(),
                     }
-                )
-            except Exception as error:
+                ) from exc
+            except Exception as exc:
                 raise JsonRpcApplicationError(
                     data={
-                        "type": error.__class__.__name__,
-                        "message": str(error),
+                        "type": exc.__class__.__name__,
+                        "message": str(exc),
                         "traceback": traceback.format_exc(),
                     }
-                )
-        except JsonRpcError as error:
+                ) from exc
+        except JsonRpcError as exc:
             if self._is_notification(request):
                 return None
-            return error.get_response(request["id"])
+            return exc.get_response(request["id"])
 
     def _validate_request(self, request):
         if not isinstance(request, dict):
@@ -196,15 +196,17 @@ class JsonRpcWrapper:
 
         try:
             obj = self.objects[mount]
-        except KeyError:
-            raise JsonRpcMethodNotFoundError(data=f"No object found at {mount!r}")
+        except KeyError as exc:
+            raise JsonRpcMethodNotFoundError(
+                data=f"No object found at {mount!r}"
+            ) from exc
 
         try:
             return getattr(obj, method_name)
-        except AttributeError:
+        except AttributeError as exc:
             raise JsonRpcMethodNotFoundError(
                 data=f"Object mounted at {mount!r} has no member {method_name!r}"
-            )
+            ) from exc
 
     def _is_notification(self, request):
         return "id" not in request

--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -5,7 +5,7 @@ import logging.config
 import logging.handlers
 import platform
 from logging import LogRecord
-from typing import TYPE_CHECKING, Literal, Optional
+from typing import TYPE_CHECKING, ClassVar, Literal, Optional
 
 if TYPE_CHECKING:
     from mopidy.config import Config, LoggingConfig
@@ -176,7 +176,9 @@ class ColorizingStreamHandler(logging.StreamHandler):
     """
 
     # Map logging levels to (background, foreground, bold/intense)
-    level_map: dict[int, tuple[Optional[LogColorName], LogColorName, bool]] = {
+    level_map: ClassVar[
+        dict[int, tuple[Optional[LogColorName], LogColorName, bool]]
+    ] = {
         TRACE_LOG_LEVEL: (None, "blue", False),
         logging.DEBUG: (None, "blue", False),
         logging.INFO: (None, "white", False),
@@ -185,7 +187,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
         logging.CRITICAL: ("red", "white", True),
     }
     # Map logger name to foreground colors
-    logger_map: dict[LogLevelName, LogColorName] = {}
+    logger_map: dict[LogLevelName, LogColorName]
 
     csi = "\x1b["
     reset = "\x1b[0m"

--- a/mopidy/internal/log.py
+++ b/mopidy/internal/log.py
@@ -32,12 +32,12 @@ LogColorName = Literal[
 ]
 
 LOG_LEVELS: dict[int, dict[str, int]] = {
-    -1: dict(root=logging.ERROR, mopidy=logging.WARNING),
-    0: dict(root=logging.ERROR, mopidy=logging.INFO),
-    1: dict(root=logging.WARNING, mopidy=logging.DEBUG),
-    2: dict(root=logging.INFO, mopidy=logging.DEBUG),
-    3: dict(root=logging.DEBUG, mopidy=logging.DEBUG),
-    4: dict(root=logging.NOTSET, mopidy=logging.NOTSET),
+    -1: {"root": logging.ERROR, "mopidy": logging.WARNING},
+    0: {"root": logging.ERROR, "mopidy": logging.INFO},
+    1: {"root": logging.WARNING, "mopidy": logging.DEBUG},
+    2: {"root": logging.INFO, "mopidy": logging.DEBUG},
+    3: {"root": logging.DEBUG, "mopidy": logging.DEBUG},
+    4: {"root": logging.NOTSET, "mopidy": logging.NOTSET},
 }
 
 # Custom log level which has even lower priority than DEBUG

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -14,7 +14,7 @@ def try_ipv6_socket() -> bool:
         return True
     except OSError as exc:
         logger.debug(
-            f"Platform supports IPv6, but socket creation failed, " f"disabling: {exc}"
+            f"Platform supports IPv6, but socket creation failed, disabling: {exc}"
         )
     return False
 

--- a/mopidy/internal/network.py
+++ b/mopidy/internal/network.py
@@ -11,12 +11,13 @@ def try_ipv6_socket() -> bool:
         return False
     try:
         socket.socket(socket.AF_INET6).close()
-        return True
     except OSError as exc:
         logger.debug(
             f"Platform supports IPv6, but socket creation failed, disabling: {exc}"
         )
-    return False
+        return False
+    else:
+        return True
 
 
 #: Boolean value that indicates if creating an IPv6 socket will succeed.

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -18,7 +18,7 @@ def get_or_create_dir(dir_path):
             f"A file with the same name as the desired dir, "
             f"{dir_path!r}, already exists."
         )
-    elif not dir_path.is_dir():
+    if not dir_path.is_dir():
         logger.info(f"Creating dir {dir_path.as_uri()}")
         dir_path.mkdir(mode=0o755, parents=True)
     return dir_path

--- a/mopidy/internal/path.py
+++ b/mopidy/internal/path.py
@@ -2,6 +2,8 @@ import logging
 import pathlib
 import re
 import urllib.parse
+from os import PathLike
+from typing import Union
 
 from mopidy.internal import xdg
 
@@ -45,7 +47,7 @@ def get_unix_socket_path(socket_path):
     return match.group(1)
 
 
-def path_to_uri(path):
+def path_to_uri(path: Union[str, PathLike[str]]) -> str:
     """
     Convert OS specific path to file:// URI.
 

--- a/mopidy/internal/playlists.py
+++ b/mopidy/internal/playlists.py
@@ -1,6 +1,6 @@
 import configparser
 import io
-import xml.etree.ElementTree as elementtree
+from xml.etree import ElementTree
 
 from mopidy.internal import validation
 
@@ -33,9 +33,9 @@ def detect_xspf_header(data):
 
     try:
         data = io.BytesIO(data)
-        for _event, element in elementtree.iterparse(data, events=["start"]):
+        for _event, element in ElementTree.iterparse(data, events=["start"]):
             return element.tag.lower() == "{http://xspf.org/ns/0/}playlist"
-    except elementtree.ParseError:
+    except ElementTree.ParseError:
         pass
     return False
 
@@ -47,9 +47,9 @@ def detect_asx_header(data):
 
     try:
         data = io.BytesIO(data)
-        for _event, element in elementtree.iterparse(data, events=["start"]):
+        for _event, element in ElementTree.iterparse(data, events=["start"]):
             return element.tag.lower() == "asx"
-    except elementtree.ParseError:
+    except ElementTree.ParseError:
         pass
     return False
 
@@ -93,9 +93,9 @@ def parse_xspf(data):
     element = None
     try:
         # Last element will be root.
-        for _event, element in elementtree.iterparse(io.BytesIO(data)):
+        for _event, element in ElementTree.iterparse(io.BytesIO(data)):
             element.tag = element.tag.lower()  # normalize
-    except elementtree.ParseError:
+    except ElementTree.ParseError:
         return
     if element is None:
         return
@@ -110,9 +110,9 @@ def parse_asx(data):
     element = None
     try:
         # Last element will be root.
-        for _event, element in elementtree.iterparse(io.BytesIO(data)):
+        for _event, element in ElementTree.iterparse(io.BytesIO(data)):
             element.tag = element.tag.lower()  # normalize
-    except elementtree.ParseError:
+    except ElementTree.ParseError:
         return
     if element is None:
         return

--- a/mopidy/internal/playlists.py
+++ b/mopidy/internal/playlists.py
@@ -1,6 +1,6 @@
 import configparser
 import io
-import xml.etree.ElementTree as elementtree  # noqa: N813
+import xml.etree.ElementTree as elementtree
 
 from mopidy.internal import validation
 

--- a/mopidy/internal/process.py
+++ b/mopidy/internal/process.py
@@ -13,7 +13,7 @@ def exit_process():
     logger.debug("Interrupted main")
 
 
-def sigterm_handler(signum, frame):
+def sigterm_handler(_signum, _frame):
     """A :mod:`signal` handler which will exit the program on signal.
 
     This function is not called when the process' main thread is running a GLib

--- a/mopidy/internal/validation.py
+++ b/mopidy/internal/validation.py
@@ -128,7 +128,7 @@ def check_query(
         check_choice(
             key,
             fields,
-            msg="Expected query field to be one of " "{choices}, not {arg!r}",
+            msg="Expected query field to be one of {choices}, not {arg!r}",
         )
         if list_values:
             msg = 'Expected "{key}" to be list of strings, not {arg!r}'

--- a/mopidy/internal/validation.py
+++ b/mopidy/internal/validation.py
@@ -51,9 +51,9 @@ def _check_iterable(
     """Ensure we have an iterable which is not a string or an iterator"""
     if isinstance(arg, str):
         raise exceptions.ValidationError(msg.format(arg=arg, **kwargs))
-    elif not isinstance(arg, Iterable):
+    if not isinstance(arg, Iterable):
         raise exceptions.ValidationError(msg.format(arg=arg, **kwargs))
-    elif iter(arg) is iter(arg):
+    if iter(arg) is iter(arg):
         raise exceptions.ValidationError(msg.format(arg=arg, **kwargs))
 
 
@@ -99,11 +99,11 @@ def check_integer(
 ) -> None:
     if not isinstance(arg, int):
         raise exceptions.ValidationError(f"Expected an integer, not {arg!r}")
-    elif min is not None and arg < min:
+    if min is not None and arg < min:
         raise exceptions.ValidationError(
             f"Expected number larger or equal to {min}, not {arg!r}"
         )
-    elif max is not None and arg > max:
+    if max is not None and arg > max:
         raise exceptions.ValidationError(
             f"Expected number smaller or equal to {max}, not {arg!r}"
         )
@@ -155,7 +155,7 @@ def check_uri(
 ) -> None:
     if not isinstance(arg, str):
         raise exceptions.ValidationError(msg.format(arg=arg))
-    elif urllib.parse.urlparse(arg).scheme == "":
+    if urllib.parse.urlparse(arg).scheme == "":
         raise exceptions.ValidationError(msg.format(arg=arg))
 
 

--- a/mopidy/internal/versioning.py
+++ b/mopidy/internal/versioning.py
@@ -1,5 +1,5 @@
-import os
 import subprocess
+from pathlib import Path
 
 import mopidy
 
@@ -12,7 +12,7 @@ def get_version():
 
 
 def get_git_version():
-    project_dir = os.path.abspath(os.path.join(os.path.dirname(mopidy.__file__), ".."))
+    project_dir = Path(mopidy.__file__).parent.parent.resolve()
     process = subprocess.Popen(
         ["git", "describe"],
         stdout=subprocess.PIPE,

--- a/mopidy/listener.py
+++ b/mopidy/listener.py
@@ -30,8 +30,7 @@ def send(cls, event, **kwargs):
 
 class Listener:
     def on_event(self, event, **kwargs):
-        """
-        Called on all events.
+        """Called on all events.
 
         *MAY* be implemented by actor. By default, this method forwards the
         event to the specific event methods.

--- a/mopidy/m3u/__init__.py
+++ b/mopidy/m3u/__init__.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 
 import mopidy
 from mopidy import config, ext
@@ -13,8 +13,7 @@ class Extension(ext.Extension):
     version = mopidy.__version__
 
     def get_default_config(self):
-        conf_file = os.path.join(os.path.dirname(__file__), "ext.conf")
-        return config.read(conf_file)
+        return config.read(Path(__file__).parent / "ext.conf")
 
     def get_config_schema(self):
         schema = super().get_config_schema()

--- a/mopidy/m3u/backend.py
+++ b/mopidy/m3u/backend.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ARG002
+
 import pykka
 
 from mopidy import backend

--- a/mopidy/m3u/backend.py
+++ b/mopidy/m3u/backend.py
@@ -1,5 +1,7 @@
 # ruff: noqa: ARG002
 
+from typing import ClassVar
+
 import pykka
 
 from mopidy import backend
@@ -8,7 +10,7 @@ from . import playlists
 
 
 class M3UBackend(pykka.ThreadingActor, backend.Backend):
-    uri_schemes = ["m3u"]
+    uri_schemes: ClassVar[list[str]] = ["m3u"]
 
     def __init__(self, config, audio):
         super().__init__()

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -162,10 +162,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         return path.is_path_inside_base_dir(local_path, self._playlists_dir)
 
     def _open(self, path, mode="r"):
-        if path.suffix == ".m3u8":
-            encoding = "utf-8"
-        else:
-            encoding = self._default_encoding
+        encoding = "utf-8" if path.suffix == ".m3u8" else self._default_encoding
         if not path.is_absolute():
             path = self._abspath(path)
         if not self._is_in_basedir(path):

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -71,11 +71,10 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         for entry in self._playlists_dir.iterdir():
             if entry.suffix not in [".m3u", ".m3u8"]:
                 continue
-            elif not entry.is_file():
+            if not entry.is_file():
                 continue
-            else:
-                playlist_path = entry.relative_to(self._playlists_dir)
-                result.append(translator.path_to_ref(playlist_path))
+            playlist_path = entry.relative_to(self._playlists_dir)
+            result.append(translator.path_to_ref(playlist_path))
         result.sort(key=operator.attrgetter("name"))
         return result
 
@@ -154,10 +153,9 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             return translator.playlist(path, playlist.tracks, mtime)
 
     def _abspath(self, path):
-        if not path.is_absolute():
-            return self._playlists_dir / path
-        else:
+        if path.is_absolute():
             return path
+        return self._playlists_dir / path
 
     def _is_in_basedir(self, local_path):
         local_path = self._abspath(local_path)
@@ -176,5 +174,4 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
             )
         if "w" in mode:
             return replace(path, mode, encoding=encoding, errors="replace")
-        else:
-            return path.open(mode, encoding=encoding, errors="replace")
+        return path.open(mode, encoding=encoding, errors="replace")

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -10,6 +10,7 @@ import tempfile
 from typing import TYPE_CHECKING
 
 from mopidy import backend
+from mopidy.exceptions import BackendError
 from mopidy.internal import path
 
 from . import Extension, translator
@@ -166,7 +167,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         if not path.is_absolute():
             path = self._abspath(path)
         if not self._is_in_basedir(path):
-            raise Exception(
+            raise BackendError(
                 f"Path {path!r} is not inside playlist dir {self._playlists_dir!r}"
             )
         if "w" in mode:

--- a/mopidy/m3u/playlists.py
+++ b/mopidy/m3u/playlists.py
@@ -33,7 +33,7 @@ def replace(path, mode="w+b", encoding=None, errors=None):
     (fd, tempname) = tempfile.mkstemp(dir=str(path.parent))
     tempname = pathlib.Path(tempname)
     try:
-        fp = open(fd, mode, encoding=encoding, errors=errors)
+        fp = open(fd, mode, encoding=encoding, errors=errors)  # noqa: PTH123, SIM115
     except Exception:
         tempname.unlink()
         os.close(fd)

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -50,7 +50,7 @@ def load_items(fp, basedir):
             if line.startswith("#EXTINF:"):
                 name = line.partition(",")[2]
             continue
-        elif not urllib.parse.urlsplit(line).scheme:
+        if not urllib.parse.urlsplit(line).scheme:
             path = basedir / line
             if not name:
                 name = name_from_path(path)

--- a/mopidy/m3u/translator.py
+++ b/mopidy/m3u/translator.py
@@ -31,10 +31,7 @@ def name_from_path(path):
 
 def path_from_name(name, ext=None, sep="|"):
     """Convert name with optional extension to file path."""
-    if ext:
-        name = name.replace(os.sep, sep) + ext
-    else:
-        name = name.replace(os.sep, sep)
+    name = name.replace(os.sep, sep) + ext if ext else name.replace(os.sep, sep)
     return pathlib.Path(name)
 
 

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -1,3 +1,5 @@
+# ruff: noqa: ARG002
+
 from __future__ import annotations
 
 import logging

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -138,7 +138,6 @@ class MixerListener(listener.Listener):
         :param volume: the new volume
         :type volume: int in range [0..100]
         """
-        pass
 
     def mute_changed(self, mute: bool) -> None:
         """Called after the mute state has changed.
@@ -148,7 +147,6 @@ class MixerListener(listener.Listener):
         :param mute: :class:`True` if muted, :class:`False` if not muted
         :type mute: bool
         """
-        pass
 
 
 if TYPE_CHECKING:

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -4,6 +4,7 @@ import logging
 from typing import TYPE_CHECKING
 
 import pykka
+from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
 
 from mopidy import listener
 
@@ -149,20 +150,18 @@ class MixerListener(listener.Listener):
         """
 
 
-if TYPE_CHECKING:
-    from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
+class MixerActor(pykka.ThreadingActor, Mixer):
+    pass
 
-    class MixerActor(pykka.ThreadingActor, Mixer):
-        pass
 
-    class MixerProxy(ActorMemberMixin, pykka.ActorProxy[MixerActor]):
-        """Mixer wrapped in a Pykka actor proxy."""
+class MixerProxy(ActorMemberMixin, pykka.ActorProxy[MixerActor]):
+    """Mixer wrapped in a Pykka actor proxy."""
 
-        name = proxy_field(MixerActor.name)
-        get_volume = proxy_method(MixerActor.get_volume)
-        set_volume = proxy_method(MixerActor.set_volume)
-        trigger_volume_changed = proxy_method(MixerActor.trigger_volume_changed)
-        get_mute = proxy_method(MixerActor.get_mute)
-        set_mute = proxy_method(MixerActor.set_mute)
-        trigger_mute_changed = proxy_method(MixerActor.trigger_mute_changed)
-        ping = proxy_method(MixerActor.ping)
+    name = proxy_field(MixerActor.name)
+    get_volume = proxy_method(MixerActor.get_volume)
+    set_volume = proxy_method(MixerActor.set_volume)
+    trigger_volume_changed = proxy_method(MixerActor.trigger_volume_changed)
+    get_mute = proxy_method(MixerActor.get_mute)
+    set_mute = proxy_method(MixerActor.set_mute)
+    trigger_mute_changed = proxy_method(MixerActor.trigger_mute_changed)
+    ping = proxy_method(MixerActor.ping)

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, ClassVar
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
@@ -31,7 +31,7 @@ class Mixer:
     :type config: dict
     """
 
-    name: str
+    name: ClassVar[str] = ""
     """
     Name of the mixer.
 

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -17,9 +17,7 @@ logger = logging.getLogger(__name__)
 
 
 class Mixer:
-
-    """
-    Audio mixer API
+    """Audio mixer API.
 
     If the mixer has problems during initialization it should raise
     :exc:`mopidy.exceptions.MixerError` with a descriptive error message. This
@@ -43,8 +41,7 @@ class Mixer:
         pass
 
     def get_volume(self) -> Optional[int]:
-        """
-        Get volume level of the mixer on a linear scale from 0 to 100.
+        """Get volume level of the mixer on a linear scale from 0 to 100.
 
         Example values:
 
@@ -62,8 +59,7 @@ class Mixer:
         return None
 
     def set_volume(self, volume: int) -> bool:
-        """
-        Set volume level of the mixer.
+        """Set volume level of the mixer.
 
         *MAY be implemented by subclass.*
 
@@ -74,8 +70,7 @@ class Mixer:
         return False
 
     def trigger_volume_changed(self, volume: int) -> None:
-        """
-        Send ``volume_changed`` event to all mixer listeners.
+        """Send ``volume_changed`` event to all mixer listeners.
 
         This method should be called by subclasses when the volume is changed,
         either because of a call to :meth:`set_volume` or because of any
@@ -85,8 +80,7 @@ class Mixer:
         MixerListener.send("volume_changed", volume=volume)
 
     def get_mute(self) -> Optional[bool]:
-        """
-        Get mute state of the mixer.
+        """Get mute state of the mixer.
 
         *MAY be implemented by subclass.*
 
@@ -96,8 +90,7 @@ class Mixer:
         return None
 
     def set_mute(self, mute: bool) -> bool:
-        """
-        Mute or unmute the mixer.
+        """Mute or unmute the mixer.
 
         *MAY be implemented by subclass.*
 
@@ -108,8 +101,7 @@ class Mixer:
         return False
 
     def trigger_mute_changed(self, mute: bool) -> None:
-        """
-        Send ``mute_changed`` event to all mixer listeners.
+        """Send ``mute_changed`` event to all mixer listeners.
 
         This method should be called by subclasses when the mute state is
         changed, either because of a call to :meth:`set_mute` or because of
@@ -124,9 +116,7 @@ class Mixer:
 
 
 class MixerListener(listener.Listener):
-
-    """
-    Marker interface for recipients of events sent by the mixer actor.
+    """Marker interface for recipients of events sent by the mixer actor.
 
     Any Pykka actor that mixes in this class will receive calls to the methods
     defined here when the corresponding events happen in the mixer actor. This
@@ -137,12 +127,11 @@ class MixerListener(listener.Listener):
 
     @staticmethod
     def send(event: MixerEvent, **kwargs: Any) -> None:
-        """Helper to allow calling of mixer listener events"""
+        """Helper to allow calling of mixer listener events."""
         listener.send(MixerListener, event, **kwargs)
 
     def volume_changed(self, volume: int) -> None:
-        """
-        Called after the volume has changed.
+        """Called after the volume has changed.
 
         *MAY* be implemented by actor.
 
@@ -152,8 +141,7 @@ class MixerListener(listener.Listener):
         pass
 
     def mute_changed(self, mute: bool) -> None:
-        """
-        Called after the mute state has changed.
+        """Called after the mute state has changed.
 
         *MAY* be implemented by actor.
 

--- a/mopidy/models/__init__.py
+++ b/mopidy/models/__init__.py
@@ -40,7 +40,6 @@ class Ref(ValidatedImmutableObject):
     #: The object type, e.g. "artist", "album", "track", "playlist",
     #: "directory". Read-only.
     type = fields.Identifier()  # TODO: consider locking this down.
-    # type = fields.Field(choices=(ALBUM, ARTIST, DIRECTORY, PLAYLIST, TRACK))
 
     #: Constant used for comparison with the :attr:`type` field.
     ALBUM = "album"

--- a/mopidy/models/__init__.py
+++ b/mopidy/models/__init__.py
@@ -19,9 +19,7 @@ __all__ = [
 
 
 class Ref(ValidatedImmutableObject):
-
-    """
-    Model to represent URI references with a human friendly name and type
+    """Model to represent URI references with a human friendly name and type
     attached. This is intended for use a lightweight object "free" of metadata
     that can be passed around instead of using full blown models.
 
@@ -91,9 +89,7 @@ class Ref(ValidatedImmutableObject):
 
 
 class Image(ValidatedImmutableObject):
-
-    """
-    :param string uri: URI of the image
+    """:param string uri: URI of the image
     :param int width: Optional width of image or :class:`None`
     :param int height: Optional height of image or :class:`None`
     """
@@ -109,9 +105,7 @@ class Image(ValidatedImmutableObject):
 
 
 class Artist(ValidatedImmutableObject):
-
-    """
-    :param uri: artist URI
+    """:param uri: artist URI
     :type uri: string
     :param name: artist name
     :type name: string
@@ -135,9 +129,7 @@ class Artist(ValidatedImmutableObject):
 
 
 class Album(ValidatedImmutableObject):
-
-    """
-    :param uri: album URI
+    """:param uri: album URI
     :type uri: string
     :param name: album name
     :type name: string
@@ -176,9 +168,7 @@ class Album(ValidatedImmutableObject):
 
 
 class Track(ValidatedImmutableObject):
-
-    """
-    :param uri: track URI
+    """:param uri: track URI
     :type uri: string
     :param name: track name
     :type name: string
@@ -260,9 +250,7 @@ class Track(ValidatedImmutableObject):
 
 
 class TlTrack(ValidatedImmutableObject):
-
-    """
-    A tracklist track. Wraps a regular track and it's tracklist ID.
+    """A tracklist track. Wraps a regular track and it's tracklist ID.
 
     The use of :class:`TlTrack` allows the same track to appear multiple times
     in the tracklist.
@@ -299,9 +287,7 @@ class TlTrack(ValidatedImmutableObject):
 
 
 class Playlist(ValidatedImmutableObject):
-
-    """
-    :param uri: playlist URI
+    """:param uri: playlist URI
     :type uri: string
     :param name: playlist name
     :type name: string
@@ -336,9 +322,7 @@ class Playlist(ValidatedImmutableObject):
 
 
 class SearchResult(ValidatedImmutableObject):
-
-    """
-    :param uri: search result URI
+    """:param uri: search result URI
     :type uri: string
     :param tracks: matching tracks
     :type tracks: list of :class:`Track` elements

--- a/mopidy/models/fields.py
+++ b/mopidy/models/fields.py
@@ -112,7 +112,7 @@ class Date(String):
     :param default: default value for field
     """
 
-    pass  # TODO: make this check for YYYY-MM-DD, YYYY-MM, YYYY using strptime.
+    # TODO: make this check for YYYY-MM-DD, YYYY-MM, YYYY using strptime.
 
 
 class Identifier(String):
@@ -138,7 +138,7 @@ class URI(Identifier):
     :param default: default value for field
     """
 
-    pass  # TODO: validate URIs?
+    # TODO: validate URIs?
 
 
 class Integer(Field[int]):

--- a/mopidy/models/fields.py
+++ b/mopidy/models/fields.py
@@ -2,16 +2,19 @@ from __future__ import annotations
 
 import sys
 from typing import (
+    TYPE_CHECKING,
     Any,
     Callable,
     Generic,
-    Iterable,
     Optional,
     TypeVar,
     Union,
     cast,
     overload,
 )
+
+if TYPE_CHECKING:
+    from collections.abc import Iterable
 
 T = TypeVar("T")
 TField = TypeVar("TField", bound="Field")

--- a/mopidy/models/fields.py
+++ b/mopidy/models/fields.py
@@ -18,9 +18,7 @@ TField = TypeVar("TField", bound="Field")
 
 
 class Field(Generic[T]):
-
-    """
-    Base field for use in
+    """Base field for use in
     :class:`~mopidy.models.immutable.ValidatedImmutableObject`. These fields
     are responsible for type checking and other data sanitation in our models.
 
@@ -50,7 +48,7 @@ class Field(Generic[T]):
             self.validate(self._default)
 
     def validate(self, value: T) -> T:
-        """Validate and possibly modify the field value before assignment"""
+        """Validate and possibly modify the field value before assignment."""
         if self._type and not isinstance(value, self._type):
             raise TypeError(
                 f"Expected {self._name} to be a {self._type}, not {value!r}"
@@ -93,9 +91,7 @@ class Field(Generic[T]):
 
 
 class String(Field[str]):
-
-    """
-    Specialized :class:`Field` which is wired up for bytes and unicode.
+    """Specialized :class:`Field` which is wired up for bytes and unicode.
 
     :param default: default value for field
     """
@@ -108,8 +104,7 @@ class String(Field[str]):
 
 
 class Date(String):
-    """
-    :class:`Field` for storing ISO 8601 dates as a string.
+    """:class:`Field` for storing ISO 8601 dates as a string.
 
     Supported formats are ``YYYY-MM-DD``, ``YYYY-MM`` and ``YYYY``, currently
     not validated.
@@ -121,8 +116,7 @@ class Date(String):
 
 
 class Identifier(String):
-    """
-    :class:`Field` for storing values such as GUIDs or other identifiers.
+    """:class:`Field` for storing values such as GUIDs or other identifiers.
 
     Values will be interned.
 
@@ -137,8 +131,7 @@ class Identifier(String):
 
 
 class URI(Identifier):
-    """
-    :class:`Field` for storing URIs
+    """:class:`Field` for storing URIs.
 
     Values will be interned, currently not validated.
 
@@ -149,8 +142,7 @@ class URI(Identifier):
 
 
 class Integer(Field[int]):
-    """
-    :class:`Field` for storing integer numbers.
+    """:class:`Field` for storing integer numbers.
 
     :param default: default value for field
     :param min: field value must be larger or equal to this value when set
@@ -176,8 +168,7 @@ class Integer(Field[int]):
 
 
 class Boolean(Field[bool]):
-    """
-    :class:`Field` for storing boolean values
+    """:class:`Field` for storing boolean values.
 
     :param default: default value for field
     """
@@ -187,8 +178,7 @@ class Boolean(Field[bool]):
 
 
 class Collection(Field[Union[tuple, frozenset]]):
-    """
-    :class:`Field` for storing collections of a given type.
+    """:class:`Field` for storing collections of a given type.
 
     :param type: all items stored in the collection must be of this type
     :param container: the type to store the items in

--- a/mopidy/models/immutable.py
+++ b/mopidy/models/immutable.py
@@ -164,7 +164,7 @@ class _ValidatedImmutableObjectMeta(type, Generic[T]):
         cls,
         *args: Any,
         **kwargs: Any,
-    ) -> T:  # noqa: N805
+    ) -> T:
         instance = super().__call__(*args, **kwargs)
         return cls._instances.setdefault(weakref.ref(instance), instance)
 

--- a/mopidy/models/immutable.py
+++ b/mopidy/models/immutable.py
@@ -30,7 +30,7 @@ class ImmutableObject:
     # slots as they will still get an instance dict.
     __slots__ = ["__weakref__"]
 
-    def __init__(self, *args, **kwargs):
+    def __init__(self, *_args, **kwargs):
         for key, value in kwargs.items():
             if not self._is_valid_field(key):
                 raise TypeError(

--- a/mopidy/models/immutable.py
+++ b/mopidy/models/immutable.py
@@ -131,7 +131,9 @@ class ImmutableObject:
 class _ValidatedImmutableObjectMeta(type, Generic[T]):
     """Helper that initializes fields, slots and memoizes instance creation."""
 
-    _instances: dict[weakref.ReferenceType[_ValidatedImmutableObjectMeta[T]], T] = {}
+    _instances: dict[
+        weakref.ReferenceType[_ValidatedImmutableObjectMeta[T]], T
+    ] = {}  # noqa: RUF012
 
     def __new__(
         cls: type[_ValidatedImmutableObjectMeta],

--- a/mopidy/models/immutable.py
+++ b/mopidy/models/immutable.py
@@ -14,8 +14,7 @@ _models = {}
 
 
 class ImmutableObject:
-    """
-    Superclass for immutable objects whose fields can only be modified via the
+    """Superclass for immutable objects whose fields can only be modified via the
     constructor.
 
     This version of this class has been retained to avoid breaking any clients
@@ -93,8 +92,7 @@ class ImmutableObject:
         return not self.__eq__(other)
 
     def replace(self, **kwargs):
-        """
-        Replace the fields in the model and return a new instance
+        """Replace the fields in the model and return a new instance.
 
         Examples::
 
@@ -131,7 +129,6 @@ class ImmutableObject:
 
 
 class _ValidatedImmutableObjectMeta(type, Generic[T]):
-
     """Helper that initializes fields, slots and memoizes instance creation."""
 
     _instances: dict[weakref.ReferenceType[_ValidatedImmutableObjectMeta[T]], T] = {}
@@ -175,8 +172,7 @@ class _ValidatedImmutableObjectMeta(type, Generic[T]):
 class ValidatedImmutableObject(
     ImmutableObject, metaclass=_ValidatedImmutableObjectMeta
 ):
-    """
-    Superclass for immutable objects whose fields can only be modified via the
+    """Superclass for immutable objects whose fields can only be modified via the
     constructor. Fields should be :class:`Field` instances to ensure type
     safety in our models.
 
@@ -207,8 +203,7 @@ class ValidatedImmutableObject(
                 yield field, getattr(self, key)
 
     def replace(self, **kwargs):
-        """
-        Replace the fields in the model and return a new instance
+        """Replace the fields in the model and return a new instance.
 
         Examples::
 

--- a/mopidy/models/serialize.py
+++ b/mopidy/models/serialize.py
@@ -4,9 +4,7 @@ from mopidy.models import immutable
 
 
 class ModelJSONEncoder(json.JSONEncoder):
-
-    """
-    Automatically serialize Mopidy models to JSON.
+    """Automatically serialize Mopidy models to JSON.
 
     Usage::
 
@@ -23,8 +21,7 @@ class ModelJSONEncoder(json.JSONEncoder):
 
 
 def model_json_decoder(dct):
-    """
-    Automatically deserialize Mopidy models from JSON.
+    """Automatically deserialize Mopidy models from JSON.
 
     Usage::
 

--- a/mopidy/softwaremixer/__init__.py
+++ b/mopidy/softwaremixer/__init__.py
@@ -14,8 +14,7 @@ class Extension(ext.Extension):
         return config.read(conf_file)
 
     def get_config_schema(self):
-        schema = super().get_config_schema()
-        return schema
+        return super().get_config_schema()
 
     def setup(self, registry):
         from .mixer import SoftwareMixer

--- a/mopidy/softwaremixer/__init__.py
+++ b/mopidy/softwaremixer/__init__.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import mopidy
 from mopidy import config, ext
@@ -10,8 +10,7 @@ class Extension(ext.Extension):
     version = mopidy.__version__
 
     def get_default_config(self):
-        conf_file = os.path.join(os.path.dirname(__file__), "ext.conf")
-        return config.read(conf_file)
+        return config.read(Path(__file__).parent / "ext.conf")
 
     def get_config_schema(self):
         return super().get_config_schema()

--- a/mopidy/softwaremixer/mixer.py
+++ b/mopidy/softwaremixer/mixer.py
@@ -1,7 +1,7 @@
 import logging
-from typing import TYPE_CHECKING
 
 import pykka
+from pykka.typing import proxy_method
 
 from mopidy import mixer
 
@@ -58,9 +58,6 @@ class SoftwareMixer(pykka.ThreadingActor, mixer.Mixer):
         return True
 
 
-if TYPE_CHECKING:
-    from pykka.typing import proxy_method
-
-    class SoftwareMixerProxy(mixer.MixerProxy):
-        setup = proxy_method(SoftwareMixer.setup)
-        teardown = proxy_method(SoftwareMixer.teardown)
+class SoftwareMixerProxy(mixer.MixerProxy):
+    setup = proxy_method(SoftwareMixer.setup)
+    teardown = proxy_method(SoftwareMixer.teardown)

--- a/mopidy/stream/__init__.py
+++ b/mopidy/stream/__init__.py
@@ -1,4 +1,4 @@
-import os
+from pathlib import Path
 
 import mopidy
 from mopidy import config, ext
@@ -10,8 +10,7 @@ class Extension(ext.Extension):
     version = mopidy.__version__
 
     def get_default_config(self):
-        conf_file = os.path.join(os.path.dirname(__file__), "ext.conf")
-        return config.read(conf_file)
+        return config.read(Path(__file__).parent / "ext.conf")
 
     def get_config_schema(self):
         schema = super().get_config_schema()

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -100,8 +100,7 @@ class StreamPlaybackProvider(backend.PlaybackProvider):
         return unwrapped_uri
 
 
-# TODO: cleanup the return value of this.
-def _unwrap_stream(
+def _unwrap_stream(  # noqa: PLR0911  # TODO: cleanup the return value of this.
     uri: str,
     timeout: float,
     scanner: scan.Scanner,

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -119,7 +119,7 @@ def _unwrap_stream(
     while time.time() < deadline:
         if uri in seen_uris:
             logger.info(
-                "Unwrapping stream from URI (%s) failed: " "playlist referenced itself",
+                "Unwrapping stream from URI (%s) failed: playlist referenced itself",
                 uri,
             )
             return None, None
@@ -132,7 +132,7 @@ def _unwrap_stream(
             scan_timeout = deadline - time.time()
             if scan_timeout < 0:
                 logger.info(
-                    "Unwrapping stream from URI (%s) failed: " "timed out in %sms",
+                    "Unwrapping stream from URI (%s) failed: timed out in %sms",
                     uri,
                     timeout,
                 )
@@ -164,7 +164,7 @@ def _unwrap_stream(
 
         if content is None:
             logger.info(
-                "Unwrapping stream from URI (%s) failed: " "error downloading URI %s",
+                "Unwrapping stream from URI (%s) failed: error downloading URI %s",
                 original_uri,
                 uri,
             )

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -48,7 +48,7 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
                 "Please remove it from the stream/protocols config."
             )
             uri_schemes -= {"file"}
-        self.uri_schemes = sorted(list(uri_schemes))
+        self.uri_schemes = sorted(uri_schemes)
 
 
 class StreamLibraryProvider(backend.LibraryProvider):

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -107,13 +107,11 @@ def _unwrap_stream(
     scanner: scan.Scanner,
     requests_session,
 ) -> tuple[Optional[str], Optional[scan._Result]]:
-    """
-    Get a stream URI from a playlist URI, ``uri``.
+    """Get a stream URI from a playlist URI, ``uri``.
 
     Unwraps nested playlists until something that's not a playlist is found or
     the ``timeout`` is reached.
     """
-
     original_uri = uri
     seen_uris = set()
     deadline = time.time() + timeout

--- a/mopidy/stream/actor.py
+++ b/mopidy/stream/actor.py
@@ -123,8 +123,8 @@ def _unwrap_stream(
                 uri,
             )
             return None, None
-        else:
-            seen_uris.add(uri)
+
+        seen_uris.add(uri)
 
         logger.debug("Unwrapping stream from URI: %s", uri)
 

--- a/mopidy/zeroconf.py
+++ b/mopidy/zeroconf.py
@@ -14,7 +14,7 @@ _AVAHI_PUBLISHFLAGS_NONE = 0
 
 
 def _is_loopback_address(host):
-    return host.startswith("127.") or host.startswith("::ffff:127.") or host == "::1"
+    return host.startswith(("127.", "::ffff:127.")) or host == "::1"
 
 
 def _convert_text_list_to_dbus_format(text_list):

--- a/mopidy/zeroconf.py
+++ b/mopidy/zeroconf.py
@@ -26,7 +26,6 @@ def _convert_text_list_to_dbus_format(text_list):
 
 
 class Zeroconf:
-
     """Publish a network service with Zeroconf.
 
     Currently, this only works on Linux using Avahi via D-Bus.
@@ -79,7 +78,6 @@ class Zeroconf:
 
         Call when your service starts.
         """
-
         if _is_loopback_address(self.host):
             logger.debug("%s: Publish on loopback interface is not supported.", self)
             return False

--- a/mopidy/zeroconf.py
+++ b/mopidy/zeroconf.py
@@ -1,5 +1,6 @@
 import logging
 import string
+from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -13,11 +14,11 @@ _AVAHI_PROTO_UNSPEC = -1
 _AVAHI_PUBLISHFLAGS_NONE = 0
 
 
-def _is_loopback_address(host):
+def _is_loopback_address(host: str) -> bool:
     return host.startswith(("127.", "::ffff:127.")) or host == "::1"
 
 
-def _convert_text_list_to_dbus_format(text_list):
+def _convert_text_list_to_dbus_format(text_list: list[str]):
     assert dbus
     array = dbus.Array(signature="ay")
     for text in text_list:
@@ -40,7 +41,15 @@ class Zeroconf:
     :type text: list of str
     """
 
-    def __init__(self, name, stype, port, domain="", host="", text=None):
+    def __init__(  # noqa: PLR0913
+        self,
+        name: str,
+        stype: str,
+        port: int,
+        domain: str = "",
+        host: str = "",
+        text: Optional[list[str]] = None,
+    ) -> None:
         self.stype = stype
         self.port = port
         self.domain = domain
@@ -67,13 +76,13 @@ class Zeroconf:
             except dbus.exceptions.DBusException as e:
                 logger.debug("%s: Server failed: %s", self, e)
 
-    def __str__(self):
+    def __str__(self) -> str:
         return (
             f"Zeroconf service {self.name!r} "
             f"({self.stype} at [{self.host}]:{self.port:d})"
         )
 
-    def publish(self):
+    def publish(self) -> bool:  # noqa: PLR0911
         """Publish the service.
 
         Call when your service starts.
@@ -126,7 +135,7 @@ class Zeroconf:
         else:
             return True
 
-    def unpublish(self):
+    def unpublish(self) -> None:
         """Unpublish the service.
 
         Call when your service shuts down.

--- a/mopidy/zeroconf.py
+++ b/mopidy/zeroconf.py
@@ -120,10 +120,11 @@ class Zeroconf:
 
             self.group.Commit()
             logger.debug("%s: Published", self)
-            return True
         except dbus.exceptions.DBusException as e:
             logger.debug("%s: Publish failed: %s", self, e)
             return False
+        else:
+            return True
 
     def unpublish(self):
         """Unpublish the service.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,10 +6,6 @@ requires = ["setuptools >= 30.3.0", "wheel"]
 target-version = ["py39", "py310", "py311"]
 
 
-[tool.isort]
-profile = "black"
-
-
 [tool.pyright]
 pythonVersion = "3.9"
 # Use venv from parent directory, to share it with any extensions:
@@ -20,3 +16,99 @@ typeCheckingMode = "basic"
 reportMissingTypeStubs = false
 # Already covered by flake8-self:
 reportPrivateImportUsage = false
+
+
+[tool.ruff]
+select = [
+    "A", # flake8-builtins
+    # "ANN", # flake8-annotations  # TODO: Enable when we are fully type hinted
+    "ARG", # flake8-unused-arguments
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "C90", # mccabe
+    "D",   # pydocstyle
+    "DTZ", # flake8-datetimez
+    "E",   # pycodestyle
+    "ERA", # eradicate
+    "F",   # pyflakes
+    "FBT", # flake8-boolean-trap
+    "I",   # isort
+    "INP", # flake8-no-pep420
+    "ISC", # flake8-implicit-str-concat
+    "N",   # pep8-naming
+    "PGH", # pygrep-hooks
+    "PIE", # flake8-pie
+    "PLC", # pylint convention
+    "PLE", # pylint error
+    "PLR", # pylint refactor
+    "PLW", # pylint warning
+    "PT",  # flake8-pytest-style
+    "PTH", # flake8-use-pathlib
+    "Q",   # flake8-quotes
+    "RET", # flake8-return
+    "RSE", # flake8-raise
+    "RUF", # ruff
+    "SIM", # flake8-simplify
+    "SLF", # flake8-self
+    "T20", # flake8-print
+    "TCH", # flake8-type-checking
+    "TID", # flake8-tidy-imports
+    "TRY", # tryceratops
+    "UP",  # pyupgrade
+    "W",   # pycodestyle
+]
+ignore = [
+    "A002",    # builtin-argument-shadowing  # TODO
+    "A003",    # builtin-attribute-shadowing
+    "ANN101",  # missing-type-self
+    "ANN102",  # missing-type-cls
+    "D100",    # undocumented-public-module  # TODO
+    "D101",    # undocumented-public-class  # TODO
+    "D102",    # undocumented-public-method  # TODO
+    "D103",    # undocumented-public-function  # TODO
+    "D104",    # undocumented-public-package  # TODO
+    "D105",    # undocumented-magic-method
+    "D107",    # undocumented-public-init  # TODO
+    "D203",    # one-blank-line-before-class
+    "D205",    # blank-line-after-summary  # TODO
+    "D213",    # multi-line-summary-second-line
+    "D401",    # non-imperative-mood  # TODO
+    "FBT001",  # boolean-positional-arg-in-function-definition  # TODO
+    "FBT002",  # boolean-default-value-in-function-definition  # TODO
+    "FBT003",  # boolean-positional-value-in-function-call  # TODO
+    "PLR2004", # magic-value-comparison
+    "PLW2901", # redefined-loop-name
+    "RET504",  # unnecessary-assign
+    "SLF001",  # private-member-access  # TODO
+    "TCH003",  # typing-only-standard-library-import
+    "TRY003",  # raise-vanilla-args
+    #
+    # Equivalent to `pyupgrade --keep-runtime-typing`:
+    "UP006", # deprecated-collection-type
+    "UP007", # typing-union
+]
+target-version = "py39"
+
+[tool.ruff.per-file-ignores]
+"docs/*" = [
+    "D",      # pydocstyle
+    "INP001", # flake8-no-pep420
+]
+"mopidy/internal/*" = [
+    "D", # pydocstyle
+]
+"tests/*" = [
+    "ANN",     # flake8-annotations
+    "ARG",     # flake8-unused-arguments
+    "D",       # pydocstyle
+    "FBT",     # flake8-boolean-trap
+    "PLR0913", # too-many-arguments
+    "PT007",   # pytest-parametrize-values-wrong-type  # TODO
+    "PT009",   # pytest-unittest-assertion  # TODO
+    "PT011",   # pytest-raises-too-broad  # TODO
+    "SLF001",  # private-member-access
+    "TRY002",  # raise-vanilla-class
+]
+
+[tool.ruff.isort]
+known-first-party = ["mopidy"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,7 @@ ignore = [
     "SLF001",  # private-member-access  # TODO
     "TCH003",  # typing-only-standard-library-import
     "TRY003",  # raise-vanilla-args
+    "TRY400",  # error-instead-of-exception
     #
     # Equivalent to `pyupgrade --keep-runtime-typing`:
     "UP006", # deprecated-collection-type

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,11 +49,7 @@ docs =
 lint =
     black
     check-manifest
-    flake8
-    flake8-black
-    flake8-bugbear
-    isort
-    pep8-naming
+    ruff
 test =
     pytest
     pytest-cov
@@ -93,27 +89,3 @@ filterwarnings =
     error::DeprecationWarning:mopidy[.*]
     ignore::PendingDeprecationWarning:mopidy[.*]
     ignore::DeprecationWarning:mopidy[.*]
-
-
-[flake8]
-application-import-names = mopidy, tests
-max-line-length = 88
-exclude = .git, .tox, build
-select =
-    # Regular flake8 rules
-    C, E, F, W
-    # flake8-bugbear rules
-    B
-    # B950: line too long (soft speed limit)
-    B950
-    # pep8-naming rules
-    N
-ignore =
-    # E203: whitespace before ':' (not PEP8 compliant)
-    E203
-    # E501: line too long (replaced by B950)
-    E501
-    # W503: line break before binary operator (not PEP8 compliant)
-    W503
-    # B305: .next() is not a thing on Python 3 (used by playback controller)
-    B305

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,7 @@ class IsA:
         try:
             return isinstance(rhs, self.klass)
         except TypeError:
-            return type(rhs) == type(self.klass)
+            return type(rhs) == type(self.klass)  # noqa: E721
 
     def __ne__(self, rhs):
         return not self.__eq__(rhs)

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -14,7 +14,7 @@ class IsA:
         try:
             return isinstance(rhs, self.klass)
         except TypeError:
-            return type(rhs) == type(self.klass)  # noqa
+            return type(rhs) == type(self.klass)
 
     def __ne__(self, rhs):
         return not self.__eq__(rhs)

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -1,5 +1,6 @@
 import threading
 import unittest
+from typing import ClassVar
 from unittest import mock
 
 import pykka
@@ -16,7 +17,7 @@ from tests import dummy_audio, path_to_data_dir
 
 
 class BaseTest(unittest.TestCase):
-    uris = [
+    uris: ClassVar[list[str]] = [
         path.path_to_uri(path_to_data_dir("song1.wav")),
         path.path_to_uri(path_to_data_dir("song2.wav")),
     ]
@@ -152,10 +153,10 @@ class AudioEventTest(BaseTest):
     def tearDown(self):
         super().tearDown()
 
-    def assertEvent(self, event, **kwargs):
+    def assert_event(self, event, **kwargs):
         assert (event, kwargs) in self.listener.get_events().get()
 
-    def assertNotEvent(self, event, **kwargs):
+    def assert_not_event(self, event, **kwargs):
         assert (event, kwargs) not in self.listener.get_events().get()
 
     # TODO: test without uri set, with bad uri and gapless...
@@ -169,7 +170,7 @@ class AudioEventTest(BaseTest):
         self.audio.start_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent(
+        self.assert_event(
             "state_changed",
             old_state=PlaybackState.STOPPED,
             new_state=PlaybackState.PLAYING,
@@ -182,7 +183,7 @@ class AudioEventTest(BaseTest):
         self.audio.pause_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent(
+        self.assert_event(
             "state_changed",
             old_state=PlaybackState.STOPPED,
             new_state=PlaybackState.PAUSED,
@@ -199,7 +200,7 @@ class AudioEventTest(BaseTest):
         self.audio.start_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent(
+        self.assert_event(
             "state_changed",
             old_state=PlaybackState.PAUSED,
             new_state=PlaybackState.PLAYING,
@@ -216,7 +217,7 @@ class AudioEventTest(BaseTest):
         self.audio.stop_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent(
+        self.assert_event(
             "state_changed",
             old_state=PlaybackState.PAUSED,
             new_state=PlaybackState.STOPPED,
@@ -233,7 +234,7 @@ class AudioEventTest(BaseTest):
         self.audio.pause_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent(
+        self.assert_event(
             "state_changed",
             old_state=PlaybackState.PLAYING,
             new_state=PlaybackState.PAUSED,
@@ -250,7 +251,7 @@ class AudioEventTest(BaseTest):
         self.audio.stop_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent(
+        self.assert_event(
             "state_changed",
             old_state=PlaybackState.PLAYING,
             new_state=PlaybackState.STOPPED,
@@ -266,7 +267,7 @@ class AudioEventTest(BaseTest):
         # Since we are going from stopped to playing, the state change is
         # enough to ensure the stream changed.
         self.audio.wait_for_state_change().get()
-        self.assertEvent("stream_changed", uri=self.uris[0])
+        self.assert_event("stream_changed", uri=self.uris[0])
 
     def test_stream_changed_event_on_multiple_changes(self):
         self.audio.prepare_change()
@@ -275,14 +276,14 @@ class AudioEventTest(BaseTest):
         self.audio.start_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("stream_changed", uri=self.uris[0])
+        self.assert_event("stream_changed", uri=self.uris[0])
 
         self.audio.prepare_change()
         self.audio.set_uri(self.uris[1])
         self.audio.pause_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("stream_changed", uri=self.uris[1])
+        self.assert_event("stream_changed", uri=self.uris[1])
 
     def test_stream_changed_event_on_playing_to_paused(self):
         self.audio.prepare_change()
@@ -291,13 +292,13 @@ class AudioEventTest(BaseTest):
         self.audio.start_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("stream_changed", uri=self.uris[0])
+        self.assert_event("stream_changed", uri=self.uris[0])
 
         self.listener.clear_events()
         self.audio.pause_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertNotEvent("stream_changed", uri=self.uris[0])
+        self.assert_not_event("stream_changed", uri=self.uris[0])
 
     def test_stream_changed_event_on_paused_to_stopped(self):
         self.audio.prepare_change()
@@ -309,7 +310,7 @@ class AudioEventTest(BaseTest):
         self.audio.stop_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("stream_changed", uri=None)
+        self.assert_event("stream_changed", uri=None)
 
     def test_position_changed_on_pause(self):
         self.audio.prepare_change()
@@ -318,7 +319,7 @@ class AudioEventTest(BaseTest):
         self.audio.wait_for_state_change()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("position_changed", position=0)
+        self.assert_event("position_changed", position=0)
 
     def test_stream_changed_event_on_paused_to_playing(self):
         self.audio.prepare_change()
@@ -327,13 +328,13 @@ class AudioEventTest(BaseTest):
         self.audio.pause_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("stream_changed", uri=self.uris[0])
+        self.assert_event("stream_changed", uri=self.uris[0])
 
         self.listener.clear_events()
         self.audio.start_playback()
 
         self.audio.wait_for_state_change().get()
-        self.assertNotEvent("stream_changed", uri=self.uris[0])
+        self.assert_not_event("stream_changed", uri=self.uris[0])
 
     def test_position_changed_on_play(self):
         self.audio.prepare_change()
@@ -342,7 +343,7 @@ class AudioEventTest(BaseTest):
         self.audio.wait_for_state_change()
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("position_changed", position=0)
+        self.assert_event("position_changed", position=0)
 
     def test_position_changed_on_seek_while_stopped(self):
         self.audio.prepare_change()
@@ -350,7 +351,7 @@ class AudioEventTest(BaseTest):
         self.audio.set_position(2000)
 
         self.audio.wait_for_state_change().get()
-        self.assertNotEvent("position_changed", position=0)
+        self.assert_not_event("position_changed", position=0)
 
     def test_position_changed_on_seek_after_play(self):
         self.audio.prepare_change()
@@ -362,7 +363,7 @@ class AudioEventTest(BaseTest):
         self.audio.set_position(2000)
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("position_changed", position=2000)
+        self.assert_event("position_changed", position=2000)
 
     def test_position_changed_on_seek_after_pause(self):
         self.audio.prepare_change()
@@ -374,7 +375,7 @@ class AudioEventTest(BaseTest):
         self.audio.set_position(2000)
 
         self.audio.wait_for_state_change().get()
-        self.assertEvent("position_changed", position=2000)
+        self.assert_event("position_changed", position=2000)
 
     def test_tags_changed_on_playback(self):
         self.audio.prepare_change()
@@ -382,7 +383,7 @@ class AudioEventTest(BaseTest):
         self.audio.start_playback()
         self.audio.wait_for_state_change().get()
 
-        self.assertEvent("tags_changed", tags=mock.ANY)
+        self.assert_event("tags_changed", tags=mock.ANY)
 
     # Unlike the other events, having the state changed done is not
     # enough to ensure our event is called. So we setup a threading
@@ -400,7 +401,7 @@ class AudioEventTest(BaseTest):
         if not event.wait(timeout=1.0):
             self.fail("Stream changed not reached within deadline")
 
-        self.assertEvent("stream_changed", uri=self.uris[0])
+        self.assert_event("stream_changed", uri=self.uris[0])
 
     def test_reached_end_of_stream_event(self):
         event = self.listener.wait("reached_end_of_stream").get()
@@ -439,8 +440,8 @@ class AudioEventTest(BaseTest):
             self.fail("EOS not received")
 
         # Check that both uris got played
-        self.assertEvent("stream_changed", uri=self.uris[0])
-        self.assertEvent("stream_changed", uri=self.uris[1])
+        self.assert_event("stream_changed", uri=self.uris[0])
+        self.assert_event("stream_changed", uri=self.uris[1])
 
         # Check that events counts check out.
         keys = [k for k, v in self.listener.get_events().get()]
@@ -691,7 +692,7 @@ class DownloadBufferingTest(unittest.TestCase):
 
         playbin.set_property.assert_has_calls([mock.call("flags", 0x02 | 0x80)])
 
-    def test_download_flag_is_not_passed_to_playbin_if_download_buffering_is_not_enabled(
+    def test_download_flag_is_not_passed_to_playbin_if_download_buffering_is_disabled(
         self,
     ):
         playbin = self.audio._playbin

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -23,7 +23,7 @@ class BaseTest(unittest.TestCase):
 
     audio_class = audio.Audio
 
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         config = {
             "audio": {
                 "buffer_time": None,
@@ -37,7 +37,7 @@ class BaseTest(unittest.TestCase):
         self.song_uri = path.path_to_uri(path_to_data_dir("song1.wav"))
         self.audio = self.audio_class.start(config=config, mixer=None).proxy()
 
-    def tearDown(self):  # noqa
+    def tearDown(self):
         pykka.ActorRegistry.stop_all()
 
     def possibly_trigger_fake_playback_error(self, uri):
@@ -144,18 +144,18 @@ class DummyAudioListener(pykka.ThreadingActor, audio.AudioListener):
 
 
 class AudioEventTest(BaseTest):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         super().setUp()
         self.audio.enable_sync_handler().get()
         self.listener = DummyAudioListener.start().proxy()
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         super().tearDown()
 
-    def assertEvent(self, event, **kwargs):  # noqa: N802
+    def assertEvent(self, event, **kwargs):
         assert (event, kwargs) in self.listener.get_events().get()
 
-    def assertNotEvent(self, event, **kwargs):  # noqa: N802
+    def assertNotEvent(self, event, **kwargs):
         assert (event, kwargs) not in self.listener.get_events().get()
 
     # TODO: test without uri set, with bad uri and gapless...
@@ -534,7 +534,7 @@ class MixerTest(BaseTest):
 
 
 class AudioStateTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.audio = audio.Audio(config=None, mixer=None)
 
     def test_state_starts_as_stopped(self):
@@ -586,7 +586,7 @@ class AudioStateTest(unittest.TestCase):
 
 
 class AudioBufferingTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.audio = audio.Audio(config=None, mixer=None)
         self.audio._playbin = mock.Mock(spec=["set_state"])
 
@@ -641,7 +641,7 @@ class AudioBufferingTest(unittest.TestCase):
 
 
 class AudioLiveTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         config = {"proxy": {}}
         self.audio = audio.Audio(config=config, mixer=None)
         self.audio._playbin = mock.Mock(spec=["set_property"])
@@ -678,7 +678,7 @@ class AudioLiveTest(unittest.TestCase):
 
 
 class DownloadBufferingTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.audio = audio.Audio(config=None, mixer=None)
         self.audio._playbin = mock.Mock(spec=["set_property"])
 
@@ -691,7 +691,7 @@ class DownloadBufferingTest(unittest.TestCase):
 
         playbin.set_property.assert_has_calls([mock.call("flags", 0x02 | 0x80)])
 
-    def test_download_flag_is_not_passed_to_playbin_if_download_buffering_is_not_enabled(  # noqa: B950
+    def test_download_flag_is_not_passed_to_playbin_if_download_buffering_is_not_enabled(
         self,
     ):
         playbin = self.audio._playbin
@@ -700,7 +700,7 @@ class DownloadBufferingTest(unittest.TestCase):
 
         playbin.set_property.assert_has_calls([mock.call("flags", 0x02)])
 
-    def test_download_flag_is_not_passed_to_playbin_if_set_appsrc(  # noqa: B950
+    def test_download_flag_is_not_passed_to_playbin_if_set_appsrc(
         self,
     ):
         playbin = self.audio._playbin
@@ -711,7 +711,7 @@ class DownloadBufferingTest(unittest.TestCase):
 
 
 class SourceSetupCallbackTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         config = {"proxy": {}}
         self.audio = audio.Audio(config=config, mixer=None)
         self.audio._playbin = mock.Mock(spec=["set_property"])

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -538,14 +538,14 @@ class AudioStateTest(unittest.TestCase):
         self.audio = audio.Audio(config=None, mixer=None)
 
     def test_state_starts_as_stopped(self):
-        assert audio.PlaybackState.STOPPED == self.audio.state
+        assert self.audio.state == audio.PlaybackState.STOPPED
 
     def test_state_does_not_change_when_in_gst_ready_state(self):
         self.audio._handler.on_playbin_state_changed(
             Gst.State.NULL, Gst.State.READY, Gst.State.VOID_PENDING
         )
 
-        assert audio.PlaybackState.STOPPED == self.audio.state
+        assert self.audio.state == audio.PlaybackState.STOPPED
 
     def test_state_changes_from_stopped_to_playing_on_play(self):
         self.audio._handler.on_playbin_state_changed(
@@ -558,7 +558,7 @@ class AudioStateTest(unittest.TestCase):
             Gst.State.PAUSED, Gst.State.PLAYING, Gst.State.VOID_PENDING
         )
 
-        assert audio.PlaybackState.PLAYING == self.audio.state
+        assert self.audio.state == audio.PlaybackState.PLAYING
 
     def test_state_changes_from_playing_to_paused_on_pause(self):
         self.audio.state = audio.PlaybackState.PLAYING
@@ -567,7 +567,7 @@ class AudioStateTest(unittest.TestCase):
             Gst.State.PLAYING, Gst.State.PAUSED, Gst.State.VOID_PENDING
         )
 
-        assert audio.PlaybackState.PAUSED == self.audio.state
+        assert self.audio.state == audio.PlaybackState.PAUSED
 
     def test_state_changes_from_playing_to_stopped_on_stop(self):
         self.audio.state = audio.PlaybackState.PLAYING
@@ -582,7 +582,7 @@ class AudioStateTest(unittest.TestCase):
         # self.audio._handler.on_playbin_state_changed(
         #     Gst.State.READY, Gst.State.NULL, Gst.State.VOID_PENDING)
 
-        assert audio.PlaybackState.STOPPED == self.audio.state
+        assert self.audio.state == audio.PlaybackState.STOPPED
 
 
 class AudioBufferingTest(unittest.TestCase):

--- a/tests/audio/test_listener.py
+++ b/tests/audio/test_listener.py
@@ -5,7 +5,7 @@ from mopidy import audio
 
 
 class AudioListenerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.listener = audio.AudioListener()
 
     def test_on_event_forwards_to_specific_handler(self):

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -7,7 +7,7 @@ from tests import path_to_data_dir
 
 
 class ScannerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.errors = {}
         self.result = {}
 

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -41,7 +41,7 @@ class ScannerTest(unittest.TestCase):
     def test_tags_is_set(self):
         self.scan(self.find("scanner/simple"))
 
-        assert list(self.result.values())[0].tags
+        assert next(iter(self.result.values())).tags
 
     def test_errors_is_not_set(self):
         self.scan(self.find("scanner/simple"))
@@ -90,7 +90,7 @@ class ScannerTest(unittest.TestCase):
 
     def test_other_media_is_ignored(self):
         self.scan(self.find("scanner/image"))
-        assert not list(self.result.values())[0].playable
+        assert not next(iter(self.result.values())).playable
 
     def test_log_file_that_gst_thinks_is_mpeg_1_is_ignored(self):
         self.scan([path_to_data_dir("scanner/example.log")])

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -238,7 +238,7 @@ class TagsToTrackTest(unittest.TestCase):
 
     def test_missing_track_artist_musicbrainz_id(self):
         del self.tags["musicbrainz-artistid"]
-        artist = list(self.track.artists)[0].replace(musicbrainz_id=None)
+        artist = next(iter(self.track.artists)).replace(musicbrainz_id=None)
         self.check(self.track.replace(artists=[artist]))
 
     def test_multiple_track_artist_musicbrainz_id(self):
@@ -311,7 +311,7 @@ class TagsToTrackTest(unittest.TestCase):
 
     def test_missing_album_artist_musicbrainz_id(self):
         del self.tags["musicbrainz-albumartistid"]
-        albumartist = list(self.track.album.artists)[0]
+        albumartist = next(iter(self.track.album.artists))
         albumartist = albumartist.replace(musicbrainz_id=None)
         album = self.track.album.replace(artists=[albumartist])
         self.check(self.track.replace(album=album))

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -96,7 +96,7 @@ class TestConvertTaglist:
 # TODO: current test is trying to test everything at once with a complete tags
 # set, instead we might want to try with a minimal one making testing easier.
 class TagsToTrackTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.tags = {
             "album": ["album"],
             "track-number": [1],

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -12,7 +12,7 @@ class LibraryTest(unittest.TestCase):
 
 
 class PlaylistsTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.provider = backend.PlaylistsProvider(backend=None)
 
     def test_as_list_default_impl(self):

--- a/tests/backend/test_listener.py
+++ b/tests/backend/test_listener.py
@@ -5,7 +5,7 @@ from mopidy import backend
 
 
 class BackendListenerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.listener = backend.BackendListener()
 
     def test_on_event_forwards_to_specific_handler(self):

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -96,7 +96,7 @@ class LoadConfigTest(unittest.TestCase):
 
 
 class ValidateTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.schema = config.ConfigSchema("foo")
         self.schema["bar"] = config.String()
 
@@ -162,7 +162,7 @@ __HASH10__ = foo # = should all be treated as a comment."""
 
 
 class PreProcessorTest(unittest.TestCase):
-    maxDiff = None  # Show entire diff.  # noqa: N815
+    maxDiff = None  # Show entire diff.
 
     def test_empty_config(self):
         result = config._preprocess("")
@@ -215,7 +215,7 @@ class PreProcessorTest(unittest.TestCase):
 
 
 class PostProcessorTest(unittest.TestCase):
-    maxDiff = None  # Show entire diff.  # noqa: N815
+    maxDiff = None  # Show entire diff.
 
     def test_empty_config(self):
         result = config._postprocess("[__COMMENTS__]")

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -222,18 +222,18 @@ class PostProcessorTest(unittest.TestCase):
         assert result == ""
 
     def test_plain_section(self):
-        result = config._postprocess("[__COMMENTS__]\n" "[section]\n" "foo = bar")
+        result = config._postprocess("[__COMMENTS__]\n[section]\nfoo = bar")
         assert result == "[section]\nfoo = bar"
 
     def test_initial_comments(self):
-        result = config._postprocess("[__COMMENTS__]\n" "__SEMICOLON0__ = foobar")
+        result = config._postprocess("[__COMMENTS__]\n__SEMICOLON0__ = foobar")
         assert result == "; foobar"
 
-        result = config._postprocess("[__COMMENTS__]\n" "__HASH0__ = foobar")
+        result = config._postprocess("[__COMMENTS__]\n__HASH0__ = foobar")
         assert result == "# foobar"
 
         result = config._postprocess(
-            "[__COMMENTS__]\n" "__SEMICOLON0__ = foo\n" "__HASH1__ = bar"
+            "[__COMMENTS__]\n__SEMICOLON0__ = foo\n__HASH1__ = bar"
         )
         assert result == "; foo\n# bar"
 
@@ -248,7 +248,7 @@ class PostProcessorTest(unittest.TestCase):
 
     def test_inline_semicolon_comment(self):
         result = config._postprocess(
-            "[__COMMENTS__]\n" "[section]\n" "foo = bar\n" "__INLINE0__ = baz"
+            "[__COMMENTS__]\n[section]\nfoo = bar\n__INLINE0__ = baz"
         )
         assert result == "[section]\nfoo = bar ; baz"
 
@@ -258,7 +258,7 @@ class PostProcessorTest(unittest.TestCase):
 
     def test_section_extra_text(self):
         result = config._postprocess(
-            "[__COMMENTS__]\n" "[section]\n" "__SECTION0__ = foobar"
+            "[__COMMENTS__]\n[section]\n__SECTION0__ = foobar"
         )
         assert result == "[section] foobar"
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -257,9 +257,7 @@ class PostProcessorTest(unittest.TestCase):
         assert result == "[__COMMENTS__]\n[section]\nfoo = bar # baz"
 
     def test_section_extra_text(self):
-        result = config._postprocess(
-            "[__COMMENTS__]\n[section]\n__SECTION0__ = foobar"
-        )
+        result = config._postprocess("[__COMMENTS__]\n[section]\n__SECTION0__ = foobar")
         assert result == "[section] foobar"
 
     def test_section_extra_text_inline_semicolon(self):

--- a/tests/config/test_schemas.py
+++ b/tests/config/test_schemas.py
@@ -7,7 +7,7 @@ from tests import any_unicode
 
 
 class ConfigSchemaTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.schema = schemas.ConfigSchema("test")
         self.schema["foo"] = mock.Mock()
         self.schema["bar"] = mock.Mock()

--- a/tests/config/test_schemas.py
+++ b/tests/config/test_schemas.py
@@ -87,8 +87,8 @@ class MapConfigSchemaTest(unittest.TestCase):
         schema = schemas.MapConfigSchema("test", types.LogLevel())
         result, errors = schema.deserialize({"foo.bar": "DEBUG", "baz": "INFO"})
 
-        assert logging.DEBUG == result["foo.bar"]
-        assert logging.INFO == result["baz"]
+        assert result["foo.bar"] == logging.DEBUG
+        assert result["baz"] == logging.INFO
 
 
 class DidYouMeanTest(unittest.TestCase):

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -11,7 +11,7 @@ from mopidy.internal import log
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # bytes are coded from UTF-8 and string-escaped:
         (b"abc", "abc"),
@@ -30,7 +30,7 @@ def test_decode(value, expected):
 
 
 @pytest.mark.parametrize(
-    "value, expected",
+    ("value", "expected"),
     [
         # unicode strings are string-escaped and encoded as UTF-8:
         ("abc", "abc"),

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -2,6 +2,7 @@ import codecs
 import logging
 import re
 import socket
+from typing import ClassVar
 from unittest import mock
 
 import pytest
@@ -1209,7 +1210,7 @@ class TestLogColor:
 
 
 class TestLogLevel:
-    levels = {
+    levels: ClassVar[dict[str, int]] = {
         "critical": logging.CRITICAL,
         "error": logging.ERROR,
         "warning": logging.WARNING,

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -143,7 +143,7 @@ class CoreActorTest(unittest.TestCase):
 
         self.assertRaisesRegex(
             AssertionError,
-            "Cannot add URI scheme 'dummy1' for B2, " "it is already handled by B1",
+            "Cannot add URI scheme 'dummy1' for B2, it is already handled by B1",
             Core,
             config={},
             mixer=None,

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -51,7 +51,7 @@ def make_backend_mock(
 
 
 class CoreActorTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.backend1 = make_backend_mock(
             "B1",
             uri_schemes=["dummy1"],
@@ -75,7 +75,7 @@ class CoreActorTest(unittest.TestCase):
             backends=[self.backend1, self.backend2],
         )
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         pykka.ActorRegistry.stop_all()
 
     def test_uri_schemes_has_uris_from_all_backends(self):
@@ -187,7 +187,7 @@ class CoreActorSaveLoadStateTest(unittest.TestCase):
             backends=[],
         )
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         pykka.ActorRegistry.stop_all()
         shutil.rmtree(self.temp_dir)
 

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -11,7 +11,7 @@ from tests import dummy_backend
 
 @mock.patch.object(core.CoreListener, "send")
 class BackendEventsTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         config = {"core": {"max_tracklist_length": 10000}}
 
         self.backend = dummy_backend.create_proxy()
@@ -23,7 +23,7 @@ class BackendEventsTest(unittest.TestCase):
         with deprecation.ignore():
             self.core = core.Core.start(config, backends=[self.backend]).proxy()
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         pykka.ActorRegistry.stop_all()
 
     def test_forwards_backend_playlists_loaded_event_to_frontends(self, send):

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -6,7 +6,7 @@ from mopidy.models import Artist, Ref, Track
 
 
 class PlaybackHistoryTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.tracks = [
             Track(
                 uri="dummy1:a",
@@ -54,7 +54,7 @@ class PlaybackHistoryTest(unittest.TestCase):
 
 
 class CoreHistorySaveLoadStateTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.tracks = [
             Track(uri="dummy1:a", name="foober"),
             Track(uri="dummy2:a", name="foo"),

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -7,7 +7,7 @@ from mopidy.models import Image, Ref, SearchResult, Track
 
 
 class BaseCoreLibraryTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         dummy1_root = Ref.directory(uri="dummy1:directory", name="dummy1")
         self.backend1 = mock.Mock()
         self.backend1.uri_schemes.get.return_value = ["dummy1"]
@@ -404,7 +404,7 @@ class GetDistinctTest(BaseCoreLibraryTest):
 
 
 class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.backend = mock.Mock()
         self.backend.actor_ref.actor_class.__name__ = "DummyBackend"
         self.backend.uri_schemes.get.return_value = ["dummy"]
@@ -430,7 +430,7 @@ class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
 
 
 class MockBackendCoreLibraryBase(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         dummy_root = Ref.directory(uri="dummy:directory", name="dummy")
 
         self.library = mock.Mock(spec=backend.LibraryProvider)

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -414,13 +414,13 @@ class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
     def test_core_search_call_backend_search_with_exact(self):
         self.core.library.search(query={"any": ["a"]})
         self.backend.library.search.assert_called_once_with(
-            query=dict(any=["a"]), uris=None, exact=False
+            query={"any": ["a"]}, uris=None, exact=False
         )
 
     def test_core_search_with_exact_call_backend_search_with_exact(self):
         self.core.library.search(query={"any": ["a"]}, exact=True)
         self.backend.library.search.assert_called_once_with(
-            query=dict(any=["a"]), uris=None, exact=True
+            query={"any": ["a"]}, uris=None, exact=True
         )
 
     def test_core_search_with_handles_legacy_backend(self):

--- a/tests/core/test_listener.py
+++ b/tests/core/test_listener.py
@@ -6,7 +6,7 @@ from mopidy.models import Playlist, TlTrack
 
 
 class CoreListenerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.listener = CoreListener()
 
     def test_on_event_forwards_to_specific_handler(self):

--- a/tests/core/test_mixer.py
+++ b/tests/core/test_mixer.py
@@ -9,7 +9,7 @@ from tests import dummy_mixer
 
 
 class CoreMixerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.mixer = mock.Mock(spec=mixer.Mixer)
         self.core = core.Core(
             config={},
@@ -43,7 +43,7 @@ class CoreMixerTest(unittest.TestCase):
 
 
 class CoreNoneMixerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.core = core.Core(
             config={},
             mixer=None,
@@ -65,7 +65,7 @@ class CoreNoneMixerTest(unittest.TestCase):
 
 @mock.patch.object(mixer.MixerListener, "send")
 class CoreMixerListenerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.mixer = dummy_mixer.create_proxy()
         self.core = core.Core(
             config={},
@@ -73,7 +73,7 @@ class CoreMixerListenerTest(unittest.TestCase):
             backends=[],
         )
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         pykka.ActorRegistry.stop_all()
 
     def test_forwards_mixer_volume_changed_event_to_frontends(self, send):
@@ -90,7 +90,7 @@ class CoreMixerListenerTest(unittest.TestCase):
 
 @mock.patch.object(mixer.MixerListener, "send")
 class CoreNoneMixerListenerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.core = core.Core(
             config={},
             mixer=None,
@@ -107,7 +107,7 @@ class CoreNoneMixerListenerTest(unittest.TestCase):
 
 
 class MockBackendCoreMixerBase(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.mixer = mock.Mock()
         self.mixer.actor_ref.actor_class.__name__ = "DummyMixer"
         self.core = core.Core(
@@ -166,7 +166,7 @@ class SetMuteBadBackendTest(MockBackendCoreMixerBase):
 
 
 class CoreMixerSaveLoadStateTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.mixer = dummy_mixer.create_proxy()
         self.core = core.Core(
             config={},

--- a/tests/core/test_mixer.py
+++ b/tests/core/test_mixer.py
@@ -206,7 +206,7 @@ class CoreMixerSaveLoadStateTest(unittest.TestCase):
         target = MixerState(volume=56, mute=False)
         coverage = ["other"]
         self.core.mixer._load_state(target, coverage)
-        assert 21 == self.core.mixer.get_volume()
+        assert self.core.mixer.get_volume() == 21
         assert self.core.mixer.get_mute() is True
 
     def test_load_mute_on(self):

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -207,7 +207,7 @@ class TestNextHandling(BaseTest):
         assert current_track == self.tracks[1]
 
     @pytest.mark.parametrize(
-        "repeat, random, single, consume, index, result",
+        ("repeat", "random", "single", "consume", "index", "result"),
         [
             (False, False, False, False, 0, 1),
             (False, False, False, False, 2, None),
@@ -308,7 +308,7 @@ class TestPreviousHandling(BaseTest):
         assert self.core.playback.get_current_track() == self.tracks[0]
 
     @pytest.mark.parametrize(
-        "repeat, random, single, consume, index, result",
+        ("repeat", "random", "single", "consume", "index", "result"),
         [
             (False, False, False, False, 0, None),
             (False, False, False, False, 1, 0),

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -535,7 +535,7 @@ class TestCurrentAndPendingTlTrack(BaseTest):
 
 @mock.patch("mopidy.core.playback.listener.CoreListener", spec=core.CoreListener)
 class TestEventEmission(BaseTest):
-    maxDiff = None  # noqa: N815
+    maxDiff = None
 
     def test_play_when_stopped_emits_events(self, listener_mock):
         tl_tracks = self.core.tracklist.get_tl_tracks()

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -32,7 +32,7 @@ class MyTestPlaybackProvider(backend.PlaybackProvider):
         if "limit_never" in uri:
             # unplayable
             return None
-        elif "limit_one" in uri:
+        if "limit_one" in uri:
             # one time playable
             if self._call_onetime:
                 return None
@@ -42,12 +42,11 @@ class MyTestPlaybackProvider(backend.PlaybackProvider):
     def translate_uri(self, uri):
         if "error" in uri:
             raise Exception(uri)
-        elif "unplayable" in uri:
+        if "unplayable" in uri:
             return None
-        elif "limit" in uri:
+        if "limit" in uri:
             return self._translate_uri_call_limit(uri)
-        else:
-            return uri
+        return uri
 
 
 class MyTestBackend(dummy_backend.DummyBackend):

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -1,3 +1,4 @@
+from typing import ClassVar
 from unittest import mock
 
 import pykka
@@ -56,8 +57,10 @@ class MyTestBackend(dummy_backend.DummyBackend):
 
 
 class BaseTest:
-    config = {"core": {"max_tracklist_length": 10000}}
-    tracks = [
+    config: ClassVar[dict[str, dict[str, int]]] = {
+        "core": {"max_tracklist_length": 10000}
+    }
+    tracks: ClassVar[list[Track]] = [
         Track(uri="dummy:a", length=1234, name="foo"),
         Track(uri="dummy:b", length=1234),
         Track(uri="dummy:c", length=1234),
@@ -834,7 +837,7 @@ class TestEventEmission(BaseTest):
 
 
 class TestUnplayableURI(BaseTest):
-    tracks = [
+    tracks: ClassVar[list[Track]] = [
         Track(uri="unplayable://"),
         Track(uri="dummy:b"),
     ]
@@ -1262,7 +1265,7 @@ class TestCorePlaybackSaveLoadState(BaseTest):
 
 
 class TestBug1352Regression(BaseTest):
-    tracks = [
+    tracks: ClassVar[list[Track]] = [
         Track(uri="dummy:a", length=40000),
         Track(uri="dummy:b", length=40000),
     ]
@@ -1289,12 +1292,12 @@ class TestBug1352Regression(BaseTest):
 
 
 class TestEndlessLoop(BaseTest):
-    tracks_play = [
+    tracks_play: ClassVar[list[Track]] = [
         Track(uri="dummy:limit_never:a"),
         Track(uri="dummy:limit_never:b"),
     ]
 
-    tracks_other = [
+    tracks_other: ClassVar[list[Track]] = [
         Track(uri="dummy:limit_never:a"),
         Track(uri="dummy:limit_one"),
         Track(uri="dummy:limit_never:b"),

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -889,7 +889,7 @@ class TestSeek(BaseTest):
         self.replay_events()
 
         self.core.playback.seek(-100)  # Dummy audio doesn't progress time.
-        assert 0 == self.core.playback.get_time_position()
+        assert self.core.playback.get_time_position() == 0
 
     def test_seek_fails_for_track_without_duration(self):
         track = self.tracks[0].replace(length=None)
@@ -901,7 +901,7 @@ class TestSeek(BaseTest):
         self.replay_events()
 
         assert not self.core.playback.seek(1000)
-        assert 0 == self.core.playback.get_time_position()
+        assert self.core.playback.get_time_position() == 0
 
     def test_seek_play_stay_playing(self):
         tl_tracks = self.core.tracklist.get_tl_tracks()
@@ -1229,14 +1229,14 @@ class TestCorePlaybackSaveLoadState(BaseTest):
 
         self.core.playback.stop()
         self.replay_events()
-        assert "stopped" == self.core.playback.get_state()
+        assert self.core.playback.get_state() == "stopped"
 
         state = PlaybackState(time_position=0, state="playing", tlid=tl_tracks[2].tlid)
         coverage = ["play-last"]
         self.core.playback._load_state(state, coverage)
         self.replay_events()
 
-        assert "playing" == self.core.playback.get_state()
+        assert self.core.playback.get_state() == "playing"
         assert tl_tracks[2] == self.core.playback.get_current_tl_track()
 
     def test_load_not_covered(self):
@@ -1244,14 +1244,14 @@ class TestCorePlaybackSaveLoadState(BaseTest):
 
         self.core.playback.stop()
         self.replay_events()
-        assert "stopped" == self.core.playback.get_state()
+        assert self.core.playback.get_state() == "stopped"
 
         state = PlaybackState(time_position=0, state="playing", tlid=tl_tracks[2].tlid)
         coverage = ["other"]
         self.core.playback._load_state(state, coverage)
         self.replay_events()
 
-        assert "stopped" == self.core.playback.get_state()
+        assert self.core.playback.get_state() == "stopped"
         assert self.core.playback.get_current_tl_track() is None
 
     def test_load_invalid_type(self):

--- a/tests/core/test_playlists.py
+++ b/tests/core/test_playlists.py
@@ -6,7 +6,7 @@ from mopidy.models import Playlist, Ref, Track
 
 
 class BasePlaylistsTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.plr1a = Ref.playlist(name="A", uri="dummy1:pl:a")
         self.plr1b = Ref.playlist(name="B", uri="dummy1:pl:b")
         self.plr2a = Ref.playlist(name="A", uri="dummy2:pl:a")
@@ -259,7 +259,7 @@ class PlaylistTest(BasePlaylistsTest):
 
 
 class MockBackendCorePlaylistsBase(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.playlists = mock.Mock(spec=backend.PlaylistsProvider)
 
         self.backend = mock.Mock()

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -7,7 +7,7 @@ from mopidy.models import TlTrack, Track
 
 
 class TracklistTest(unittest.TestCase):
-    def setUp(self):  # noqa:
+    def setUp(self):
         config = {"core": {"max_tracklist_length": 10000}}
 
         self.tracks = [
@@ -102,7 +102,7 @@ class TracklistTest(unittest.TestCase):
 
 
 class TracklistIndexTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         config = {"core": {"max_tracklist_length": 10000}}
 
         self.tracks = [
@@ -169,7 +169,7 @@ class TracklistIndexTest(unittest.TestCase):
 
 
 class TracklistSaveLoadStateTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         config = {"core": {"max_tracklist_length": 10000}}
 
         self.tracks = [

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -37,7 +37,7 @@ class TracklistTest(unittest.TestCase):
         tl_tracks = self.core.tracklist.add(uris=["dummy1:a"])
 
         self.library.lookup.assert_called_once_with("dummy1:a")
-        assert 1 == len(tl_tracks)
+        assert len(tl_tracks) == 1
         assert self.tracks[0] == tl_tracks[0].track
         assert tl_tracks == self.core.tracklist.get_tl_tracks()[(-1):]
 
@@ -54,7 +54,7 @@ class TracklistTest(unittest.TestCase):
                 mock.call("dummy1:c"),
             ]
         )
-        assert 3 == len(tl_tracks)
+        assert len(tl_tracks) == 3
         assert self.tracks[0] == tl_tracks[0].track
         assert self.tracks[1] == tl_tracks[1].track
         assert self.tracks[2] == tl_tracks[2].track
@@ -63,31 +63,31 @@ class TracklistTest(unittest.TestCase):
     def test_remove_removes_tl_tracks_matching_query(self):
         tl_tracks = self.core.tracklist.remove({"name": ["foo"]})
 
-        assert 2 == len(tl_tracks)
+        assert len(tl_tracks) == 2
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
-        assert 1 == self.core.tracklist.get_length()
+        assert self.core.tracklist.get_length() == 1
         self.assertListEqual(self.tl_tracks[2:], self.core.tracklist.get_tl_tracks())
 
     def test_remove_works_with_dict_instead_of_kwargs(self):
         tl_tracks = self.core.tracklist.remove({"name": ["foo"]})
 
-        assert 2 == len(tl_tracks)
+        assert len(tl_tracks) == 2
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
-        assert 1 == self.core.tracklist.get_length()
+        assert self.core.tracklist.get_length() == 1
         self.assertListEqual(self.tl_tracks[2:], self.core.tracklist.get_tl_tracks())
 
     def test_filter_returns_tl_tracks_matching_query(self):
         tl_tracks = self.core.tracklist.filter({"name": ["foo"]})
 
-        assert 2 == len(tl_tracks)
+        assert len(tl_tracks) == 2
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
     def test_filter_works_with_dict_instead_of_kwargs(self):
         tl_tracks = self.core.tracklist.filter({"name": ["foo"]})
 
-        assert 2 == len(tl_tracks)
+        assert len(tl_tracks) == 2
         self.assertListEqual(self.tl_tracks[:2], tl_tracks)
 
     def test_filter_fails_if_values_isnt_iterable(self):
@@ -123,9 +123,9 @@ class TracklistIndexTest(unittest.TestCase):
         self.tl_tracks = self.core.tracklist.add(uris=[t.uri for t in self.tracks])
 
     def test_index_returns_index_of_track(self):
-        assert 0 == self.core.tracklist.index(self.tl_tracks[0])
-        assert 1 == self.core.tracklist.index(self.tl_tracks[1])
-        assert 2 == self.core.tracklist.index(self.tl_tracks[2])
+        assert self.core.tracklist.index(self.tl_tracks[0]) == 0
+        assert self.core.tracklist.index(self.tl_tracks[1]) == 1
+        assert self.core.tracklist.index(self.tl_tracks[2]) == 2
 
     def test_index_returns_none_if_item_not_found(self):
         tl_track = TlTrack(0, Track())
@@ -140,9 +140,9 @@ class TracklistIndexTest(unittest.TestCase):
 
     def test_index_return_index_when_called_with_tlids(self):
         tl_tracks = self.tl_tracks
-        assert 0 == self.core.tracklist.index(tlid=tl_tracks[0].tlid)
-        assert 1 == self.core.tracklist.index(tlid=tl_tracks[1].tlid)
-        assert 2 == self.core.tracklist.index(tlid=tl_tracks[2].tlid)
+        assert self.core.tracklist.index(tlid=tl_tracks[0].tlid) == 0
+        assert self.core.tracklist.index(tlid=tl_tracks[1].tlid) == 1
+        assert self.core.tracklist.index(tlid=tl_tracks[2].tlid) == 2
 
     def test_index_returns_none_if_tlid_not_found(self):
         assert self.core.tracklist.index(tlid=123) is None
@@ -163,9 +163,9 @@ class TracklistIndexTest(unittest.TestCase):
         ]
 
         assert self.core.tracklist.index() is None
-        assert 0 == self.core.tracklist.index()
-        assert 1 == self.core.tracklist.index()
-        assert 2 == self.core.tracklist.index()
+        assert self.core.tracklist.index() == 0
+        assert self.core.tracklist.index() == 1
+        assert self.core.tracklist.index() == 2
 
 
 class TracklistSaveLoadStateTest(unittest.TestCase):
@@ -226,15 +226,15 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
         assert self.core.tracklist.get_repeat() is True
         assert self.core.tracklist.get_single() is True
         assert self.core.tracklist.get_random() is False
-        assert 12 == self.core.tracklist._next_tlid
-        assert 4 == self.core.tracklist.get_length()
+        assert self.core.tracklist._next_tlid == 12
+        assert self.core.tracklist.get_length() == 4
         assert self.tl_tracks == self.core.tracklist.get_tl_tracks()
         assert self.core.tracklist.get_version() > old_version
 
         # after load, adding more tracks must be possible
         self.core.tracklist.add(uris=[self.tracks[1].uri])
-        assert 13 == self.core.tracklist._next_tlid
-        assert 5 == self.core.tracklist.get_length()
+        assert self.core.tracklist._next_tlid == 13
+        assert self.core.tracklist.get_length() == 5
 
     def test_load_mode_only(self):
         old_version = self.core.tracklist.get_version()
@@ -252,8 +252,8 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
         assert self.core.tracklist.get_repeat() is True
         assert self.core.tracklist.get_single() is True
         assert self.core.tracklist.get_random() is False
-        assert 1 == self.core.tracklist._next_tlid
-        assert 0 == self.core.tracklist.get_length()
+        assert self.core.tracklist._next_tlid == 1
+        assert self.core.tracklist.get_length() == 0
         assert [] == self.core.tracklist.get_tl_tracks()
         assert self.core.tracklist.get_version() == old_version
 
@@ -273,8 +273,8 @@ class TracklistSaveLoadStateTest(unittest.TestCase):
         assert self.core.tracklist.get_repeat() is False
         assert self.core.tracklist.get_single() is False
         assert self.core.tracklist.get_random() is False
-        assert 12 == self.core.tracklist._next_tlid
-        assert 4 == self.core.tracklist.get_length()
+        assert self.core.tracklist._next_tlid == 12
+        assert self.core.tracklist.get_length() == 4
         assert self.tl_tracks == self.core.tracklist.get_tl_tracks()
         assert self.core.tracklist.get_version() > old_version
 

--- a/tests/dummy_backend.py
+++ b/tests/dummy_backend.py
@@ -114,7 +114,7 @@ class DummyPlaylistsProvider(backend.PlaylistsProvider):
     def get_items(self, uri):
         playlist = self.lookup(uri)
         if playlist is None:
-            return
+            return None
         return [Ref.track(uri=t.uri, name=t.name) for t in playlist.tracks]
 
     def lookup(self, uri):
@@ -122,6 +122,7 @@ class DummyPlaylistsProvider(backend.PlaylistsProvider):
         for playlist in self._playlists:
             if playlist.uri == uri:
                 return playlist
+        return None
 
     def refresh(self):
         pass

--- a/tests/file/conftest.py
+++ b/tests/file/conftest.py
@@ -6,17 +6,17 @@ from mopidy.file import backend
 from tests import path_to_data_dir
 
 
-@pytest.fixture
+@pytest.fixture()
 def media_dirs():
     return [str(path_to_data_dir(""))]
 
 
-@pytest.fixture
+@pytest.fixture()
 def follow_symlinks():
     return False
 
 
-@pytest.fixture
+@pytest.fixture()
 def config(media_dirs, follow_symlinks):
     return {
         "proxy": {},
@@ -30,6 +30,6 @@ def config(media_dirs, follow_symlinks):
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def provider(config):
     return backend.FileBackend(audio=mock.Mock(), config=config).library

--- a/tests/file/test_browse.py
+++ b/tests/file/test_browse.py
@@ -6,7 +6,7 @@ from tests import path_to_data_dir
 
 @pytest.mark.parametrize("follow_symlinks", [True, False])
 @pytest.mark.parametrize(
-    "uri, levelname",
+    ("uri", "levelname"),
     [
         ("file:root", None),
         ("not_in_data_path", "WARNING"),
@@ -28,7 +28,7 @@ def test_file_browse(provider, uri, levelname, caplog):
 
 
 @pytest.mark.parametrize(
-    "media_dirs, expected",
+    ("media_dirs", "expected"),
     [
         ([str(path_to_data_dir(""))], False),
         ([str(path_to_data_dir("")), str(path_to_data_dir(""))], True),

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -29,14 +29,14 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
     def test_static_handler(self):
         response = self.fetch("/test_handlers.py", method="GET")
 
-        assert 200 == response.code
+        assert response.code == 200
         assert response.headers["X-Mopidy-Version"] == mopidy.__version__
         assert response.headers["Cache-Control"] == "no-cache"
 
     def test_static_default_filename(self):
         response = self.fetch("/", method="GET")
 
-        assert 200 == response.code
+        assert response.code == 200
         assert response.headers["X-Mopidy-Version"] == mopidy.__version__
         assert response.headers["Cache-Control"] == "no-cache"
 

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -165,7 +165,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
 
         assert response.code == 204
         for k, v in self.get_cors_response_headers():
-            self.assertEqual(response.headers[k], v)
+            assert response.headers[k] == v
 
     def test_options_bad_origin_forbidden(self):
         self.headers.update({"Origin": "http://foo:6680"})
@@ -174,7 +174,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
         assert response.code == 403
         assert response.reason == "Access denied for origin http://foo:6680"
         for k, _ in self.get_cors_response_headers():
-            self.assertNotIn(k, response.headers)
+            assert k not in response.headers
 
     def test_options_no_origin_forbidden(self):
         response = self.fetch("/rpc", method="OPTIONS", headers=self.headers)
@@ -182,14 +182,14 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
         assert response.code == 403
         assert response.reason == "Access denied for origin None"
         for k, _ in self.get_cors_response_headers():
-            self.assertNotIn(k, response.headers)
+            assert k not in response.headers
 
     def test_post_no_content_type_unsupported(self):
         response = self.fetch("/rpc", method="POST", body="hi", headers=self.headers)
 
         assert response.code == 415
         for k, _ in self.get_cors_response_headers():
-            self.assertNotIn(k, response.headers)
+            assert k not in response.headers
 
     def test_post_wrong_content_type_unsupported(self):
         self.headers.update({"Content-Type": "application/cats"})
@@ -198,7 +198,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
         assert response.code == 415
         assert response.reason == "Content-Type must be application/json"
         for k, _ in self.get_cors_response_headers():
-            self.assertNotIn(k, response.headers)
+            assert k not in response.headers
 
     def test_post_no_origin_ok_but_doesnt_set_cors_headers(self):
         self.headers.update({"Content-Type": "application/json"})
@@ -206,7 +206,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
 
         assert response.code == 200
         for k, _ in self.get_cors_response_headers():
-            self.assertNotIn(k, response.headers)
+            assert k not in response.headers
 
     def test_post_with_origin_ok_sets_cors_headers(self):
         self.headers.update(
@@ -217,7 +217,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
         assert response.code == 200
         self.assert_extra_response_headers(response.headers)
         for k, v in self.get_cors_response_headers():
-            self.assertEqual(response.headers[k], v)
+            assert response.headers[k] == v
 
 
 class JsonRpcHandlerTestCSRFDisabled(JsonRpcHandlerTestBase):
@@ -233,7 +233,7 @@ class JsonRpcHandlerTestCSRFDisabled(JsonRpcHandlerTestBase):
 
         assert response.code == 200
         for k, _ in self.get_cors_response_headers():
-            self.assertNotIn(k, response.headers)
+            assert k not in response.headers
 
 
 class CheckOriginTests(unittest.TestCase):

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -1,5 +1,5 @@
-import os
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import tornado.httpclient
@@ -19,7 +19,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     r"/(.*)",
                     handlers.StaticFileHandler,
                     {
-                        "path": os.path.dirname(__file__),
+                        "path": Path(__file__).parent,
                         "default_filename": "test_handlers.py",
                     },
                 )

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -87,12 +87,12 @@ class MopidyWebSocketHandlerTest(HttpServerTest):
     def test_should_return_ws(self):
         response = self.fetch("/mopidy/ws", method="GET")
 
-        assert 'Can "Upgrade" only to "WebSocket".' == response.body.decode()
+        assert response.body.decode() == 'Can "Upgrade" only to "WebSocket".'
 
     def test_should_return_ws_old(self):
         response = self.fetch("/mopidy/ws/", method="GET")
 
-        assert 'Can "Upgrade" only to "WebSocket".' == response.body.decode()
+        assert response.body.decode() == 'Can "Upgrade" only to "WebSocket".'
 
 
 class MopidyRPCHandlerTest(HttpServerTest):
@@ -238,7 +238,7 @@ class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
     def test_can_serve_static_files(self):
         response = self.fetch("/static/test_server.py", method="GET")
 
-        assert 200 == response.code
+        assert response.code == 200
         assert response.headers["X-Mopidy-Version"] == mopidy.__version__
         assert response.headers["Cache-Control"] == "no-cache"
 
@@ -436,13 +436,13 @@ class HttpServerTestLoginWithSecureCookie(tornado.testing.AsyncHTTPTestCase):
     def test_main_access_without_login(self):
         response = self.fetch("/cookie_secret", method="GET")
 
-        assert 200 == response.code
+        assert response.code == 200
         assert "Unknown user..." in response.body.decode()
 
     def test_accessing_login_form_get(self):
         response = self.fetch("/cookie_secret/login", method="GET")
 
-        assert 200 == response.code
+        assert response.code == 200
         assert "This is a login form" in response.body.decode()
 
     def test_login(self):
@@ -451,7 +451,7 @@ class HttpServerTestLoginWithSecureCookie(tornado.testing.AsyncHTTPTestCase):
 
         response = self.fetch("/cookie_secret/login", method="POST", body=body)
 
-        assert 200 == response.code
+        assert response.code == 200
         assert "Logged in" in response.body.decode()
 
         shutil.rmtree(self._dirpath)

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -1,7 +1,7 @@
-import os
 import shutil
 import tempfile
 import urllib
+from pathlib import Path
 from unittest import mock
 
 import tornado.testing
@@ -221,7 +221,12 @@ class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
         }
         core = mock.Mock()
 
-        statics = [{"name": "static", "path": os.path.dirname(__file__)}]
+        statics = [
+            {
+                "name": "static",
+                "path": Path(__file__).parent,
+            }
+        ]
 
         http_server = actor.HttpServer(
             config=config, core=core, sockets=[], apps=[], statics=statics
@@ -344,7 +349,12 @@ class HttpServerWithStaticDefaultApp(tornado.testing.AsyncHTTPTestCase):
         }
         core = mock.Mock()
 
-        statics = [{"name": "default_app", "path": os.path.dirname(__file__)}]
+        statics = [
+            {
+                "name": "default_app",
+                "path": Path(__file__).parent,
+            }
+        ]
 
         http_server = actor.HttpServer(
             config=config, core=core, sockets=[], apps=[], statics=statics

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -29,8 +29,8 @@ class HttpServerTest(tornado.testing.AsyncHTTPTestCase):
         core.get_version = mock.MagicMock(name="get_version")
         core.get_version.return_value = mopidy.__version__
 
-        testapps = [dict(name="testapp")]
-        teststatics = [dict(name="teststatic")]
+        testapps = [{"name": "testapp"}]
+        teststatics = [{"name": "teststatic"}]
 
         apps = [
             {
@@ -221,7 +221,7 @@ class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
         }
         core = mock.Mock()
 
-        statics = [dict(name="static", path=os.path.dirname(__file__))]
+        statics = [{"name": "static", "path": os.path.dirname(__file__)}]
 
         http_server = actor.HttpServer(
             config=config, core=core, sockets=[], apps=[], statics=statics
@@ -312,7 +312,7 @@ class HttpServerWithAppDefaultApp(tornado.testing.AsyncHTTPTestCase):
         }
         core = mock.Mock()
 
-        apps = [dict(name="default_app", factory=default_webapp_factory)]
+        apps = [{"name": "default_app", "factory": default_webapp_factory}]
 
         http_server = actor.HttpServer(
             config=config, core=core, sockets=[], apps=apps, statics=[]
@@ -344,7 +344,7 @@ class HttpServerWithStaticDefaultApp(tornado.testing.AsyncHTTPTestCase):
         }
         core = mock.Mock()
 
-        statics = [dict(name="default_app", path=os.path.dirname(__file__))]
+        statics = [{"name": "default_app", "path": os.path.dirname(__file__)}]
 
         http_server = actor.HttpServer(
             config=config, core=core, sockets=[], apps=[], statics=statics

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -82,16 +82,16 @@ class TestDeps:
         assert result["name"] == "Python"
         assert platform.python_implementation() in result["version"]
         assert platform.python_version() in result["version"]
-        assert "python" in result["path"]
-        assert "platform.py" not in result["path"]
+        assert "python" in str(result["path"])
+        assert "platform.py" not in str(result["path"])
 
     def test_gstreamer_info(self):
         result = deps.gstreamer_info()
 
         assert result["name"] == "GStreamer"
         assert ".".join(map(str, Gst.version())) == result["version"]
-        assert "gi" in result["path"]
-        assert "__init__.py" not in result["path"]
+        assert "gi" in str(result["path"])
+        assert "__init__.py" not in str(result["path"])
         assert "Python wrapper: python-gi" in result["other"]
         assert gi.__version__ in result["other"]
         assert "Relevant elements:" in result["other"]
@@ -140,7 +140,7 @@ class TestDeps:
 
         assert result["name"] == "Mopidy"
         assert result["version"] == "0.13"
-        assert "mopidy" in result["path"]
+        assert "mopidy" in str(result["path"])
 
         dep_info_pykka = result["dependencies"][0]
         assert dep_info_pykka["name"] == "Pykka"

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -17,21 +17,34 @@ from mopidy.internal.gi import Gst, gi
 class TestDeps:
     def test_format_dependency_list(self):
         adapters = [
-            lambda: dict(name="Python", version="FooPython 2.7.3"),
-            lambda: dict(name="Platform", version="Loonix 4.0.1"),
-            lambda: dict(name="Pykka", version="1.1", path="/foo/bar", other="Quux"),
-            lambda: dict(name="Foo"),
-            lambda: dict(
-                name="Mopidy",
-                version="0.13",
-                dependencies=[
-                    dict(
-                        name="pylast",
-                        version="0.5",
-                        dependencies=[dict(name="setuptools", version="0.6")],
-                    )
+            lambda: {
+                "name": "Python",
+                "version": "FooPython 2.7.3",
+            },
+            lambda: {
+                "name": "Platform",
+                "version": "Loonix 4.0.1",
+            },
+            lambda: {
+                "name": "Pykka",
+                "version": "1.1",
+                "path": "/foo/bar",
+                "other": "Quux",
+            },
+            lambda: {
+                "name": "Foo",
+            },
+            lambda: {
+                "name": "Mopidy",
+                "version": "0.13",
+                "dependencies": [
+                    {
+                        "name": "pylast",
+                        "version": "0.5",
+                        "dependencies": [{"name": "setuptools", "version": "0.6"}],
+                    }
                 ],
-            ),
+            },
         ]
 
         result = deps.format_dependency_list(adapters)

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -160,16 +160,6 @@ class TestDeps:
         assert "version" not in result
         assert "path" not in result
 
-    @pytest.mark.skip("Version control missing in metadata")
-    @mock.patch.object(metadata, "distribution")
-    def test_pkg_info_for_wrong_dist_version(self, get_distribution_mock):
-        # get_distribution_mock.side_effect = metadata.VersionConflict
-        result = deps.pkg_info()
-
-        assert result["name"] == "Mopidy"
-        assert "version" not in result
-        assert "path" not in result
-
     @pytest.mark.parametrize("include_transitive_deps", [True, False])
     @pytest.mark.parametrize("include_extras", [True, False])
     def test_pkg_info_real(self, include_transitive_deps, include_extras):

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -54,19 +54,19 @@ class TestDeps:
     def test_executable_info(self):
         result = deps.executable_info()
 
-        assert "Executable" == result["name"]
+        assert result["name"] == "Executable"
         assert sys.argv[0] in result["version"]
 
     def test_platform_info(self):
         result = deps.platform_info()
 
-        assert "Platform" == result["name"]
+        assert result["name"] == "Platform"
         assert platform.platform() in result["version"]
 
     def test_python_info(self):
         result = deps.python_info()
 
-        assert "Python" == result["name"]
+        assert result["name"] == "Python"
         assert platform.python_implementation() in result["version"]
         assert platform.python_version() in result["version"]
         assert "python" in result["path"]
@@ -75,7 +75,7 @@ class TestDeps:
     def test_gstreamer_info(self):
         result = deps.gstreamer_info()
 
-        assert "GStreamer" == result["name"]
+        assert result["name"] == "GStreamer"
         assert ".".join(map(str, Gst.version())) == result["version"]
         assert "gi" in result["path"]
         assert "__init__.py" not in result["path"]
@@ -125,17 +125,17 @@ class TestDeps:
 
         result = deps.pkg_info()
 
-        assert "Mopidy" == result["name"]
-        assert "0.13" == result["version"]
+        assert result["name"] == "Mopidy"
+        assert result["version"] == "0.13"
         assert "mopidy" in result["path"]
 
         dep_info_pykka = result["dependencies"][0]
-        assert "Pykka" == dep_info_pykka["name"]
-        assert "1.1" == dep_info_pykka["version"]
+        assert dep_info_pykka["name"] == "Pykka"
+        assert dep_info_pykka["version"] == "1.1"
 
         dep_info_setuptools = dep_info_pykka["dependencies"][0]
-        assert "setuptools" == dep_info_setuptools["name"]
-        assert "0.6" == dep_info_setuptools["version"]
+        assert dep_info_setuptools["name"] == "setuptools"
+        assert dep_info_setuptools["version"] == "0.6"
 
     @mock.patch.object(metadata, "distribution")
     def test_pkg_info_for_missing_dist(self, get_distribution_mock):
@@ -143,7 +143,7 @@ class TestDeps:
 
         result = deps.pkg_info()
 
-        assert "Mopidy" == result["name"]
+        assert result["name"] == "Mopidy"
         assert "version" not in result
         assert "path" not in result
 
@@ -153,7 +153,7 @@ class TestDeps:
         # get_distribution_mock.side_effect = metadata.VersionConflict
         result = deps.pkg_info()
 
-        assert "Mopidy" == result["name"]
+        assert result["name"] == "Mopidy"
         assert "version" not in result
         assert "path" not in result
 

--- a/tests/internal/test_http.py
+++ b/tests/internal/test_http.py
@@ -11,12 +11,12 @@ URI = "http://example.com/foo.txt"
 BODY = "This is the contents of foo.txt."
 
 
-@pytest.fixture
+@pytest.fixture()
 def session():
     return requests.Session()
 
 
-@pytest.fixture
+@pytest.fixture()
 def session_mock():
     return mock.Mock(spec=requests.Session)
 

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -46,7 +46,7 @@ class Calculator:
 
 
 class JsonRpcTestBase(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.backend = dummy_backend.create_proxy()
         self.calc = Calculator()
 
@@ -69,7 +69,7 @@ class JsonRpcTestBase(unittest.TestCase):
             decoders=[models.model_json_decoder],
         )
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         pykka.ActorRegistry.stop_all()
 
 

--- a/tests/internal/test_log.py
+++ b/tests/internal/test_log.py
@@ -3,7 +3,7 @@ import pytest
 from mopidy.internal import log
 
 
-@pytest.fixture
+@pytest.fixture()
 def config():
     return {
         "verbosity": 2,

--- a/tests/internal/test_network.py
+++ b/tests/internal/test_network.py
@@ -12,7 +12,7 @@ class TryIPv6SocketTest(unittest.TestCase):
     @patch("socket.has_ipv6", True)
     @patch("socket.socket")
     def test_system_with_broken_ipv6(self, socket_mock):
-        socket_mock.side_effect = IOError()
+        socket_mock.side_effect = OSError()
         assert not network.try_ipv6_socket()
 
     @patch("socket.has_ipv6", True)

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -10,10 +10,10 @@ from mopidy.internal.gi import GLib
 
 
 class GetOrCreateDirTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.parent = pathlib.Path(tempfile.mkdtemp()).resolve()
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         if self.parent.is_dir():
             shutil.rmtree(str(self.parent))
 
@@ -58,10 +58,10 @@ class GetOrCreateDirTest(unittest.TestCase):
 
 
 class GetOrCreateFileTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.parent = pathlib.Path(tempfile.mkdtemp()).resolve()
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         if self.parent.is_dir():
             shutil.rmtree(str(self.parent))
 

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -176,7 +176,7 @@ class ExpandPathTest(unittest.TestCase):
     def test_empty_path(self):
         result = path.expand_path("")
 
-        assert result == pathlib.Path(".").resolve()
+        assert result == pathlib.Path().resolve()
 
     def test_absolute_path(self):
         result = path.expand_path("/tmp/foo")

--- a/tests/internal/test_playlists.py
+++ b/tests/internal/test_playlists.py
@@ -85,7 +85,7 @@ EXPECTED = ["file:///tmp/foo", "file:///tmp/bar", "file:///tmp/baz"]
 
 
 @pytest.mark.parametrize(
-    "detect_fn, data",
+    ("detect_fn", "data"),
     [
         (playlists.detect_extm3u_header, EXTM3U),
         (playlists.detect_pls_header, PLS),
@@ -113,7 +113,7 @@ def test_detect_from_invalid_header(detect_fn):
 
 
 @pytest.mark.parametrize(
-    "parse_fn, data",
+    ("parse_fn", "data"),
     [
         (playlists.parse_extm3u, EXTM3U),
         (playlists.parse_pls, PLS),

--- a/tests/internal/test_validation.py
+++ b/tests/internal/test_validation.py
@@ -10,7 +10,7 @@ def test_check_boolean_with_valid_values():
 
 
 def test_check_boolean_with_other_values():
-    for value in 1, 0, None, "", list(), tuple():
+    for value in 1, 0, None, "", [], ():
         with raises(exceptions.ValidationError):
             validation.check_boolean(value)
 
@@ -86,7 +86,7 @@ def test_check_query_valid_values():
 
 
 def test_check_query_random_iterables():
-    for value in None, tuple(), list(), "abc":
+    for value in None, (), [], "abc":
         with raises(exceptions.ValidationError):
             validation.check_query(value)
 
@@ -129,7 +129,7 @@ def test_check_uri_with_valid_values():
 def test_check_uri_with_invalid_values():
     # Note that tuple catches a potential bug with using "'foo' % arg" for
     # formatting.
-    for value in ("foobar", "htt p://example.com", None, 1234, tuple()):
+    for value in ("foobar", "htt p://example.com", None, 1234, ()):
         with raises(exceptions.ValidationError):
             validation.check_uri(value)
 

--- a/tests/internal/test_validation.py
+++ b/tests/internal/test_validation.py
@@ -18,7 +18,7 @@ def test_check_boolean_with_other_values():
 def test_check_boolean_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_boolean(1234)
-    assert "Expected a boolean, not 1234" == str(excinfo.value)
+    assert str(excinfo.value) == "Expected a boolean, not 1234"
 
 
 def test_check_choice_with_valid_values():
@@ -35,7 +35,7 @@ def test_check_choice_with_invalid_values():
 def test_check_choice_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_choice(5, (1, 2, 3))
-    assert "Expected one of (1, 2, 3), not 5" == str(excinfo.value)
+    assert str(excinfo.value) == "Expected one of (1, 2, 3), not 5"
 
 
 def test_check_instance_with_valid_choices():
@@ -52,7 +52,7 @@ def test_check_instance_with_invalid_values():
 def test_check_instance_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_instance(1, dict)
-    assert "Expected a dict instance, not 1" == str(excinfo.value)
+    assert str(excinfo.value) == "Expected a dict instance, not 1"
 
 
 def test_check_instances_with_valid_values():
@@ -77,7 +77,7 @@ def test_check_instances_with_invalid_values():
 def test_check_instances_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_instances([1], str)
-    assert "Expected a list of str, not [1]" == str(excinfo.value)
+    assert str(excinfo.value) == "Expected a list of str, not [1]"
 
 
 def test_check_query_valid_values():
@@ -94,7 +94,7 @@ def test_check_query_random_iterables():
 def test_check_mapping_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_query([])
-    assert "Expected a query dictionary, not []" == str(excinfo.value)
+    assert str(excinfo.value) == "Expected a query dictionary, not []"
 
 
 def test_check_query_invalid_fields():
@@ -137,7 +137,7 @@ def test_check_uri_with_invalid_values():
 def test_check_uri_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_uri("testing")
-    assert "Expected a valid URI, not 'testing'" == str(excinfo.value)
+    assert str(excinfo.value) == "Expected a valid URI, not 'testing'"
 
 
 def test_check_uris_with_valid_values():
@@ -162,4 +162,4 @@ def test_check_uris_with_invalid_values():
 def test_check_uris_error_message():
     with raises(exceptions.ValidationError) as excinfo:
         validation.check_uris("testing")
-    assert "Expected a list of URIs, not 'testing'" == str(excinfo.value)
+    assert str(excinfo.value) == "Expected a list of URIs, not 'testing'"

--- a/tests/internal/test_validation.py
+++ b/tests/internal/test_validation.py
@@ -1,4 +1,4 @@
-from pytest import raises
+import pytest
 
 from mopidy import exceptions
 from mopidy.internal import validation
@@ -11,12 +11,12 @@ def test_check_boolean_with_valid_values():
 
 def test_check_boolean_with_other_values():
     for value in 1, 0, None, "", [], ():
-        with raises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             validation.check_boolean(value)
 
 
 def test_check_boolean_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_boolean(1234)
     assert str(excinfo.value) == "Expected a boolean, not 1234"
 
@@ -28,12 +28,12 @@ def test_check_choice_with_valid_values():
 
 def test_check_choice_with_invalid_values():
     for value, choices in (5, (1, 2, 3)), ("xyz", ("abc", "def")):
-        with raises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             validation.check_choice(value, choices)
 
 
 def test_check_choice_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_choice(5, (1, 2, 3))
     assert str(excinfo.value) == "Expected one of (1, 2, 3), not 5"
 
@@ -45,12 +45,12 @@ def test_check_instance_with_valid_choices():
 
 def test_check_instance_with_invalid_values():
     for value, cls in (1, str), ("abc", int):
-        with raises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             validation.check_instance(value, cls)
 
 
 def test_check_instance_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_instance(1, dict)
     assert str(excinfo.value) == "Expected a dict instance, not 1"
 
@@ -62,20 +62,20 @@ def test_check_instances_with_valid_values():
 
 
 def test_check_instances_with_invalid_values():
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_instances("abc", str)
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_instances(["abc", 123], str)
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_instances(None, str)
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_instances([None], str)
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_instances(iter(["abc"]), str)
 
 
 def test_check_instances_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_instances([1], str)
     assert str(excinfo.value) == "Expected a list of str, not [1]"
 
@@ -87,36 +87,36 @@ def test_check_query_valid_values():
 
 def test_check_query_random_iterables():
     for value in None, (), [], "abc":
-        with raises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             validation.check_query(value)
 
 
 def test_check_mapping_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_query([])
     assert str(excinfo.value) == "Expected a query dictionary, not []"
 
 
 def test_check_query_invalid_fields():
     for value in "wrong", "bar", "foo", "tlid":
-        with raises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             validation.check_query({value: []})
 
 
 def test_check_field_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_query({"wrong": ["abc"]})
     assert "Expected query field to be one of " in str(excinfo.value)
 
 
 def test_check_query_invalid_values():
     for value in "", None, "foo", 123, [""], [None], iter(["abc"]):
-        with raises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             validation.check_query({"any": value})
 
 
 def test_check_values_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_query({"any": "abc"})
     assert 'Expected "any" to be list of strings, not' in str(excinfo.value)
 
@@ -130,12 +130,12 @@ def test_check_uri_with_invalid_values():
     # Note that tuple catches a potential bug with using "'foo' % arg" for
     # formatting.
     for value in ("foobar", "htt p://example.com", None, 1234, ()):
-        with raises(exceptions.ValidationError):
+        with pytest.raises(exceptions.ValidationError):
             validation.check_uri(value)
 
 
 def test_check_uri_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_uri("testing")
     assert str(excinfo.value) == "Expected a valid URI, not 'testing'"
 
@@ -147,19 +147,19 @@ def test_check_uris_with_valid_values():
 
 
 def test_check_uris_with_invalid_values():
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_uris("foobar:")
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_uris(None)
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_uris([None])
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_uris(["foobar:", "foobar"])
-    with raises(exceptions.ValidationError):
+    with pytest.raises(exceptions.ValidationError):
         validation.check_uris(iter(["http://example.com"]))
 
 
 def test_check_uris_error_message():
-    with raises(exceptions.ValidationError) as excinfo:
+    with pytest.raises(exceptions.ValidationError) as excinfo:
         validation.check_uris("testing")
     assert str(excinfo.value) == "Expected a list of URIs, not 'testing'"

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -7,7 +7,7 @@ import pytest
 from mopidy.internal import xdg
 
 
-@pytest.fixture
+@pytest.fixture()
 def environ():
     patcher = mock.patch.dict(os.environ, clear=True)
     yield patcher.start()

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -1,5 +1,5 @@
 import os
-import pathlib
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -15,47 +15,45 @@ def environ():
 
 
 def test_cache_dir_default(environ):
-    assert xdg.get_dirs()["XDG_CACHE_DIR"] == (pathlib.Path("~/.cache").expanduser())
+    assert xdg.get_dirs()["XDG_CACHE_DIR"] == Path("~/.cache").expanduser()
 
 
 def test_cache_dir_from_env(environ):
     os.environ["XDG_CACHE_HOME"] = "/foo/bar"
 
-    assert xdg.get_dirs()["XDG_CACHE_DIR"] == pathlib.Path("/foo/bar")
+    assert xdg.get_dirs()["XDG_CACHE_DIR"] == Path("/foo/bar")
 
 
 def test_config_dir_default(environ):
-    assert xdg.get_dirs()["XDG_CONFIG_DIR"] == (pathlib.Path("~/.config").expanduser())
+    assert xdg.get_dirs()["XDG_CONFIG_DIR"] == Path("~/.config").expanduser()
 
 
 def test_config_dir_from_env(environ):
     os.environ["XDG_CONFIG_HOME"] = "/foo/bar"
 
-    assert xdg.get_dirs()["XDG_CONFIG_DIR"] == pathlib.Path("/foo/bar")
+    assert xdg.get_dirs()["XDG_CONFIG_DIR"] == Path("/foo/bar")
 
 
 def test_data_dir_default(environ):
-    assert xdg.get_dirs()["XDG_DATA_DIR"] == (
-        pathlib.Path("~/.local/share").expanduser()
-    )
+    assert xdg.get_dirs()["XDG_DATA_DIR"] == Path("~/.local/share").expanduser()
 
 
 def test_data_dir_from_env(environ):
     os.environ["XDG_DATA_HOME"] = "/foo/bar"
 
-    assert xdg.get_dirs()["XDG_DATA_DIR"] == pathlib.Path("/foo/bar")
+    assert xdg.get_dirs()["XDG_DATA_DIR"] == Path("/foo/bar")
 
 
 def test_user_dirs(environ, tmpdir):
     os.environ["XDG_CONFIG_HOME"] = str(tmpdir)
 
-    with open(os.path.join(str(tmpdir), "user-dirs.dirs"), "wb") as fh:
+    with (Path(tmpdir) / "user-dirs.dirs").open("wb") as fh:
         fh.write(b"# Some comments\n")
         fh.write(b'XDG_MUSIC_DIR="$HOME/Music2"\n')
 
     result = xdg.get_dirs()
 
-    assert result["XDG_MUSIC_DIR"] == pathlib.Path("~/Music2").expanduser()
+    assert result["XDG_MUSIC_DIR"] == Path("~/Music2").expanduser()
     assert "XDG_DOWNLOAD_DIR" not in result
 
 

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -3,6 +3,7 @@ import platform
 import shutil
 import tempfile
 import unittest
+from typing import Any, ClassVar
 
 import pykka
 
@@ -15,7 +16,7 @@ from tests.m3u import generate_song
 
 class M3UPlaylistsProviderTest(unittest.TestCase):
     backend_class = M3UBackend
-    config = {
+    config: ClassVar[dict[str, dict[str, Any]]] = {
         "m3u": {
             "enabled": True,
             "base_dir": None,

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -25,7 +25,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         }
     }
 
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.config["m3u"]["playlists_dir"] = pathlib.Path(tempfile.mkdtemp())
         self.playlists_dir = self.config["m3u"]["playlists_dir"]
         self.base_dir = self.config["m3u"]["base_dir"] or self.playlists_dir
@@ -34,7 +34,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         backend = M3UBackend.start(config=self.config, audio=audio).proxy()
         self.core = core.Core(config=self.config, backends=[backend])
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         pykka.ActorRegistry.stop_all()
 
         if self.playlists_dir.exists():
@@ -359,6 +359,6 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
 
 class M3UPlaylistsProviderBaseDirectoryTest(M3UPlaylistsProviderTest):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.config["m3u"]["base_dir"] = pathlib.Path(tempfile.mkdtemp())
         super().setUp()

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -46,13 +46,13 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         assert not path.exists()
 
         playlist = self.core.playlists.create("test")
-        assert "test" == playlist.name
+        assert playlist.name == "test"
         assert uri == playlist.uri
         assert path.exists()
 
     def test_create_sanitizes_playlist_name(self):
         playlist = self.core.playlists.create("  ../../test FOO baR ")
-        assert "..|..|test FOO baR" == playlist.name
+        assert playlist.name == "..|..|test FOO baR"
         path = self.playlists_dir / "..|..|test FOO baR.m3u"
         assert self.playlists_dir == path.parent
         assert path.exists()
@@ -65,13 +65,13 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         path2 = self.playlists_dir / "test2.m3u"
 
         playlist = self.core.playlists.create("test1")
-        assert "test1" == playlist.name
+        assert playlist.name == "test1"
         assert uri1 == playlist.uri
         assert path1.exists()
         assert not path2.exists()
 
         playlist = self.core.playlists.save(playlist.replace(name="test2"))
-        assert "test2" == playlist.name
+        assert playlist.name == "test2"
         assert uri2 == playlist.uri
         assert not path1.exists()
         assert path2.exists()
@@ -83,7 +83,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
         assert not path.exists()
 
         playlist = self.core.playlists.create("test")
-        assert "test" == playlist.name
+        assert playlist.name == "test"
         assert uri == playlist.uri
         assert path.exists()
 
@@ -168,7 +168,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.as_list()
-        assert "���" == result[0].name
+        assert result[0].name == "���"
 
     @unittest.SkipTest
     def test_playlists_dir_is_created(self):
@@ -281,7 +281,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.lookup("m3u:test.m3u")
-        assert "m3u:test.m3u" == result.uri
+        assert result.uri == "m3u:test.m3u"
         assert playlist.name == result.name
         assert track.uri == result.tracks[0].uri
 
@@ -294,7 +294,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.lookup("m3u:test.m3u")
-        assert "m3u:test.m3u" == result.uri
+        assert result.uri == "m3u:test.m3u"
         assert playlist.name == result.name
         assert filepath.as_uri() == result.tracks[0].uri
 
@@ -307,7 +307,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         assert len(self.core.playlists.as_list()) == 1
         result = self.core.playlists.lookup("m3u:test.m3u")
-        assert "m3u:test.m3u" == result.uri
+        assert result.uri == "m3u:test.m3u"
         assert playlist.name == result.name
         assert filepath.resolve().as_uri() == result.tracks[0].uri
 

--- a/tests/m3u/test_translator.py
+++ b/tests/m3u/test_translator.py
@@ -118,16 +118,16 @@ def test_dump_items():
     assert dumps([]) == ""
     assert dumps([Ref.track(uri="file:///test.mp3")]) == ("file:///test.mp3\n")
     assert dumps([Ref.track(uri="file:///test.mp3", name="test")]) == (
-        "#EXTM3U\n" "#EXTINF:-1,test\n" "file:///test.mp3\n"
+        "#EXTM3U\n#EXTINF:-1,test\nfile:///test.mp3\n"
     )
     assert dumps([Track(uri="file:///test.mp3", name="test", length=42)]) == (
-        "#EXTM3U\n" "#EXTINF:-1,test\n" "file:///test.mp3\n"
+        "#EXTM3U\n#EXTINF:-1,test\nfile:///test.mp3\n"
     )
     assert dumps([Track(uri="http://example.com/stream")]) == (
         "http://example.com/stream\n"
     )
     assert dumps([Track(uri="http://example.com/stream", name="Test")]) == (
-        "#EXTM3U\n" "#EXTINF:-1,Test\n" "http://example.com/stream\n"
+        "#EXTM3U\n#EXTINF:-1,Test\nhttp://example.com/stream\n"
     )
 
 

--- a/tests/m3u/test_translator.py
+++ b/tests/m3u/test_translator.py
@@ -19,7 +19,7 @@ def dumps(items):
 
 
 @pytest.mark.parametrize(
-    "path,scheme,expected",
+    ("path", "scheme", "expected"),
     [
         ("test", None, "m3u:test"),
         ("test.m3u", None, "m3u:test.m3u"),
@@ -51,7 +51,7 @@ def test_utf8_path_to_uri():
 
 
 @pytest.mark.parametrize(
-    "path,expected",
+    ("path", "expected"),
     [
         ("test", "test"),
         ("test.m3u", "test"),
@@ -72,7 +72,7 @@ def test_path_from_name():
 
 
 @pytest.mark.parametrize(
-    "path,expected",
+    ("path", "expected"),
     [
         ("test.m3u", ("m3u:test.m3u", "test")),
         ("Test Playlist.m3u", ("m3u:Test%20Playlist.m3u", "Test Playlist")),
@@ -86,7 +86,7 @@ def test_path_to_ref(path, expected):
 
 
 @pytest.mark.parametrize(
-    "contents,basedir,expected",
+    ("contents", "basedir", "expected"),
     [
         ("", ".", None),
         ("test.mp3", "/playlists", ("file:///playlists/test.mp3", "test")),

--- a/tests/models/test_fields.py
+++ b/tests/models/test_fields.py
@@ -157,7 +157,7 @@ class IntegerTest(unittest.TestCase):
 
     def test_int_allowed(self):
         instance = create_instance(Integer())
-        instance.attr = int(123)
+        instance.attr = 123
         assert instance.attr == 123
 
     def test_float_disallowed(self):

--- a/tests/models/test_fields.py
+++ b/tests/models/test_fields.py
@@ -21,7 +21,7 @@ class FieldDescriptorTest(unittest.TestCase):
 
     def test_field_knows_its_name(self):
         instance = create_instance(Field())
-        assert "attr" == instance.__class__.attr._name
+        assert instance.__class__.attr._name == "attr"
 
     def test_field_has_none_as_default(self):
         instance = create_instance(Field())
@@ -34,13 +34,13 @@ class FieldDescriptorTest(unittest.TestCase):
     def test_field_assigment_and_retrival(self):
         instance = create_instance(Field())
         instance.attr = 1234
-        assert 1234 == instance.attr
+        assert instance.attr == 1234
 
     def test_field_can_be_reassigned(self):
         instance = create_instance(Field())
         instance.attr = 1234
         instance.attr = 5678
-        assert 5678 == instance.attr
+        assert instance.attr == 5678
 
     def test_field_can_be_deleted(self):
         instance = create_instance(Field())
@@ -68,7 +68,7 @@ class FieldDescriptorTest(unittest.TestCase):
 class FieldTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(Field(default=1234))
-        assert 1234 == instance.attr
+        assert instance.attr == 1234
 
     def test_type_checking(self):
         instance = create_instance(Field(type=set))
@@ -96,17 +96,17 @@ class FieldTest(unittest.TestCase):
 class StringTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(String(default="abc"))
-        assert "abc" == instance.attr
+        assert instance.attr == "abc"
 
     def test_native_str_allowed(self):
         instance = create_instance(String())
         instance.attr = "abc"
-        assert "abc" == instance.attr
+        assert instance.attr == "abc"
 
     def test_unicode_allowed(self):
         instance = create_instance(String())
         instance.attr = "abc"
-        assert "abc" == instance.attr
+        assert instance.attr == "abc"
 
     def test_other_disallowed(self):
         instance = create_instance(String())
@@ -116,28 +116,28 @@ class StringTest(unittest.TestCase):
     def test_empty_string(self):
         instance = create_instance(String())
         instance.attr = ""
-        assert "" == instance.attr
+        assert instance.attr == ""
 
 
 class IdentifierTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(Identifier(default="abc"))
-        assert "abc" == instance.attr
+        assert instance.attr == "abc"
 
     def test_native_str_allowed(self):
         instance = create_instance(Identifier())
         instance.attr = "abc"
-        assert "abc" == instance.attr
+        assert instance.attr == "abc"
 
     def test_unicode_allowed(self):
         instance = create_instance(Identifier())
         instance.attr = "abc"
-        assert "abc" == instance.attr
+        assert instance.attr == "abc"
 
     def test_unicode_with_nonascii_allowed(self):
         instance = create_instance(Identifier())
         instance.attr = "æøå"
-        assert "æøå" == instance.attr
+        assert instance.attr == "æøå"
 
     def test_other_disallowed(self):
         instance = create_instance(Identifier())
@@ -147,18 +147,18 @@ class IdentifierTest(unittest.TestCase):
     def test_empty_string(self):
         instance = create_instance(Identifier())
         instance.attr = ""
-        assert "" == instance.attr
+        assert instance.attr == ""
 
 
 class IntegerTest(unittest.TestCase):
     def test_default_handling(self):
         instance = create_instance(Integer(default=1234))
-        assert 1234 == instance.attr
+        assert instance.attr == 1234
 
     def test_int_allowed(self):
         instance = create_instance(Integer())
         instance.attr = int(123)
-        assert 123 == instance.attr
+        assert instance.attr == 123
 
     def test_float_disallowed(self):
         instance = create_instance(Integer())
@@ -178,7 +178,7 @@ class IntegerTest(unittest.TestCase):
     def test_min_validation(self):
         instance = create_instance(Integer(min=0))
         instance.attr = 0
-        assert 0 == instance.attr
+        assert instance.attr == 0
 
         with self.assertRaises(ValueError):
             instance.attr = -1
@@ -186,7 +186,7 @@ class IntegerTest(unittest.TestCase):
     def test_max_validation(self):
         instance = create_instance(Integer(max=10))
         instance.attr = 10
-        assert 10 == instance.attr
+        assert instance.attr == 10
 
         with self.assertRaises(ValueError):
             instance.attr = 11

--- a/tests/models/test_fields.py
+++ b/tests/models/test_fields.py
@@ -173,7 +173,7 @@ class IntegerTest(unittest.TestCase):
     def test_other_disallowed(self):
         instance = create_instance(String())
         with self.assertRaises(TypeError):
-            instance.attr = tuple()
+            instance.attr = ()
 
     def test_min_validation(self):
         instance = create_instance(Integer(min=0))

--- a/tests/models/test_legacy.py
+++ b/tests/models/test_legacy.py
@@ -30,14 +30,14 @@ class GenericCopyTest(unittest.TestCase):
     def test_copying_model_with_basic_values(self):
         model = Model(name="foo", uri="bar")
         other = model.replace(name="baz")
-        assert "baz" == other.name
-        assert "bar" == other.uri
+        assert other.name == "baz"
+        assert other.uri == "bar"
 
     def test_copying_model_with_missing_values(self):
         model = Model(uri="bar")
         other = model.replace(name="baz")
-        assert "baz" == other.name
-        assert "bar" == other.uri
+        assert other.name == "baz"
+        assert other.uri == "bar"
 
     def test_copying_model_with_private_internal_value(self):
         model = Model(models=[SubModel(name=123)])
@@ -83,12 +83,12 @@ class ModelTest(unittest.TestCase):
             Model(foo="baz")
 
     def test_repr_without_models(self):
-        assert "Model(name='name', uri='uri')" == repr(Model(uri="uri", name="name"))
+        assert repr(Model(uri="uri", name="name")) == "Model(name='name', uri='uri')"
 
     def test_repr_with_models(self):
-        assert "Model(models=[SubModel(name=123)], name='name', uri='uri')" == repr(
+        assert repr(
             Model(uri="uri", name="name", models=[SubModel(name=123)])
-        )
+        ) == "Model(models=[SubModel(name=123)], name='name', uri='uri')"
 
     def test_serialize_without_models(self):
         self.assertDictEqual(

--- a/tests/models/test_legacy.py
+++ b/tests/models/test_legacy.py
@@ -86,9 +86,10 @@ class ModelTest(unittest.TestCase):
         assert repr(Model(uri="uri", name="name")) == "Model(name='name', uri='uri')"
 
     def test_repr_with_models(self):
-        assert repr(
-            Model(uri="uri", name="name", models=[SubModel(name=123)])
-        ) == "Model(models=[SubModel(name=123)], name='name', uri='uri')"
+        assert (
+            repr(Model(uri="uri", name="name", models=[SubModel(name=123)]))
+            == "Model(models=[SubModel(name=123)], name='name', uri='uri')"
+        )
 
     def test_serialize_without_models(self):
         self.assertDictEqual(

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -84,14 +84,14 @@ class GenericReplaceTest(unittest.TestCase):
     def test_replace_track_with_basic_values(self):
         track = Track(name="foo", uri="bar")
         other = track.replace(name="baz")
-        assert "baz" == other.name
-        assert "bar" == other.uri
+        assert other.name == "baz"
+        assert other.uri == "bar"
 
     def test_replace_track_with_missing_values(self):
         track = Track(uri="bar")
         other = track.replace(name="baz")
-        assert "baz" == other.name
-        assert "bar" == other.uri
+        assert other.name == "baz"
+        assert other.uri == "bar"
 
     def test_replace_track_with_private_internal_value(self):
         artist1 = Artist(name="foo")
@@ -135,9 +135,9 @@ class RefTest(unittest.TestCase):
             Ref(foo="baz")
 
     def test_repr_without_results(self):
-        assert "Ref(name='foo', type='artist', uri='uri')" == repr(
+        assert repr(
             Ref(uri="uri", name="foo", type="artist")
-        )
+        ) == "Ref(name='foo', type='artist', uri='uri')"
 
     def test_serialize_without_results(self):
         self.assertDictEqual(
@@ -247,7 +247,7 @@ class ArtistTest(unittest.TestCase):
             Artist(serialize="baz")
 
     def test_repr(self):
-        assert "Artist(name='name', uri='uri')" == repr(Artist(uri="uri", name="name"))
+        assert repr(Artist(uri="uri", name="name")) == "Artist(name='name', uri='uri')"
 
     def test_serialize(self):
         self.assertDictEqual(
@@ -401,12 +401,12 @@ class AlbumTest(unittest.TestCase):
             Album(foo="baz")
 
     def test_repr_without_artists(self):
-        assert "Album(name='name', uri='uri')" == repr(Album(uri="uri", name="name"))
+        assert repr(Album(uri="uri", name="name")) == "Album(name='name', uri='uri')"
 
     def test_repr_with_artists(self):
-        assert "Album(artists=[Artist(name='foo')], name='name', uri='uri')" == repr(
+        assert repr(
             Album(uri="uri", name="name", artists=[Artist(name="foo")])
-        )
+        ) == "Album(artists=[Artist(name='foo')], name='name', uri='uri')"
 
     def test_serialize_without_artists(self):
         self.assertDictEqual(
@@ -657,12 +657,12 @@ class TrackTest(unittest.TestCase):
             Track(foo="baz")
 
     def test_repr_without_artists(self):
-        assert "Track(name='name', uri='uri')" == repr(Track(uri="uri", name="name"))
+        assert repr(Track(uri="uri", name="name")) == "Track(name='name', uri='uri')"
 
     def test_repr_with_artists(self):
-        assert "Track(artists=[Artist(name='foo')], name='name', uri='uri')" == repr(
+        assert repr(
             Track(uri="uri", name="name", artists=[Artist(name="foo")])
-        )
+        ) == "Track(artists=[Artist(name='foo')], name='name', uri='uri')"
 
     def test_serialize_without_artists(self):
         self.assertDictEqual(
@@ -933,9 +933,9 @@ class TlTrackTest(unittest.TestCase):
         assert track2 == track
 
     def test_repr(self):
-        assert "TlTrack(tlid=123, track=Track(uri='uri'))" == repr(
+        assert repr(
             TlTrack(tlid=123, track=Track(uri="uri"))
-        )
+        ) == "TlTrack(tlid=123, track=Track(uri='uri'))"
 
     def test_serialize(self):
         track = Track(uri="uri", name="name")
@@ -1078,14 +1078,14 @@ class PlaylistTest(unittest.TestCase):
             Playlist(foo="baz")
 
     def test_repr_without_tracks(self):
-        assert "Playlist(name='name', uri='uri')" == repr(
+        assert repr(
             Playlist(uri="uri", name="name")
-        )
+        ) == "Playlist(name='name', uri='uri')"
 
     def test_repr_with_tracks(self):
-        assert "Playlist(name='name', tracks=[Track(name='foo')], uri='uri')" == repr(
+        assert repr(
             Playlist(uri="uri", name="name", tracks=[Track(name="foo")])
-        )
+        ) == "Playlist(name='name', tracks=[Track(name='foo')], uri='uri')"
 
     def test_serialize_without_tracks(self):
         self.assertDictEqual(
@@ -1224,7 +1224,7 @@ class SearchResultTest(unittest.TestCase):
             SearchResult(foo="baz")
 
     def test_repr_without_results(self):
-        assert "SearchResult(uri='uri')" == repr(SearchResult(uri="uri"))
+        assert repr(SearchResult(uri="uri")) == "SearchResult(uri='uri')"
 
     def test_serialize_without_results(self):
         self.assertDictEqual(

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -135,9 +135,10 @@ class RefTest(unittest.TestCase):
             Ref(foo="baz")
 
     def test_repr_without_results(self):
-        assert repr(
-            Ref(uri="uri", name="foo", type="artist")
-        ) == "Ref(name='foo', type='artist', uri='uri')"
+        assert (
+            repr(Ref(uri="uri", name="foo", type="artist"))
+            == "Ref(name='foo', type='artist', uri='uri')"
+        )
 
     def test_serialize_without_results(self):
         self.assertDictEqual(
@@ -404,9 +405,10 @@ class AlbumTest(unittest.TestCase):
         assert repr(Album(uri="uri", name="name")) == "Album(name='name', uri='uri')"
 
     def test_repr_with_artists(self):
-        assert repr(
-            Album(uri="uri", name="name", artists=[Artist(name="foo")])
-        ) == "Album(artists=[Artist(name='foo')], name='name', uri='uri')"
+        assert (
+            repr(Album(uri="uri", name="name", artists=[Artist(name="foo")]))
+            == "Album(artists=[Artist(name='foo')], name='name', uri='uri')"
+        )
 
     def test_serialize_without_artists(self):
         self.assertDictEqual(
@@ -660,9 +662,10 @@ class TrackTest(unittest.TestCase):
         assert repr(Track(uri="uri", name="name")) == "Track(name='name', uri='uri')"
 
     def test_repr_with_artists(self):
-        assert repr(
-            Track(uri="uri", name="name", artists=[Artist(name="foo")])
-        ) == "Track(artists=[Artist(name='foo')], name='name', uri='uri')"
+        assert (
+            repr(Track(uri="uri", name="name", artists=[Artist(name="foo")]))
+            == "Track(artists=[Artist(name='foo')], name='name', uri='uri')"
+        )
 
     def test_serialize_without_artists(self):
         self.assertDictEqual(
@@ -933,9 +936,10 @@ class TlTrackTest(unittest.TestCase):
         assert track2 == track
 
     def test_repr(self):
-        assert repr(
-            TlTrack(tlid=123, track=Track(uri="uri"))
-        ) == "TlTrack(tlid=123, track=Track(uri='uri'))"
+        assert (
+            repr(TlTrack(tlid=123, track=Track(uri="uri")))
+            == "TlTrack(tlid=123, track=Track(uri='uri'))"
+        )
 
     def test_serialize(self):
         track = Track(uri="uri", name="name")
@@ -1078,14 +1082,15 @@ class PlaylistTest(unittest.TestCase):
             Playlist(foo="baz")
 
     def test_repr_without_tracks(self):
-        assert repr(
-            Playlist(uri="uri", name="name")
-        ) == "Playlist(name='name', uri='uri')"
+        assert (
+            repr(Playlist(uri="uri", name="name")) == "Playlist(name='name', uri='uri')"
+        )
 
     def test_repr_with_tracks(self):
-        assert repr(
-            Playlist(uri="uri", name="name", tracks=[Track(name="foo")])
-        ) == "Playlist(name='name', tracks=[Track(name='foo')], uri='uri')"
+        assert (
+            repr(Playlist(uri="uri", name="name", tracks=[Track(name="foo")]))
+            == "Playlist(name='name', tracks=[Track(name='foo')], uri='uri')"
+        )
 
     def test_serialize_without_tracks(self):
         self.assertDictEqual(

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -8,7 +8,7 @@ from mopidy.stream import actor
 from tests import path_to_data_dir
 
 
-@pytest.fixture
+@pytest.fixture()
 def config():
     return {
         "proxy": {},
@@ -21,12 +21,12 @@ def config():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def audio():
     return mock.Mock()
 
 
-@pytest.fixture
+@pytest.fixture()
 def track_uri():
     return path.path_to_uri(path_to_data_dir("song1.wav"))
 

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -1,5 +1,5 @@
 import logging
-import os
+from pathlib import Path
 from unittest import mock
 
 import pytest
@@ -240,7 +240,7 @@ class TestTranslateURI:
         responses.add(
             responses.GET,
             PLAYLIST_URI,
-            body=BODY.replace(STREAM_URI, os.path.basename(STREAM_URI)),
+            body=BODY.replace(STREAM_URI, Path(STREAM_URI).name),
             content_type="audio/x-mpegurl",
         )
 
@@ -254,6 +254,6 @@ class TestTranslateURI:
 
         assert (
             f"Parsed playlist ({PLAYLIST_URI}) and found new URI: "
-            f"{os.path.basename(STREAM_URI)}"
+            f"{Path(STREAM_URI).name}"
         ) in caplog.text
         assert f"Unwrapping stream from URI: {STREAM_URI}" in caplog.text

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -20,7 +20,7 @@ http://foo.bar/baz
 """.strip()
 
 
-@pytest.fixture
+@pytest.fixture()
 def config():
     return {
         "proxy": {},
@@ -33,24 +33,24 @@ def config():
     }
 
 
-@pytest.fixture
+@pytest.fixture()
 def audio():
     return mock.Mock()
 
 
-@pytest.fixture
+@pytest.fixture()
 def scanner():
     patcher = mock.patch.object(scan, "Scanner")
     yield patcher.start()()
     patcher.stop()
 
 
-@pytest.fixture
+@pytest.fixture()
 def backend(audio, config, scanner):
     return actor.StreamBackend(audio=audio, config=config)
 
 
-@pytest.fixture
+@pytest.fixture()
 def provider(backend):
     return backend.playback
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -28,12 +28,12 @@ class ConfigOverrideTypeTest(unittest.TestCase):
 
 
 class CommandParsingTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.exit_patcher = mock.patch.object(commands.Command, "exit")
         self.exit_mock = self.exit_patcher.start()
         self.exit_mock.side_effect = SystemExit
 
-    def tearDown(self):  # noqa: N802
+    def tearDown(self):
         self.exit_patcher.stop()
 
     def test_command_parsing_returns_namespace(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -306,7 +306,7 @@ class HelpTest(unittest.TestCase):
         cmd.add_argument("-h", "--help", action="store_true", help="show this message")
 
         expected = (
-            "usage: foo [-h]\n\n" "OPTIONS:\n\n" "  -h, --help  show this message"
+            "usage: foo [-h]\n\nOPTIONS:\n\n  -h, --help  show this message"
         )
         assert expected == cmd.format_help("foo").strip()
 
@@ -327,7 +327,7 @@ class HelpTest(unittest.TestCase):
         cmd = commands.Command()
         cmd.help = "some text about everything this command does."
 
-        expected = "usage: foo\n\n" "some text about everything this command does."
+        expected = "usage: foo\n\nsome text about everything this command does."
         assert expected == cmd.format_help("foo").strip()
 
     def test_command_with_documentation_and_option(self):

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -261,32 +261,32 @@ class UsageTest(unittest.TestCase):
     def test_prog_name_default_and_override(self, argv_mock):
         argv_mock.__getitem__.return_value = "/usr/bin/foo"
         cmd = commands.Command()
-        assert "usage: foo" == cmd.format_usage().strip()
-        assert "usage: baz" == cmd.format_usage("baz").strip()
+        assert cmd.format_usage().strip() == "usage: foo"
+        assert cmd.format_usage("baz").strip() == "usage: baz"
 
     def test_basic_usage(self):
         cmd = commands.Command()
-        assert "usage: foo" == cmd.format_usage("foo").strip()
+        assert cmd.format_usage("foo").strip() == "usage: foo"
 
         cmd.add_argument("-h", "--help", action="store_true")
-        assert "usage: foo [-h]" == cmd.format_usage("foo").strip()
+        assert cmd.format_usage("foo").strip() == "usage: foo [-h]"
 
         cmd.add_argument("bar")
-        assert "usage: foo [-h] bar" == cmd.format_usage("foo").strip()
+        assert cmd.format_usage("foo").strip() == "usage: foo [-h] bar"
 
     def test_nested_usage(self):
         child = commands.Command()
         cmd = commands.Command()
         cmd.add_child("bar", child)
 
-        assert "usage: foo" == cmd.format_usage("foo").strip()
-        assert "usage: foo bar" == cmd.format_usage("foo bar").strip()
+        assert cmd.format_usage("foo").strip() == "usage: foo"
+        assert cmd.format_usage("foo bar").strip() == "usage: foo bar"
 
         cmd.add_argument("-h", "--help", action="store_true")
-        assert "usage: foo bar" == child.format_usage("foo bar").strip()
+        assert child.format_usage("foo bar").strip() == "usage: foo bar"
 
         child.add_argument("-h", "--help", action="store_true")
-        assert "usage: foo bar [-h]" == child.format_usage("foo bar").strip()
+        assert child.format_usage("foo bar").strip() == "usage: foo bar [-h]"
 
 
 class HelpTest(unittest.TestCase):
@@ -294,12 +294,12 @@ class HelpTest(unittest.TestCase):
     def test_prog_name_default_and_override(self, argv_mock):
         argv_mock.__getitem__.return_value = "/usr/bin/foo"
         cmd = commands.Command()
-        assert "usage: foo" == cmd.format_help().strip()
-        assert "usage: bar" == cmd.format_help("bar").strip()
+        assert cmd.format_help().strip() == "usage: foo"
+        assert cmd.format_help("bar").strip() == "usage: bar"
 
     def test_command_without_documenation_or_options(self):
         cmd = commands.Command()
-        assert "usage: bar" == cmd.format_help("bar").strip()
+        assert cmd.format_help("bar").strip() == "usage: bar"
 
     def test_command_with_option(self):
         cmd = commands.Command()
@@ -348,7 +348,7 @@ class HelpTest(unittest.TestCase):
         cmd = commands.Command()
         cmd.add_child("bar", child)
 
-        assert "usage: foo" == cmd.format_help("foo").strip()
+        assert cmd.format_help("foo").strip() == "usage: foo"
 
     def test_subcommand_with_documentation_shown(self):
         child = commands.Command()

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -305,9 +305,7 @@ class HelpTest(unittest.TestCase):
         cmd = commands.Command()
         cmd.add_argument("-h", "--help", action="store_true", help="show this message")
 
-        expected = (
-            "usage: foo [-h]\n\nOPTIONS:\n\n  -h, --help  show this message"
-        )
+        expected = "usage: foo [-h]\n\nOPTIONS:\n\n  -h, --help  show this message"
         assert expected == cmd.format_help("foo").strip()
 
     def test_command_with_option_and_positional(self):

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -90,7 +90,7 @@ class TestLoadExtensions:
         entry_point = mock.Mock()
         entry_point.load = mock.Mock(return_value=DummyExtension)
         iter_entry_points_mock.return_value = [entry_point]
-        yield entry_point
+        return entry_point
 
     def test_no_extensions(self, iter_entry_points_mock):
         assert ext.load_extensions() == []
@@ -157,7 +157,7 @@ class TestValidateExtensionData:
         extension = DummyExtension()
         entry_point = mock.Mock()
         entry_point.name = extension.ext_name
-        yield ext.ExtensionData(
+        return ext.ExtensionData(
             extension,
             entry_point,
             extension.get_config_schema(),

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -183,13 +183,9 @@ class TestValidateExtensionData:
 
     @pytest.mark.skip("Version control missing in metadata")
     def test_version_conflict(self, ext_data):
-        # error = metadata.VersionConflict
         error = metadata.PackageNotFoundError
         ext_data.entry_point.require.side_effect = error
         assert not ext.validate_extension_data(ext_data)
-        # error = metadata.VersionConflict(
-        #     ext_data.extension, "test_expected"
-        # )
         ext_data.entry_point.require.side_effect = error
         assert not ext.validate_extension_data(ext_data)
 

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -27,7 +27,7 @@ any_testextension = IsA(DummyExtension)
 
 
 class TestExtension:
-    @pytest.fixture
+    @pytest.fixture()
     def extension(self):
         class MyExtension(ext.Extension):
             dist_name = "Mopidy-Foo"
@@ -77,7 +77,7 @@ class TestExtension:
 
 
 class TestLoadExtensions:
-    @pytest.fixture
+    @pytest.fixture()
     def iter_entry_points_mock(self, request):
         patcher = mock.patch.object(metadata, "entry_points")
         iter_entry_points = patcher.start()
@@ -85,7 +85,7 @@ class TestLoadExtensions:
         yield iter_entry_points
         patcher.stop()
 
-    @pytest.fixture
+    @pytest.fixture()
     def mock_entry_point(self, iter_entry_points_mock):
         entry_point = mock.Mock()
         entry_point.load = mock.Mock(return_value=DummyExtension)
@@ -152,7 +152,7 @@ class TestLoadExtensions:
 
 
 class TestValidateExtensionData:
-    @pytest.fixture
+    @pytest.fixture()
     def ext_data(self):
         extension = DummyExtension()
         entry_point = mock.Mock()

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -2,20 +2,21 @@ import os
 import subprocess
 import sys
 import unittest
+from pathlib import Path
 
 import mopidy
 
 
 class HelpTest(unittest.TestCase):
     def test_help_has_mopidy_options(self):
-        mopidy_dir = os.path.dirname(mopidy.__file__)
+        mopidy_dir = Path(mopidy.__file__).parent
         args = [sys.executable, mopidy_dir, "--help"]
         process = subprocess.Popen(
             args,
             env={
                 "PYTHONPATH": ":".join(
                     [
-                        os.path.join(mopidy_dir, ".."),
+                        str(mopidy_dir.parent),
                         os.environ.get("PYTHONPATH", ""),
                     ]
                 )

--- a/tests/test_httpclient.py
+++ b/tests/test_httpclient.py
@@ -6,7 +6,7 @@ from mopidy import httpclient
 
 
 @pytest.mark.parametrize(
-    "config,expected",
+    ("config", "expected"),
     [
         ({}, None),
         ({"hostname": ""}, None),
@@ -36,7 +36,7 @@ def test_format_proxy_without_auth():
 
 
 @pytest.mark.parametrize(
-    "name,expected",
+    ("name", "expected"),
     [
         (None, r"^Mopidy/[^ ]+ CPython|/[^ ]+$"),
         ("Foo", r"^Foo Mopidy/[^ ]+ CPython|/[^ ]+$"),

--- a/tests/test_mixer.py
+++ b/tests/test_mixer.py
@@ -5,7 +5,7 @@ from mopidy import mixer
 
 
 class MixerListenerTest(unittest.TestCase):
-    def setUp(self):  # noqa: N802
+    def setUp(self):
         self.listener = mixer.MixerListener()
 
     def test_on_event_forwards_to_specific_handler(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, check-manifest, docs, flake8, pyright
+envlist = py39, py310, py311, check-manifest, docs, pyright, ruff
 
 [testenv]
 sitepackages = true
@@ -19,10 +19,6 @@ deps = .[docs]
 changedir = docs
 commands = python -m sphinx -b html -d {envtmpdir}/doctrees . {envtmpdir}/html
 
-[testenv:flake8]
-deps = .[lint]
-commands = python -m flake8 --show-source --statistics
-
 [testenv:linkcheck]
 deps = .[docs]
 changedir = docs
@@ -34,14 +30,18 @@ deps =
     tornado >= 6  # First version to ship type information
 commands = python -m pyright mopidy
 
+[testenv:ruff]
+deps = .[lint]
+commands = python -m ruff .
+
 [testenv:ci]
 deps =
     {[testenv]deps}
     {[testenv:check-manifest]deps}
-    {[testenv:flake8]deps}
     {[testenv:pyright]deps}
+    {[testenv:ruff]deps}
 commands =
     {[testenv]commands}
     {[testenv:check-manifest]commands}
-    {[testenv:flake8]commands}
     {[testenv:pyright]commands}
+    {[testenv:ruff]commands}


### PR DESCRIPTION
This replaces flake8 and isort with ruff with *a lot* of new rules activated.

The rule setup is based on what I've enabled in other open source projects and at work without too much pain based on what was available in ruff a couple of months ago.

A few additional ignores have been added here. Some of them I think we could try to unignore with time, and I've marked those with a `# TODO` comment in `pyproject.toml`.

`ruff .` on the entire repo runs in about 100ms on my machine, which is reason enough to replace flake8 and isort.