### PR TITLE
Use stdlib's importlib on Python 3.10+

### DIFF
--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import logging
+import sys
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, NamedTuple, Union
 
-import importlib_metadata as metadata
+if sys.version_info < (3, 10):
+    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
+else:
+    from importlib import metadata
 
 from mopidy import config as config_lib
 from mopidy import exceptions

--- a/mopidy/internal/deps.py
+++ b/mopidy/internal/deps.py
@@ -112,15 +112,14 @@ def pkg_info(
                     not include_extras and "extra" in raw
                 ):
                     continue
-                entry = re.match(
-                    "[a-zA-Z0-9_']+", raw
-                ).group()  # pyright: ignore[reportOptionalMemberAccess]
-                dependencies.append(
-                    pkg_info(
-                        entry,
-                        include_transitive_deps=entry != "Mopidy",
+                if match := re.match("[a-zA-Z0-9_-]+", raw):
+                    entry = match.group(0)
+                    dependencies.append(
+                        pkg_info(
+                            entry,
+                            include_transitive_deps=entry != "Mopidy",
+                        )
                     )
-                )
         else:
             dependencies = []
         return {

--- a/mopidy/internal/deps.py
+++ b/mopidy/internal/deps.py
@@ -7,7 +7,10 @@ import re
 import sys
 from typing import TYPE_CHECKING, Callable, Optional, TypedDict
 
-import importlib_metadata as metadata
+if sys.version_info < (3, 10):
+    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
+else:
+    from importlib import metadata
 
 from mopidy.internal import formatting
 from mopidy.internal.gi import Gst, gi

--- a/setup.cfg
+++ b/setup.cfg
@@ -38,7 +38,7 @@ install_requires =
     requests >= 2.0
     setuptools
     tornado >= 4.4
-    importlib_metadata >= 4.6
+    importlib_metadata >= 4.6; python_version < "3.10"
 
 
 [options.extras_require]

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -3,7 +3,11 @@ import sys
 from pathlib import Path
 from unittest import mock
 
-import importlib_metadata as metadata
+if sys.version_info < (3, 10):
+    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
+else:
+    from importlib import metadata
+
 import pytest
 
 from mopidy.internal import deps
@@ -87,7 +91,7 @@ class TestDeps:
             result = deps.gstreamer_info()
             assert "    none" in result["other"]
 
-    @mock.patch("importlib_metadata.distribution")
+    @mock.patch.object(metadata, "distribution")
     def test_pkg_info(self, get_distribution_mock):
         dist_setuptools = mock.MagicMock()
         dist_setuptools.name = "setuptools"
@@ -133,7 +137,7 @@ class TestDeps:
         assert "setuptools" == dep_info_setuptools["name"]
         assert "0.6" == dep_info_setuptools["version"]
 
-    @mock.patch("importlib_metadata.distribution")
+    @mock.patch.object(metadata, "distribution")
     def test_pkg_info_for_missing_dist(self, get_distribution_mock):
         get_distribution_mock.side_effect = metadata.PackageNotFoundError("test")
 
@@ -144,7 +148,7 @@ class TestDeps:
         assert "path" not in result
 
     @pytest.mark.skip("Version control missing in metadata")
-    @mock.patch("importlib_metadata.distribution")
+    @mock.patch.object(metadata, "distribution")
     def test_pkg_info_for_wrong_dist_version(self, get_distribution_mock):
         # get_distribution_mock.side_effect = metadata.VersionConflict
         result = deps.pkg_info()

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,6 +1,11 @@
 import pathlib
-from importlib import metadata
+import sys
 from unittest import mock
+
+if sys.version_info < (3, 10):
+    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
+else:
+    from importlib import metadata
 
 import pytest
 
@@ -74,7 +79,7 @@ class TestExtension:
 class TestLoadExtensions:
     @pytest.fixture
     def iter_entry_points_mock(self, request):
-        patcher = mock.patch("importlib_metadata.entry_points")
+        patcher = mock.patch.object(metadata, "entry_points")
         iter_entry_points = patcher.start()
         iter_entry_points.return_value = []
         yield iter_entry_points


### PR DESCRIPTION
- Use `importlib.metadata` on Python 3.10+, and `importlib_metadata` only as a fallback on older Python versions.
- Fix infinite loop in test case when deps with dash in their name is installed.

FYI @janiversen