### PR TITLE
Type the Core API

### DIFF
--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -15,6 +15,7 @@ from mopidy.audio.constants import PlaybackState
 from mopidy.audio.listener import AudioListener
 from mopidy.internal import process
 from mopidy.internal.gi import GLib, GObject, Gst, GstPbutils
+from mopidy.types import DurationMs, Percentage
 
 if TYPE_CHECKING:
     from mopidy.config import Config
@@ -195,11 +196,11 @@ class SoftwareMixerAdapter:
         self._signals.clear()
         self._mixer.teardown()
 
-    def get_volume(self) -> int:
+    def get_volume(self) -> Percentage:
         assert self._element
-        return int(round(self._element.get_property("volume") * 100))
+        return Percentage(round(self._element.get_property("volume") * 100))
 
-    def set_volume(self, volume: int) -> None:
+    def set_volume(self, volume: Percentage) -> None:
         assert self._element
         self._element.set_property("volume", volume / 100.0)
         self._mixer.trigger_volume_changed(self.get_volume())
@@ -781,7 +782,7 @@ class Audio(pykka.ThreadingActor):
         """
         self._about_to_finish_callback = callback
 
-    def get_position(self) -> int:
+    def get_position(self) -> DurationMs:
         """Get position in milliseconds.
 
         :rtype: int
@@ -794,11 +795,11 @@ class Audio(pykka.ThreadingActor):
             # TODO: take state into account for this and possibly also return
             # None as the unknown value instead of zero?
             logger.debug("Position query failed")
-            return 0
+            return DurationMs(0)
 
         return utils.clocktime_to_millisecond(position)
 
-    def set_position(self, position: int) -> bool:
+    def set_position(self, position: DurationMs) -> bool:
         """Set position in milliseconds.
 
         :param position: the position in milliseconds

--- a/mopidy/audio/listener.py
+++ b/mopidy/audio/listener.py
@@ -1,4 +1,23 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, Literal, Optional
+
 from mopidy import listener
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    from mopidy.audio import PlaybackState
+    from mopidy.types import DurationMs, Uri
+
+
+AudioEvent: TypeAlias = Literal[
+    "position_changed",
+    "reached_end_of_stream",
+    "state_changed",
+    "stream_changed",
+    "tags_changed",
+]
 
 
 class AudioListener(listener.Listener):
@@ -12,17 +31,17 @@ class AudioListener(listener.Listener):
     """
 
     @staticmethod
-    def send(event, **kwargs):
+    def send(event: AudioEvent, **kwargs: Any) -> None:
         """Helper to allow calling of audio listener events."""
         listener.send(AudioListener, event, **kwargs)
 
-    def reached_end_of_stream(self):
+    def reached_end_of_stream(self) -> None:
         """Called whenever the end of the audio stream is reached.
 
         *MAY* be implemented by actor.
         """
 
-    def stream_changed(self, uri):
+    def stream_changed(self, uri: Uri) -> None:
         """Called whenever the audio stream changes.
 
         *MAY* be implemented by actor.
@@ -30,7 +49,7 @@ class AudioListener(listener.Listener):
         :param string uri: URI the stream has started playing.
         """
 
-    def position_changed(self, position):
+    def position_changed(self, position: DurationMs) -> None:
         """Called whenever the position of the stream changes.
 
         *MAY* be implemented by actor.
@@ -38,7 +57,12 @@ class AudioListener(listener.Listener):
         :param int position: Position in milliseconds.
         """
 
-    def state_changed(self, old_state, new_state, target_state):
+    def state_changed(
+        self,
+        old_state: PlaybackState,
+        new_state: PlaybackState,
+        target_state: Optional[PlaybackState],
+    ) -> None:
         """Called after the playback state have changed.
 
         Will be called for both immediate and async state changes in GStreamer.
@@ -56,16 +80,15 @@ class AudioListener(listener.Listener):
         *MAY* be implemented by actor.
 
         :param old_state: the state before the change
-        :type old_state: string from :class:`mopidy.core.PlaybackState` field
+        :type old_state: :class:`mopidy.audio.PlaybackState`
         :param new_state: the state after the change
-        :type new_state: A :class:`mopidy.core.PlaybackState` field
-        :type new_state: string from :class:`mopidy.core.PlaybackState` field
+        :type new_state: :class:`mopidy.audio.PlaybackState`
         :param target_state: the intended state
-        :type target_state: string from :class:`mopidy.core.PlaybackState`
-            field or :class:`None` if this is a final state.
+        :type target_state: :class:`mopidy.audio.PlaybackState`
+            or :class:`None` if this is a final state.
         """
 
-    def tags_changed(self, tags):
+    def tags_changed(self, tags: set[str]) -> None:
         """Called whenever the current audio stream's tags change.
 
         This event signals that some track metadata has been updated. This can

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -4,7 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 from mopidy import httpclient
 from mopidy.internal.gi import Gst
-from mopidy.types import UriScheme
+from mopidy.types import DurationMs, UriScheme
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -12,14 +12,14 @@ if TYPE_CHECKING:
     from mopidy.config import ProxyConfig
 
 
-def millisecond_to_clocktime(value: int) -> int:
+def millisecond_to_clocktime(value: DurationMs) -> int:
     """Convert a millisecond time to internal GStreamer time."""
     return value * Gst.MSECOND
 
 
-def clocktime_to_millisecond(value: int) -> int:
+def clocktime_to_millisecond(value: int) -> DurationMs:
     """Convert an internal GStreamer time to millisecond time."""
-    return value // Gst.MSECOND
+    return DurationMs(value // Gst.MSECOND)
 
 
 def supported_uri_schemes(uri_schemes: Iterable[UriScheme]) -> set[UriScheme]:

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -34,9 +34,10 @@ def supported_uri_schemes(uri_schemes: Iterable[UriScheme]) -> set[UriScheme]:
 
     for factory in registry.get_feature_list(Gst.ElementFactory):
         factory = cast(Gst.ElementFactory, factory)
-        for uri in factory.get_uri_protocols():
-            if uri in uri_schemes:
-                supported_schemes.add(uri)
+        for uri_protocol in factory.get_uri_protocols():
+            uri_scheme = UriScheme(uri_protocol)
+            if uri_scheme in uri_schemes:
+                supported_schemes.add(uri_scheme)
 
     return supported_schemes
 

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -4,6 +4,7 @@ from typing import TYPE_CHECKING, Any, Callable, cast
 
 from mopidy import httpclient
 from mopidy.internal.gi import Gst
+from mopidy.types import UriScheme
 
 if TYPE_CHECKING:
     from collections.abc import Iterable
@@ -21,7 +22,7 @@ def clocktime_to_millisecond(value: int) -> int:
     return value // Gst.MSECOND
 
 
-def supported_uri_schemes(uri_schemes: Iterable[str]) -> set[str]:
+def supported_uri_schemes(uri_schemes: Iterable[UriScheme]) -> set[UriScheme]:
     """Determine which URIs we can actually support from provided whitelist.
 
     :param uri_schemes: list/set of URIs to check support for.

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -109,7 +109,7 @@ class LibraryProvider:
         return []
 
     def get_distinct(
-        self, field: DistinctField, query: Optional[Query[DistinctField]] = None
+        self, field: DistinctField, query: Optional[Query[SearchField]] = None
     ) -> set[str]:
         """See :meth:`mopidy.core.LibraryController.get_distinct`.
 

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Literal, Optional
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
@@ -11,10 +11,19 @@ from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
 from mopidy import listener
 
 if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
     from mopidy.audio.actor import AudioProxy
     from mopidy.internal.gi import Gst
     from mopidy.models import Image, Playlist, Ref, SearchResult, Track
-    from mopidy.types import DistinctField, Query, SearchField, Uri, UriScheme
+    from mopidy.types import (
+        DistinctField,
+        DurationMs,
+        Query,
+        SearchField,
+        Uri,
+        UriScheme,
+    )
 
 
 logger = logging.getLogger(__name__)
@@ -295,7 +304,7 @@ class PlaybackProvider:
         """
         return self.audio.start_playback().get()
 
-    def seek(self, time_position: int) -> bool:
+    def seek(self, time_position: DurationMs) -> bool:
         """Seek to a given time position.
 
         *MAY be reimplemented by subclass.*
@@ -318,7 +327,7 @@ class PlaybackProvider:
         """
         return self.audio.stop_playback().get()
 
-    def get_time_position(self) -> int:
+    def get_time_position(self) -> DurationMs:
         """Get the current time position in milliseconds.
 
         *MAY be reimplemented by subclass.*
@@ -437,6 +446,9 @@ class PlaylistsProvider:
         raise NotImplementedError
 
 
+BackendEvent: TypeAlias = Literal["playlists_loaded"]
+
+
 class BackendListener(listener.Listener):
     """Marker interface for recipients of events sent by the backend actors.
 
@@ -450,7 +462,7 @@ class BackendListener(listener.Listener):
     """
 
     @staticmethod
-    def send(event: str, **kwargs: Any) -> None:
+    def send(event: BackendEvent, **kwargs: Any) -> None:
         """Helper to allow calling of backend listener events."""
         listener.send(BackendListener, event, **kwargs)
 

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional, TypeVar, Union
+from typing import TYPE_CHECKING, Any, Optional
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
@@ -14,37 +14,7 @@ if TYPE_CHECKING:
     from mopidy.audio.actor import AudioProxy
     from mopidy.internal.gi import Gst
     from mopidy.models import Image, Playlist, Ref, SearchResult, Track
-
-# TODO Fix duplication with mopidy.core.library.DistinctField and
-# mopidy.internal.validation.TRACK_FIELDS_WITH_TYPES
-TrackField = Literal[
-    "uri",
-    "track_name",
-    "album",
-    "artist",
-    "albumartist",
-    "composer",
-    "performer",
-    "track_no",
-    "genre",
-    "date",
-    "comment",
-    "disc_no",
-    "musicbrainz_albumid",
-    "musicbrainz_artistid",
-    "musicbrainz_trackid",
-]
-
-SearchField = Literal[TrackField, "any"]
-
-DistinctField = TrackField
-
-F = TypeVar("F")
-QueryValue = Union[str, int]
-Query = dict[F, list[QueryValue]]
-
-Uri = str
-UriScheme = str
+    from mopidy.types import DistinctField, Query, SearchField, Uri, UriScheme
 
 
 logger = logging.getLogger(__name__)

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
     from mopidy.internal.gi import Gst
     from mopidy.models import Image, Playlist, Ref, SearchResult, Track
 
-# TODO Fix duplication with mopidy.internal.validation.TRACK_FIELDS_WITH_TYPES
+# TODO Fix duplication with mopidy.core.library.DistinctField and
+# mopidy.internal.validation.TRACK_FIELDS_WITH_TYPES
 TrackField = Literal[
     "uri",
     "track_name",

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -27,6 +27,7 @@ from mopidy.core import Core, CoreProxy
 from mopidy.internal import deps, process, timer, versioning
 from mopidy.internal.gi import GLib
 from mopidy.mixer import MixerActor, MixerProxy
+from mopidy.types import Percentage
 
 if TYPE_CHECKING:
     from collections.abc import Generator, Iterable, Sequence
@@ -424,7 +425,7 @@ class RootCommand(Command):
     ) -> None:
         volume = config["audio"]["mixer_volume"]
         if volume is not None:
-            mixer.set_volume(volume)
+            mixer.set_volume(Percentage(volume))
             logger.info("Mixer volume set to %d", volume)
         else:
             logger.debug("Mixer volume left unchanged")

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -114,7 +114,7 @@ class Core(
         self,
         old_state: PlaybackState,
         new_state: PlaybackState,
-        target_state: PlaybackState,
+        target_state: Optional[PlaybackState],
     ) -> None:
         # XXX: This is a temporary fix for issue #232 while we wait for a more
         # permanent solution with the implementation of issue #234. When the

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+from collections.abc import Iterable
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
@@ -65,7 +66,7 @@ class Core(
         config: Config,
         *,
         mixer: Optional[mixer.MixerProxy] = None,
-        backends: list[backend.BackendProxy],
+        backends: Iterable[backend.BackendProxy],
         audio: Optional[audio.AudioProxy] = None,
     ) -> None:
         super().__init__()
@@ -220,7 +221,7 @@ class Core(
         storage.dump(state_file, data)
         logger.debug("Saving state done")
 
-    def _load_state(self, coverage: list[str]) -> None:
+    def _load_state(self, coverage: Iterable[str]) -> None:
         """Restore state from disk.
 
         Load state from disk and restore it. Parameter ``coverage``
@@ -259,7 +260,7 @@ class Core(
 
 
 class Backends(list):
-    def __init__(self, backends: list[backend.BackendProxy]) -> None:
+    def __init__(self, backends: Iterable[backend.BackendProxy]) -> None:
         super().__init__(backends)
 
         self.with_library: dict[backend.UriScheme, backend.BackendProxy] = {}

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -31,6 +31,7 @@ if TYPE_CHECKING:
     from mopidy.core.playback import PlaybackControllerProxy
     from mopidy.core.playlists import PlaylistsControllerProxy
     from mopidy.core.tracklist import TracklistControllerProxy
+    from mopidy.types import Uri
 
 logger = logging.getLogger(__name__)
 
@@ -102,7 +103,7 @@ class Core(
     def reached_end_of_stream(self) -> None:
         self.playback._on_end_of_stream()
 
-    def stream_changed(self, uri: str) -> None:
+    def stream_changed(self, uri: Uri) -> None:
         self.playback._on_stream_changed(uri)
 
     def position_changed(self, position: int) -> None:

--- a/mopidy/core/actor.py
+++ b/mopidy/core/actor.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import itertools
 import logging
+from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
 import pykka
@@ -101,10 +102,10 @@ class Core(
     def reached_end_of_stream(self) -> None:
         self.playback._on_end_of_stream()
 
-    def stream_changed(self, uri) -> None:
+    def stream_changed(self, uri: str) -> None:
         self.playback._on_stream_changed(uri)
 
-    def position_changed(self, position) -> None:
+    def position_changed(self, position: int) -> None:
         self.playback._on_position_changed(position)
 
     def state_changed(
@@ -130,37 +131,37 @@ class Core(
             self.playback.set_state(new_state)
             self.playback._trigger_track_playback_paused()
 
-    def playlists_loaded(self):
+    def playlists_loaded(self) -> None:
         # Forward event from backend to frontends
         CoreListener.send("playlists_loaded")
 
-    def volume_changed(self, volume):
+    def volume_changed(self, volume: int) -> None:
         # Forward event from mixer to frontends
         CoreListener.send("volume_changed", volume=volume)
 
-    def mute_changed(self, mute):
+    def mute_changed(self, mute: bool) -> None:
         # Forward event from mixer to frontends
         CoreListener.send("mute_changed", mute=mute)
 
-    def tags_changed(self, tags):
+    def tags_changed(self, tags: set[str]) -> None:
         if not self.audio or "title" not in tags:
             return
 
-        tags = self.audio.get_current_tags().get()
-        if not tags:
+        current_tags = self.audio.get_current_tags().get()
+        if not current_tags:
             return
 
         self.playback._stream_title = None
         # TODO: Do not emit stream title changes for plain tracks. We need a
         # better way to decide if something is a stream.
-        if "title" in tags and tags["title"]:
-            title = tags["title"][0]
+        if "title" in current_tags and current_tags["title"]:
+            title = current_tags["title"][0]
             current_track = self.playback.get_current_track()
             if current_track is not None and current_track.name != title:
                 self.playback._stream_title = title
                 CoreListener.send("stream_title_changed", title=title)
 
-    def _setup(self):
+    def _setup(self) -> None:
         """Do not call this function. It is for internal use at startup."""
         try:
             coverage = []
@@ -181,7 +182,7 @@ class Core(
         except Exception as e:
             logger.warning("Restore state: Unexpected error: %s", str(e))
 
-    def _teardown(self):
+    def _teardown(self) -> None:
         """Do not call this function. It is for internal use at shutdown."""
         try:
             if (
@@ -193,16 +194,16 @@ class Core(
         except Exception as e:
             logger.warning("Unexpected error while saving state: %s", str(e))
 
-    def _get_data_dir(self):
+    def _get_data_dir(self) -> Path:
         # get or create data director for core
         data_dir_path = path.expand_path(self._config["core"]["data_dir"]) / "core"
         path.get_or_create_dir(data_dir_path)
         return data_dir_path
 
-    def _get_state_file(self):
+    def _get_state_file(self) -> Path:
         return self._get_data_dir() / "state.json.gz"
 
-    def _save_state(self):
+    def _save_state(self) -> None:
         """Save current state to disk."""
         state_file = self._get_state_file()
         logger.info("Saving state to %s", state_file)
@@ -218,7 +219,7 @@ class Core(
         storage.dump(state_file, data)
         logger.debug("Saving state done")
 
-    def _load_state(self, coverage):
+    def _load_state(self, coverage: list[str]) -> None:
         """Restore state from disk.
 
         Load state from disk and restore it. Parameter ``coverage``
@@ -257,7 +258,7 @@ class Core(
 
 
 class Backends(list):
-    def __init__(self, backends: list[backend.BackendProxy]):
+    def __init__(self, backends: list[backend.BackendProxy]) -> None:
         super().__init__(backends)
 
         self.with_library: dict[backend.UriScheme, backend.BackendProxy] = {}

--- a/mopidy/core/history.py
+++ b/mopidy/core/history.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import copy
 import logging
 import time
+from collections.abc import Iterable
 from typing import TYPE_CHECKING
 
 from mopidy.internal.models import HistoryState, HistoryTrack
@@ -76,7 +77,7 @@ class HistoryController:
                 break
         return HistoryState(history=history_list)
 
-    def _load_state(self, state: HistoryState, coverage: list[str]) -> None:
+    def _load_state(self, state: HistoryState, coverage: Iterable[str]) -> None:
         if state and "history" in coverage:
             self._history = [(h.timestamp, h.track) for h in state.history]
 

--- a/mopidy/core/history.py
+++ b/mopidy/core/history.py
@@ -1,19 +1,26 @@
+from __future__ import annotations
+
 import copy
 import logging
 import time
 from typing import TYPE_CHECKING
 
-from mopidy import models
 from mopidy.internal.models import HistoryState, HistoryTrack
+from mopidy.models import Ref, Track
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
 
 logger = logging.getLogger(__name__)
 
+History: TypeAlias = list[tuple[int, Ref]]
+
 
 class HistoryController:
-    def __init__(self):
-        self._history = []
+    def __init__(self) -> None:
+        self._history: History = []
 
-    def _add_track(self, track):
+    def _add_track(self, track: Track) -> None:
         """Add track to the playback history.
 
         Internal method for :class:`mopidy.core.PlaybackController`.
@@ -21,7 +28,7 @@ class HistoryController:
         :param track: track to add
         :type track: :class:`mopidy.models.Track`
         """
-        if not isinstance(track, models.Track):
+        if not isinstance(track, Track):
             raise TypeError("Only Track objects can be added to the history")
 
         timestamp = int(time.time() * 1000)
@@ -34,11 +41,11 @@ class HistoryController:
         if track.name is not None:
             name_parts.append(track.name)
         name = " - ".join(name_parts)
-        ref = models.Ref.track(uri=track.uri, name=name)
+        ref = Ref.track(uri=track.uri, name=name)
 
         self._history.insert(0, (timestamp, ref))
 
-    def get_length(self):
+    def get_length(self) -> int:
         """Get the number of tracks in the history.
 
         :returns: the history length
@@ -46,7 +53,7 @@ class HistoryController:
         """
         return len(self._history)
 
-    def get_history(self):
+    def get_history(self) -> History:
         """Get the track history.
 
         The timestamps are milliseconds since epoch.
@@ -56,7 +63,7 @@ class HistoryController:
         """
         return copy.copy(self._history)
 
-    def _save_state(self):
+    def _save_state(self) -> HistoryState:
         # 500 tracks a 3 minutes -> 24 hours history
         count_max = 500
         count = 1
@@ -69,7 +76,7 @@ class HistoryController:
                 break
         return HistoryState(history=history_list)
 
-    def _load_state(self, state, coverage):
+    def _load_state(self, state: HistoryState, coverage: list[str]) -> None:
         if state and "history" in coverage:
             self._history = [(h.timestamp, h.track) for h in state.history]
 

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING, Any, Optional, Union, cast
 from mopidy import exceptions
 from mopidy.internal import deprecation, validation
 from mopidy.models import Image, Ref, SearchResult, Track
-from mopidy.types import DistinctField, Query, SearchField, Uri
+from mopidy.types import DistinctField, Query, SearchField, Uri, UriScheme
 
 if TYPE_CHECKING:
     from mopidy.backend import BackendProxy
@@ -48,7 +48,7 @@ class LibraryController:
         self.core = core
 
     def _get_backend(self, uri: Uri) -> Optional[BackendProxy]:
-        uri_scheme = urllib.parse.urlparse(uri).scheme
+        uri_scheme = UriScheme(urllib.parse.urlparse(uri).scheme)
         return self.backends.with_library.get(uri_scheme, None)
 
     def _get_backends_to_uris(
@@ -118,7 +118,7 @@ class LibraryController:
         return sorted(directories, key=operator.attrgetter("name"))
 
     def _browse(self, uri: Uri) -> list[Ref]:
-        scheme = urllib.parse.urlparse(uri).scheme
+        scheme = UriScheme(urllib.parse.urlparse(uri).scheme)
         backend = self.backends.with_library_browse.get(scheme)
 
         if not backend:

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -134,7 +134,7 @@ class LibraryController:
     def get_distinct(
         self,
         field: DistinctField,
-        query: Optional[Query[DistinctField]] = None,
+        query: Optional[Query[SearchField]] = None,
     ) -> set[Any]:
         """List distinct values for a given field from the library.
 

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -5,7 +5,7 @@ import contextlib
 import logging
 import operator
 import urllib.parse
-from collections.abc import Generator, Mapping
+from collections.abc import Generator, Iterable, Mapping
 from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from mopidy import exceptions
@@ -53,7 +53,7 @@ class LibraryController:
 
     def _get_backends_to_uris(
         self,
-        uris: Optional[list[Uri]],
+        uris: Optional[Iterable[Uri]],
     ) -> dict[BackendProxy, Optional[list[Uri]]]:
         if not uris:
             return {b: None for b in self.backends.with_library.values()}
@@ -181,7 +181,7 @@ class LibraryController:
                     result.update(values)
         return result
 
-    def get_images(self, uris: list[Uri]) -> dict[Uri, tuple[Image, ...]]:
+    def get_images(self, uris: Iterable[Uri]) -> dict[Uri, tuple[Image, ...]]:
         """Lookup the images for the given URIs.
 
         Backends can use this to return image URIs for any URI they know about
@@ -220,7 +220,7 @@ class LibraryController:
                     results[uri] += tuple(images)
         return results
 
-    def lookup(self, uris: list[Uri]) -> dict[Uri, list[Track]]:
+    def lookup(self, uris: Iterable[Uri]) -> dict[Uri, list[Track]]:
         """Lookup the given URIs.
 
         If the URI expands to multiple tracks, the returned list will contain
@@ -279,7 +279,7 @@ class LibraryController:
     def search(
         self,
         query: Query[SearchField],
-        uris: Optional[list[Uri]] = None,
+        uris: Optional[Iterable[Uri]] = None,
         exact: bool = False,
     ) -> list[SearchResult]:
         """Search the library for tracks where ``field`` contains ``values``.

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -6,38 +6,16 @@ import logging
 import operator
 import urllib.parse
 from collections.abc import Generator, Mapping
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 from mopidy import exceptions
 from mopidy.internal import deprecation, validation
 from mopidy.models import Image, Ref, SearchResult, Track
+from mopidy.types import DistinctField, Query, SearchField
 
 if TYPE_CHECKING:
     from mopidy.backend import BackendProxy
     from mopidy.core.actor import Backends, Core
-
-
-# TODO Fix duplication with mopidy.backend.DistinctField and
-# mopidy.internal.validation.TRACK_FIELDS_WITH_TYPES
-DistinctField = Literal[
-    "uri",
-    "track_name",
-    "album",
-    "artist",
-    "albumartist",
-    "composer",
-    "performer",
-    "track_no",
-    "genre",
-    "date",
-    "comment",
-    "disc_no",
-    "musicbrainz_albumid",
-    "musicbrainz_artistid",
-    "musicbrainz_trackid",
-]
-SearchField = Union[DistinctField, Literal["any"]]
-SearchQuery = dict[SearchField, list[str]]
 
 logger = logging.getLogger(__name__)
 
@@ -155,8 +133,8 @@ class LibraryController:
 
     def get_distinct(
         self,
-        field: SearchField,
-        query: Optional[SearchQuery] = None,
+        field: DistinctField,
+        query: Optional[Query[DistinctField]] = None,
     ) -> set[Any]:
         """List distinct values for a given field from the library.
 
@@ -300,7 +278,7 @@ class LibraryController:
 
     def search(
         self,
-        query: SearchQuery,
+        query: Query[SearchField],
         uris: Optional[list[str]] = None,
         exact: bool = False,
     ) -> list[SearchResult]:
@@ -385,7 +363,7 @@ class LibraryController:
         return results
 
 
-def _normalize_query(query: SearchQuery) -> SearchQuery:
+def _normalize_query(query: Query[SearchField]) -> Query[SearchField]:
     broken_client = False
     # TODO: this breaks if query is not a dictionary like object...
     for field, values in query.items():

--- a/mopidy/core/listener.py
+++ b/mopidy/core/listener.py
@@ -7,6 +7,7 @@ from mopidy import listener
 if TYPE_CHECKING:
     from mopidy.audio import PlaybackState
     from mopidy.models import Playlist, TlTrack
+    from mopidy.types import Uri
 
 
 class CoreListener(listener.Listener):
@@ -115,7 +116,7 @@ class CoreListener(listener.Listener):
         :type playlist: :class:`mopidy.models.Playlist`
         """
 
-    def playlist_deleted(self, uri: str) -> None:
+    def playlist_deleted(self, uri: Uri) -> None:
         """Called whenever a playlist is deleted.
 
         *MAY* be implemented by actor.

--- a/mopidy/core/listener.py
+++ b/mopidy/core/listener.py
@@ -1,4 +1,12 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
 from mopidy import listener
+
+if TYPE_CHECKING:
+    from mopidy.audio import PlaybackState
+    from mopidy.models import Playlist, TlTrack
 
 
 class CoreListener(listener.Listener):
@@ -12,11 +20,11 @@ class CoreListener(listener.Listener):
     """
 
     @staticmethod
-    def send(event, **kwargs):
+    def send(event: str, **kwargs: Any) -> None:
         """Helper to allow calling of core listener events."""
         listener.send(CoreListener, event, **kwargs)
 
-    def on_event(self, event, **kwargs):
+    def on_event(self, event: str, **kwargs: Any) -> None:
         """Called on all events.
 
         *MAY* be implemented by actor. By default, this method forwards the
@@ -29,7 +37,7 @@ class CoreListener(listener.Listener):
         # Just delegate to parent, entry mostly for docs.
         super().on_event(event, **kwargs)
 
-    def track_playback_paused(self, tl_track, time_position):
+    def track_playback_paused(self, tl_track: TlTrack, time_position: int) -> None:
         """Called whenever track playback is paused.
 
         *MAY* be implemented by actor.
@@ -40,7 +48,7 @@ class CoreListener(listener.Listener):
         :type time_position: int
         """
 
-    def track_playback_resumed(self, tl_track, time_position):
+    def track_playback_resumed(self, tl_track: TlTrack, time_position: int) -> None:
         """Called whenever track playback is resumed.
 
         *MAY* be implemented by actor.
@@ -51,7 +59,7 @@ class CoreListener(listener.Listener):
         :type time_position: int
         """
 
-    def track_playback_started(self, tl_track):
+    def track_playback_started(self, tl_track: TlTrack) -> None:
         """Called whenever a new track starts playing.
 
         *MAY* be implemented by actor.
@@ -60,7 +68,7 @@ class CoreListener(listener.Listener):
         :type tl_track: :class:`mopidy.models.TlTrack`
         """
 
-    def track_playback_ended(self, tl_track, time_position):
+    def track_playback_ended(self, tl_track: TlTrack, time_position: int) -> None:
         """Called whenever playback of a track ends.
 
         *MAY* be implemented by actor.
@@ -71,7 +79,11 @@ class CoreListener(listener.Listener):
         :type time_position: int
         """
 
-    def playback_state_changed(self, old_state, new_state):
+    def playback_state_changed(
+        self,
+        old_state: PlaybackState,
+        new_state: PlaybackState,
+    ) -> None:
         """Called whenever playback state is changed.
 
         *MAY* be implemented by actor.
@@ -82,19 +94,19 @@ class CoreListener(listener.Listener):
         :type new_state: string from :class:`mopidy.core.PlaybackState` field
         """
 
-    def tracklist_changed(self):
+    def tracklist_changed(self) -> None:
         """Called whenever the tracklist is changed.
 
         *MAY* be implemented by actor.
         """
 
-    def playlists_loaded(self):
+    def playlists_loaded(self) -> None:
         """Called when playlists are loaded or refreshed.
 
         *MAY* be implemented by actor.
         """
 
-    def playlist_changed(self, playlist):
+    def playlist_changed(self, playlist: Playlist) -> None:
         """Called whenever a playlist is changed.
 
         *MAY* be implemented by actor.
@@ -103,7 +115,7 @@ class CoreListener(listener.Listener):
         :type playlist: :class:`mopidy.models.Playlist`
         """
 
-    def playlist_deleted(self, uri):
+    def playlist_deleted(self, uri: str) -> None:
         """Called whenever a playlist is deleted.
 
         *MAY* be implemented by actor.
@@ -112,13 +124,13 @@ class CoreListener(listener.Listener):
         :type uri: string
         """
 
-    def options_changed(self):
+    def options_changed(self) -> None:
         """Called whenever an option is changed.
 
         *MAY* be implemented by actor.
         """
 
-    def volume_changed(self, volume):
+    def volume_changed(self, volume: int) -> None:
         """Called whenever the volume is changed.
 
         *MAY* be implemented by actor.
@@ -127,7 +139,7 @@ class CoreListener(listener.Listener):
         :type volume: int
         """
 
-    def mute_changed(self, mute):
+    def mute_changed(self, mute: bool) -> None:
         """Called whenever the mute state is changed.
 
         *MAY* be implemented by actor.
@@ -136,7 +148,7 @@ class CoreListener(listener.Listener):
         :type mute: boolean
         """
 
-    def seeked(self, time_position):
+    def seeked(self, time_position: int) -> None:
         """Called whenever the time position changes by an unexpected amount, e.g.
         at seek to a new time position.
 
@@ -146,7 +158,7 @@ class CoreListener(listener.Listener):
         :type time_position: int
         """
 
-    def stream_title_changed(self, title):
+    def stream_title_changed(self, title: str) -> None:
         """Called whenever the currently playing stream title changes.
 
         *MAY* be implemented by actor.

--- a/mopidy/core/mixer.py
+++ b/mopidy/core/mixer.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Iterable
 from typing import TYPE_CHECKING, Any, Optional
 
 from mopidy import exceptions
@@ -113,7 +113,7 @@ class MixerController:
     def _save_state(self) -> MixerState:
         return MixerState(volume=self.get_volume(), mute=self.get_mute())
 
-    def _load_state(self, state: MixerState, coverage: list[str]) -> None:
+    def _load_state(self, state: MixerState, coverage: Iterable[str]) -> None:
         if state and "mixer" in coverage:
             self.set_mute(state.mute)
             if state.volume:

--- a/mopidy/core/mixer.py
+++ b/mopidy/core/mixer.py
@@ -8,6 +8,7 @@ from typing import TYPE_CHECKING, Any, Optional
 from mopidy import exceptions
 from mopidy.internal import validation
 from mopidy.internal.models import MixerState
+from mopidy.types import Percentage
 
 if TYPE_CHECKING:
     from mopidy.mixer import MixerProxy
@@ -36,7 +37,7 @@ class MixerController:
     def __init__(self, mixer: Optional[MixerProxy]) -> None:
         self._mixer = mixer
 
-    def get_volume(self) -> Optional[int]:
+    def get_volume(self) -> Optional[Percentage]:
         """Get the volume.
 
         Integer in range [0..100] or :class:`None` if unknown.
@@ -54,7 +55,7 @@ class MixerController:
 
         return None
 
-    def set_volume(self, volume: int) -> bool:
+    def set_volume(self, volume: Percentage) -> bool:
         """Set the volume.
 
         The volume is defined as an integer in range [0..100].
@@ -117,7 +118,7 @@ class MixerController:
         if state and "mixer" in coverage:
             self.set_mute(state.mute)
             if state.volume:
-                self.set_volume(state.volume)
+                self.set_volume(Percentage(state.volume))
 
 
 if TYPE_CHECKING:

--- a/mopidy/core/mixer.py
+++ b/mopidy/core/mixer.py
@@ -2,7 +2,8 @@ from __future__ import annotations
 
 import contextlib
 import logging
-from typing import TYPE_CHECKING, Optional
+from collections.abc import Generator
+from typing import TYPE_CHECKING, Any, Optional
 
 from mopidy import exceptions
 from mopidy.internal import validation
@@ -15,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 
 @contextlib.contextmanager
-def _mixer_error_handling(mixer):
+def _mixer_error_handling(mixer: MixerProxy) -> Generator[None, Any, None]:
     try:
         yield
     except exceptions.ValidationError as e:
@@ -32,10 +33,10 @@ def _mixer_error_handling(mixer):
 
 
 class MixerController:
-    def __init__(self, mixer: Optional[MixerProxy]):
+    def __init__(self, mixer: Optional[MixerProxy]) -> None:
         self._mixer = mixer
 
-    def get_volume(self):
+    def get_volume(self) -> Optional[int]:
         """Get the volume.
 
         Integer in range [0..100] or :class:`None` if unknown.
@@ -53,7 +54,7 @@ class MixerController:
 
         return None
 
-    def set_volume(self, volume):
+    def set_volume(self, volume: int) -> bool:
         """Set the volume.
 
         The volume is defined as an integer in range [0..100].
@@ -74,7 +75,7 @@ class MixerController:
 
         return False
 
-    def get_mute(self):
+    def get_mute(self) -> Optional[bool]:
         """Get mute state.
 
         :class:`True` if muted, :class:`False` unmuted, :class:`None` if
@@ -91,7 +92,7 @@ class MixerController:
 
         return None
 
-    def set_mute(self, mute):
+    def set_mute(self, mute: bool) -> bool:
         """Set mute state.
 
         :class:`True` to mute, :class:`False` to unmute.
@@ -109,10 +110,10 @@ class MixerController:
 
         return False
 
-    def _save_state(self):
+    def _save_state(self) -> MixerState:
         return MixerState(volume=self.get_volume(), mute=self.get_mute())
 
-    def _load_state(self, state, coverage):
+    def _load_state(self, state: MixerState, coverage: list[str]) -> None:
         if state and "mixer" in coverage:
             self.set_mute(state.mute)
             if state.volume:

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -10,6 +10,7 @@ from mopidy.audio import PlaybackState
 from mopidy.core import listener
 from mopidy.exceptions import CoreError
 from mopidy.internal import deprecation, models, validation
+from mopidy.types import UriScheme
 
 if TYPE_CHECKING:
     from mopidy.audio.actor import AudioProxy
@@ -52,7 +53,7 @@ class PlaybackController:
     def _get_backend(self, tl_track: Optional[TlTrack]) -> Optional[BackendProxy]:
         if tl_track is None:
             return None
-        uri_scheme = urllib.parse.urlparse(tl_track.track.uri).scheme
+        uri_scheme = UriScheme(urllib.parse.urlparse(tl_track.track.uri).scheme)
         return self.backends.with_playback.get(uri_scheme, None)
 
     def get_current_tl_track(self) -> Optional[TlTrack]:

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import urllib.parse
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional
 
 from pykka.messages import ProxyCall
@@ -562,7 +563,7 @@ class PlaybackController:
             state=self.get_state(),
         )
 
-    def _load_state(self, state: models.PlaybackState, coverage: list[str]) -> None:
+    def _load_state(self, state: models.PlaybackState, coverage: Iterable[str]) -> None:
         if state and "play-last" in coverage and state.tlid is not None:
             if state.state == PlaybackState.PAUSED:
                 self._start_paused = True

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     from mopidy.backend import BackendProxy
     from mopidy.core.actor import Backends, Core
     from mopidy.models import TlTrack, Track
+    from mopidy.types import Uri
 
 logger = logging.getLogger(__name__)
 
@@ -136,7 +137,7 @@ class PlaybackController:
             self._trigger_track_playback_ended(self.get_time_position())
         self._set_current_tl_track(None)
 
-    def _on_stream_changed(self, _uri: str) -> None:
+    def _on_stream_changed(self, _uri: Uri) -> None:
         if self._last_position is None:
             position = self.get_time_position()
         else:

--- a/mopidy/core/playback.py
+++ b/mopidy/core/playback.py
@@ -13,8 +13,9 @@ from mopidy.internal import deprecation, models, validation
 
 if TYPE_CHECKING:
     from mopidy.audio.actor import AudioProxy
+    from mopidy.backend import BackendProxy
     from mopidy.core.actor import Backends, Core
-    from mopidy.models import TlTrack
+    from mopidy.models import TlTrack, Track
 
 logger = logging.getLogger(__name__)
 
@@ -31,43 +32,43 @@ class PlaybackController:
         self.core = core
         self._audio = audio
 
-        self._stream_title = None
+        self._stream_title: Optional[str] = None
         self._state = PlaybackState.STOPPED
 
         self._current_tl_track: Optional[TlTrack] = None
         self._pending_tl_track: Optional[TlTrack] = None
 
-        self._pending_position = None
-        self._last_position = None
-        self._previous = False
+        self._pending_position: Optional[int] = None
+        self._last_position: Optional[int] = None
+        self._previous: bool = False
 
-        self._start_at_position = None
-        self._start_paused = False
+        self._start_at_position: Optional[int] = None
+        self._start_paused: bool = False
 
         if self._audio:
             self._audio.set_about_to_finish_callback(self._on_about_to_finish_callback)
 
-    def _get_backend(self, tl_track):
+    def _get_backend(self, tl_track: Optional[TlTrack]) -> Optional[BackendProxy]:
         if tl_track is None:
             return None
         uri_scheme = urllib.parse.urlparse(tl_track.track.uri).scheme
         return self.backends.with_playback.get(uri_scheme, None)
 
-    def get_current_tl_track(self):
+    def get_current_tl_track(self) -> Optional[TlTrack]:
         """Get the currently playing or selected track.
 
         Returns a :class:`mopidy.models.TlTrack` or :class:`None`.
         """
         return self._current_tl_track
 
-    def _set_current_tl_track(self, value):
+    def _set_current_tl_track(self, value: Optional[TlTrack]) -> None:
         """Set the currently playing or selected track.
 
         *Internal:* This is only for use by Mopidy's test suite.
         """
         self._current_tl_track = value
 
-    def get_current_track(self):
+    def get_current_track(self) -> Optional[Track]:
         """Get the currently playing or selected track.
 
         Extracted from :meth:`get_current_tl_track` for convenience.
@@ -76,7 +77,7 @@ class PlaybackController:
         """
         return getattr(self.get_current_tl_track(), "track", None)
 
-    def get_current_tlid(self):
+    def get_current_tlid(self) -> Optional[int]:
         """Get the currently playing or selected TLID.
 
         Extracted from :meth:`get_current_tl_track` for convenience.
@@ -87,15 +88,15 @@ class PlaybackController:
         """
         return getattr(self.get_current_tl_track(), "tlid", None)
 
-    def get_stream_title(self):
+    def get_stream_title(self) -> Optional[str]:
         """Get the current stream title or :class:`None`."""
         return self._stream_title
 
-    def get_state(self):
+    def get_state(self) -> PlaybackState:
         """Get The playback state."""
         return self._state
 
-    def set_state(self, new_state):
+    def set_state(self, new_state: PlaybackState) -> None:
         """Set the playback state.
 
         Must be :attr:`PLAYING`, :attr:`PAUSED`, or :attr:`STOPPED`.
@@ -119,7 +120,7 @@ class PlaybackController:
 
         self._trigger_playback_state_changed(old_state, new_state)
 
-    def get_time_position(self):
+    def get_time_position(self) -> int:
         """Get time position in milliseconds."""
         if self._pending_position is not None:
             return self._pending_position
@@ -129,13 +130,13 @@ class PlaybackController:
         # TODO: Wrap backend call in error handling.
         return backend.playback.get_time_position().get()
 
-    def _on_end_of_stream(self):
+    def _on_end_of_stream(self) -> None:
         self.set_state(PlaybackState.STOPPED)
         if self._current_tl_track:
             self._trigger_track_playback_ended(self.get_time_position())
         self._set_current_tl_track(None)
 
-    def _on_stream_changed(self, _uri):
+    def _on_stream_changed(self, _uri: str) -> None:
         if self._last_position is None:
             position = self.get_time_position()
         else:
@@ -165,7 +166,7 @@ class PlaybackController:
                 self.set_state(PlaybackState.PLAYING)
                 self._trigger_track_playback_started()
 
-    def _on_position_changed(self, _position):
+    def _on_position_changed(self, _position: int) -> None:
         if self._pending_position is not None:
             self._trigger_seeked(self._pending_position)
             self._pending_position = None
@@ -173,7 +174,7 @@ class PlaybackController:
                 self._start_paused = False
                 self.pause()
 
-    def _on_about_to_finish_callback(self):
+    def _on_about_to_finish_callback(self) -> None:
         """Callback that performs a blocking actor call to the real callback.
 
         This is passed to audio, which is allowed to call this code from the
@@ -189,7 +190,7 @@ class PlaybackController:
             )
         )
 
-    def _on_about_to_finish(self):
+    def _on_about_to_finish(self) -> None:
         if self._state == PlaybackState.STOPPED:
             return
 
@@ -227,7 +228,7 @@ class PlaybackController:
                 logger.info("No playable track in the list.")
                 break
 
-    def _on_tracklist_change(self):
+    def _on_tracklist_change(self) -> None:
         """Tell the playback controller that the current playlist has changed.
 
         Used by :class:`mopidy.core.TracklistController`.
@@ -239,7 +240,7 @@ class PlaybackController:
         elif self.get_current_tl_track() not in tl_tracks:
             self._set_current_tl_track(None)
 
-    def next(self):
+    def next(self) -> None:
         """Change to the next track.
 
         The current playback state will be kept. If it was playing, playing
@@ -264,7 +265,7 @@ class PlaybackController:
 
         # TODO return result?
 
-    def pause(self):
+    def pause(self) -> None:
         """Pause playback."""
         backend = self._get_backend(self.get_current_tl_track())
         # TODO: Wrap backend call in error handling.
@@ -272,7 +273,11 @@ class PlaybackController:
             self.set_state(PlaybackState.PAUSED)
             self._trigger_track_playback_paused()
 
-    def play(self, tl_track=None, tlid=None) -> None:  # noqa: C901, PLR0912
+    def play(  # noqa: C901, PLR0912
+        self,
+        tl_track: Optional[TlTrack] = None,
+        tlid: Optional[int] = None,
+    ) -> None:
         """Play the given track, or if the given tl_track and tlid is
         :class:`None`, play the currently active track.
 
@@ -386,7 +391,7 @@ class PlaybackController:
 
         raise CoreError(f"Unknown playback state: {state}")
 
-    def previous(self):
+    def previous(self) -> None:
         """Change to the previous track.
 
         The current playback state will be kept. If it was playing, playing
@@ -412,7 +417,7 @@ class PlaybackController:
 
         # TODO: no return value?
 
-    def resume(self):
+    def resume(self) -> None:
         """If paused, resume playing the current track."""
         if self.get_state() != PlaybackState.PAUSED:
             return
@@ -467,7 +472,7 @@ class PlaybackController:
         # TODO: Avoid returning False here when STOPPED (seek is deferred)?
         return self._seek(time_position)
 
-    def _seek(self, time_position):
+    def _seek(self, time_position: int) -> bool:
         backend = self._get_backend(self.get_current_tl_track())
         if not backend:
             return False
@@ -515,7 +520,7 @@ class PlaybackController:
         self.core.history._add_track(tl_track.track)
         listener.CoreListener.send("track_playback_started", tl_track=tl_track)
 
-    def _trigger_track_playback_ended(self, time_position_before_stop) -> None:
+    def _trigger_track_playback_ended(self, time_position_before_stop: int) -> None:
         tl_track = self.get_current_tl_track()
         if tl_track is None:
             return
@@ -533,13 +538,17 @@ class PlaybackController:
             time_position=time_position_before_stop,
         )
 
-    def _trigger_playback_state_changed(self, old_state, new_state) -> None:
+    def _trigger_playback_state_changed(
+        self,
+        old_state: PlaybackState,
+        new_state: PlaybackState,
+    ) -> None:
         logger.debug("Triggering playback state change event")
         listener.CoreListener.send(
             "playback_state_changed", old_state=old_state, new_state=new_state
         )
 
-    def _trigger_seeked(self, time_position) -> None:
+    def _trigger_seeked(self, time_position: int) -> None:
         # TODO: Trigger this from audio events?
         logger.debug("Triggering seeked event")
         listener.CoreListener.send("seeked", time_position=time_position)
@@ -551,7 +560,7 @@ class PlaybackController:
             state=self.get_state(),
         )
 
-    def _load_state(self, state, coverage) -> None:
+    def _load_state(self, state: models.PlaybackState, coverage: list[str]) -> None:
         if state and "play-last" in coverage and state.tlid is not None:
             if state.state == PlaybackState.PAUSED:
                 self._start_paused = True

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -10,13 +10,14 @@ from mopidy import exceptions
 from mopidy.core import listener
 from mopidy.internal import validation
 from mopidy.models import Playlist, Ref
+from mopidy.types import UriScheme
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from mopidy.backend import BackendProxy
     from mopidy.core.actor import Backends, Core
-    from mopidy.types import Uri, UriScheme
+    from mopidy.types import Uri
 
 
 @contextlib.contextmanager
@@ -103,7 +104,7 @@ class PlaylistsController:
         """
         validation.check_uri(uri)
 
-        uri_scheme = urllib.parse.urlparse(uri).scheme
+        uri_scheme = UriScheme(urllib.parse.urlparse(uri).scheme)
         backend = self.backends.with_playlists.get(uri_scheme, None)
 
         if not backend:
@@ -171,7 +172,7 @@ class PlaylistsController:
         """
         validation.check_uri(uri)
 
-        uri_scheme = urllib.parse.urlparse(uri).scheme
+        uri_scheme = UriScheme(urllib.parse.urlparse(uri).scheme)
         backend = self.backends.with_playlists.get(uri_scheme, None)
         if not backend:
             return False
@@ -198,7 +199,7 @@ class PlaylistsController:
         :type uri: string
         :rtype: :class:`mopidy.models.Playlist` or :class:`None`
         """
-        uri_scheme = urllib.parse.urlparse(uri).scheme
+        uri_scheme = UriScheme(urllib.parse.urlparse(uri).scheme)
         backend = self.backends.with_playlists.get(uri_scheme, None)
         if not backend:
             return None
@@ -271,7 +272,7 @@ class PlaylistsController:
         if playlist.uri is None:
             return None  # TODO: log this problem?
 
-        uri_scheme = urllib.parse.urlparse(playlist.uri).scheme
+        uri_scheme = UriScheme(urllib.parse.urlparse(playlist.uri).scheme)
         backend = self.backends.with_playlists.get(uri_scheme, None)
         if not backend:
             return None

--- a/mopidy/core/playlists.py
+++ b/mopidy/core/playlists.py
@@ -16,6 +16,7 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from mopidy.backend import BackendProxy
     from mopidy.core.actor import Backends, Core
+    from mopidy.types import Uri, UriScheme
 
 
 @contextlib.contextmanager
@@ -45,7 +46,7 @@ class PlaylistsController:
         self.backends = backends
         self.core = core
 
-    def get_uri_schemes(self) -> list[str]:
+    def get_uri_schemes(self) -> list[UriScheme]:
         """Get the list of URI schemes that support playlists.
 
         :rtype: list of string
@@ -87,7 +88,7 @@ class PlaylistsController:
 
         return results
 
-    def get_items(self, uri: str) -> Optional[list[Ref]]:
+    def get_items(self, uri: Uri) -> Optional[list[Ref]]:
         """Get the items in a playlist specified by ``uri``.
 
         Returns a list of :class:`~mopidy.models.Ref` objects referring to the
@@ -116,7 +117,11 @@ class PlaylistsController:
 
         return None
 
-    def create(self, name: str, uri_scheme: Optional[str] = None) -> Optional[Playlist]:
+    def create(
+        self,
+        name: str,
+        uri_scheme: Optional[UriScheme] = None,
+    ) -> Optional[Playlist]:
         """Create a new playlist.
 
         If ``uri_scheme`` matches an URI scheme handled by a current backend,
@@ -149,7 +154,7 @@ class PlaylistsController:
 
         return None
 
-    def delete(self, uri: str) -> bool:
+    def delete(self, uri: Uri) -> bool:
         """Delete playlist identified by the URI.
 
         If the URI doesn't match the URI schemes handled by the current
@@ -185,7 +190,7 @@ class PlaylistsController:
 
         return success
 
-    def lookup(self, uri: str) -> Optional[Playlist]:
+    def lookup(self, uri: Uri) -> Optional[Playlist]:
         """Lookup playlist with given URI in both the set of playlists and in any
         other playlist sources. Returns :class:`None` if not found.
 
@@ -208,7 +213,7 @@ class PlaylistsController:
 
     # TODO: there is an inconsistency between library.refresh(uri) and this
     # call, not sure how to sort this out.
-    def refresh(self, uri_scheme: Optional[str] = None) -> None:
+    def refresh(self, uri_scheme: Optional[UriScheme] = None) -> None:
         """Refresh the playlists in :attr:`playlists`.
 
         If ``uri_scheme`` is :class:`None`, all backends are asked to refresh.

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Optional
 
 from mopidy import exceptions
@@ -355,9 +356,9 @@ class TracklistController:
 
     def add(  # noqa: C901
         self,
-        tracks: Optional[list[Track]] = None,
+        tracks: Optional[Iterable[Track]] = None,
         at_position: Optional[int] = None,
-        uris: Optional[list[Uri]] = None,
+        uris: Optional[Iterable[Uri]] = None,
     ) -> list[TlTrack]:
         """Add tracks to the tracklist.
 
@@ -618,7 +619,7 @@ class TracklistController:
     def _load_state(
         self,
         state: TracklistState,
-        coverage: list[str],
+        coverage: Iterable[str],
     ) -> None:
         if state:
             if "mode" in coverage:

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -1,6 +1,8 @@
+from __future__ import annotations
+
 import logging
 import random
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Any, Optional
 
 from mopidy import exceptions
 from mopidy.core import listener
@@ -10,33 +12,40 @@ from mopidy.models import TlTrack, Track
 
 logger = logging.getLogger(__name__)
 
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+    from mopidy.core.actor import Core
+
+    Criteria: TypeAlias = dict[str, list[Any]]
+
 
 class TracklistController:
-    def __init__(self, core):
+    def __init__(self, core: Core) -> None:
         self.core = core
-        self._next_tlid = 1
-        self._tl_tracks = []
-        self._version = 0
+        self._next_tlid: int = 1
+        self._tl_tracks: list[TlTrack] = []
+        self._version: int = 0
 
-        self._consume = False
-        self._random = False
-        self._shuffled = []
-        self._repeat = False
-        self._single = False
+        self._consume: bool = False
+        self._random: bool = False
+        self._shuffled: list[TlTrack] = []
+        self._repeat: bool = False
+        self._single: bool = False
 
-    def get_tl_tracks(self):
+    def get_tl_tracks(self) -> list[TlTrack]:
         """Get tracklist as list of :class:`mopidy.models.TlTrack`."""
         return self._tl_tracks[:]
 
-    def get_tracks(self):
+    def get_tracks(self) -> list[Track]:
         """Get tracklist as list of :class:`mopidy.models.Track`."""
         return [tl_track.track for tl_track in self._tl_tracks]
 
-    def get_length(self):
+    def get_length(self) -> int:
         """Get length of the tracklist."""
         return len(self._tl_tracks)
 
-    def get_version(self):
+    def get_version(self) -> int:
         """Get the tracklist version.
 
         Integer which is increased every time the tracklist is changed. Is not
@@ -44,12 +53,12 @@ class TracklistController:
         """
         return self._version
 
-    def _increase_version(self):
+    def _increase_version(self) -> None:
         self._version += 1
         self.core.playback._on_tracklist_change()
         self._trigger_tracklist_changed()
 
-    def get_consume(self):
+    def get_consume(self) -> bool:
         """Get consume mode.
 
         :class:`True`
@@ -59,7 +68,7 @@ class TracklistController:
         """
         return self._consume
 
-    def set_consume(self, value):
+    def set_consume(self, value: bool) -> None:
         """Set consume mode.
 
         :class:`True`
@@ -72,7 +81,7 @@ class TracklistController:
             self._trigger_options_changed()
         self._consume = value
 
-    def get_random(self):
+    def get_random(self) -> bool:
         """Get random mode.
 
         :class:`True`
@@ -82,7 +91,7 @@ class TracklistController:
         """
         return self._random
 
-    def set_random(self, value):
+    def set_random(self, value: bool) -> None:
         """Set random mode.
 
         :class:`True`
@@ -98,7 +107,7 @@ class TracklistController:
             random.shuffle(self._shuffled)
         self._random = value
 
-    def get_repeat(self):
+    def get_repeat(self) -> bool:
         """Get repeat mode.
 
         :class:`True`
@@ -108,7 +117,7 @@ class TracklistController:
         """
         return self._repeat
 
-    def set_repeat(self, value):
+    def set_repeat(self, value: bool) -> None:
         """Set repeat mode.
 
         To repeat a single track, set both ``repeat`` and ``single``.
@@ -123,7 +132,7 @@ class TracklistController:
             self._trigger_options_changed()
         self._repeat = value
 
-    def get_single(self):
+    def get_single(self) -> bool:
         """Get single mode.
 
         :class:`True`
@@ -133,7 +142,7 @@ class TracklistController:
         """
         return self._single
 
-    def set_single(self, value):
+    def set_single(self, value: bool) -> None:
         """Set single mode.
 
         :class:`True`
@@ -146,7 +155,11 @@ class TracklistController:
             self._trigger_options_changed()
         self._single = value
 
-    def index(self, tl_track=None, tlid=None):
+    def index(
+        self,
+        tl_track: Optional[TlTrack] = None,
+        tlid: Optional[int] = None,
+    ) -> Optional[int]:
         """The position of the given track in the tracklist.
 
         If neither *tl_track* or *tlid* is given we return the index of
@@ -180,7 +193,7 @@ class TracklistController:
                     return i
         return None
 
-    def get_eot_tlid(self):
+    def get_eot_tlid(self) -> Optional[int]:
         """The TLID of the track that will be played after the current track.
 
         Not necessarily the same TLID as returned by :meth:`get_next_tlid`.
@@ -196,7 +209,7 @@ class TracklistController:
 
         return getattr(eot_tl_track, "tlid", None)
 
-    def eot_track(self, tl_track):
+    def eot_track(self, tl_track: Optional[TlTrack]) -> Optional[TlTrack]:
         """The track that will be played after the given track.
 
         Not necessarily the same track as :meth:`next_track`.
@@ -221,7 +234,7 @@ class TracklistController:
         # shared.
         return self.next_track(tl_track)
 
-    def get_next_tlid(self):
+    def get_next_tlid(self) -> Optional[int]:
         """The tlid of the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.next()`.
 
@@ -241,7 +254,7 @@ class TracklistController:
 
         return getattr(next_tl_track, "tlid", None)
 
-    def next_track(self, tl_track) -> Optional[TlTrack]:
+    def next_track(self, tl_track: Optional[TlTrack]) -> Optional[TlTrack]:
         """The track that will be played if calling
         :meth:`mopidy.core.PlaybackController.next()`.
 
@@ -293,7 +306,7 @@ class TracklistController:
 
         return self._tl_tracks[next_index]
 
-    def get_previous_tlid(self):
+    def get_previous_tlid(self) -> Optional[int]:
         """Returns the TLID of the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.previous()`.
 
@@ -312,7 +325,7 @@ class TracklistController:
 
         return getattr(previous_tl_track, "tlid", None)
 
-    def previous_track(self, tl_track):
+    def previous_track(self, tl_track: Optional[TlTrack]) -> Optional[TlTrack]:
         """Returns the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.previous()`.
 
@@ -345,9 +358,9 @@ class TracklistController:
 
     def add(  # noqa: C901
         self,
-        tracks=None,
-        at_position=None,
-        uris=None,
+        tracks: Optional[list[Track]] = None,
+        at_position: Optional[int] = None,
+        uris: Optional[list[str]] = None,
     ) -> list[TlTrack]:
         """Add tracks to the tracklist.
 
@@ -389,8 +402,8 @@ class TracklistController:
 
         if tracks is None:
             tracks = []
-            track_map = self.core.library.lookup(uris=uris)
             assert uris is not None
+            track_map = self.core.library.lookup(uris=uris)
             for uri in uris:
                 tracks.extend(track_map[uri])
 
@@ -417,7 +430,7 @@ class TracklistController:
 
         return tl_tracks
 
-    def clear(self):
+    def clear(self) -> None:
         """Clear the tracklist.
 
         Triggers the :meth:`mopidy.core.CoreListener.tracklist_changed` event.
@@ -425,7 +438,7 @@ class TracklistController:
         self._tl_tracks = []
         self._increase_version()
 
-    def filter(self, criteria):
+    def filter(self, criteria: Criteria) -> list[TlTrack]:
         """Filter the tracklist by the given criteria.
 
         Each rule in the criteria consists of a model field and a list of
@@ -461,7 +474,7 @@ class TracklistController:
             matches = [ct for ct in matches if ct.tlid in tlids]
         return matches
 
-    def move(self, start, end, to_position):
+    def move(self, start: int, end: int, to_position: int) -> None:
         """Move the tracks in the slice ``[start:end]`` to ``to_position``.
 
         Triggers the :meth:`mopidy.core.CoreListener.tracklist_changed` event.
@@ -497,7 +510,7 @@ class TracklistController:
         self._tl_tracks = new_tl_tracks
         self._increase_version()
 
-    def remove(self, criteria):
+    def remove(self, criteria: Criteria) -> list[TlTrack]:
         """Remove the matching tracks from the tracklist.
 
         Uses :meth:`filter()` to lookup the tracks to remove.
@@ -515,7 +528,7 @@ class TracklistController:
         self._increase_version()
         return tl_tracks
 
-    def shuffle(self, start=None, end=None):
+    def shuffle(self, start: Optional[int] = None, end: Optional[int] = None) -> None:
         """Shuffles the entire tracklist. If ``start`` and ``end`` is given only
         shuffles the slice ``[start:end]``.
 
@@ -545,7 +558,7 @@ class TracklistController:
         self._tl_tracks = before + shuffled + after
         self._increase_version()
 
-    def slice(self, start, end):
+    def slice(self, start: int, end: int) -> list[TlTrack]:
         """Returns a slice of the tracklist, limited by the given start and end
         positions.
 
@@ -553,32 +566,35 @@ class TracklistController:
         :type start: int
         :param end: position after last track to include in slice
         :type end: int
-        :rtype: :class:`mopidy.models.TlTrack`
+        :rtype: list of :class:`mopidy.models.TlTrack`
         """
         # TODO: validate slice?
         return self._tl_tracks[start:end]
 
-    def _mark_playing(self, tl_track):
+    def _mark_playing(self, tl_track: TlTrack) -> None:
         """Internal method for :class:`mopidy.core.PlaybackController`."""
         if self.get_random() and tl_track in self._shuffled:
             self._shuffled.remove(tl_track)
 
-    def _mark_unplayable(self, tl_track):
+    def _mark_unplayable(self, tl_track: Optional[TlTrack]) -> None:
         """Internal method for :class:`mopidy.core.PlaybackController`."""
-        logger.warning("Track is not playable: %s", tl_track.track.uri)
+        logger.warning(
+            "Track is not playable: %s",
+            tl_track.track.uri if tl_track else None,
+        )
         if self.get_consume() and tl_track is not None:
             self.remove({"tlid": [tl_track.tlid]})
         if self.get_random() and tl_track in self._shuffled:
             self._shuffled.remove(tl_track)
 
-    def _mark_played(self, tl_track):
+    def _mark_played(self, tl_track: Optional[TlTrack]) -> bool:
         """Internal method for :class:`mopidy.core.PlaybackController`."""
         if self.get_consume() and tl_track is not None:
             self.remove({"tlid": [tl_track.tlid]})
             return True
         return False
 
-    def _trigger_tracklist_changed(self):
+    def _trigger_tracklist_changed(self) -> None:
         if self.get_random():
             self._shuffled = self._tl_tracks[:]
             random.shuffle(self._shuffled)
@@ -588,11 +604,11 @@ class TracklistController:
         logger.debug("Triggering event: tracklist_changed()")
         listener.CoreListener.send("tracklist_changed")
 
-    def _trigger_options_changed(self):
+    def _trigger_options_changed(self) -> None:
         logger.debug("Triggering options changed event")
         listener.CoreListener.send("options_changed")
 
-    def _save_state(self):
+    def _save_state(self) -> TracklistState:
         return TracklistState(
             tl_tracks=self._tl_tracks,
             next_tlid=self._next_tlid,
@@ -602,7 +618,11 @@ class TracklistController:
             single=self.get_single(),
         )
 
-    def _load_state(self, state, coverage):
+    def _load_state(
+        self,
+        state: TracklistState,
+        coverage: list[str],
+    ) -> None:
         if state:
             if "mode" in coverage:
                 self.set_consume(state.consume)

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import logging
 import random
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Optional
 
 from mopidy import exceptions
 from mopidy.core import listener
@@ -13,11 +13,8 @@ from mopidy.models import TlTrack, Track
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
-
     from mopidy.core.actor import Core
-
-    Criteria: TypeAlias = dict[str, list[Any]]
+    from mopidy.types import Query, TracklistField
 
 
 class TracklistController:
@@ -438,7 +435,7 @@ class TracklistController:
         self._tl_tracks = []
         self._increase_version()
 
-    def filter(self, criteria: Criteria) -> list[TlTrack]:
+    def filter(self, criteria: Query[TracklistField]) -> list[TlTrack]:
         """Filter the tracklist by the given criteria.
 
         Each rule in the criteria consists of a model field and a list of
@@ -464,7 +461,7 @@ class TracklistController:
         :rtype: list of :class:`mopidy.models.TlTrack`
         """
         tlids = criteria.pop("tlid", [])
-        validation.check_query(criteria, validation.TRACKLIST_FIELDS)
+        validation.check_query(criteria, validation.TRACKLIST_FIELDS.keys())
         validation.check_instances(tlids, int)
 
         matches = self._tl_tracks
@@ -510,7 +507,7 @@ class TracklistController:
         self._tl_tracks = new_tl_tracks
         self._increase_version()
 
-    def remove(self, criteria: Criteria) -> list[TlTrack]:
+    def remove(self, criteria: Query[TracklistField]) -> list[TlTrack]:
         """Remove the matching tracks from the tracklist.
 
         Uses :meth:`filter()` to lookup the tracks to remove.
@@ -549,7 +546,7 @@ class TracklistController:
             raise AssertionError("start must be at least zero")
 
         if end is not None and end > len(tl_tracks):
-            raise AssertionError("end can not be larger than " + "tracklist length")
+            raise AssertionError("end can not be larger than tracklist length")
 
         before = tl_tracks[: start or 0]
         shuffled = tl_tracks[start:end]

--- a/mopidy/core/tracklist.py
+++ b/mopidy/core/tracklist.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from mopidy.core.actor import Core
-    from mopidy.types import Query, TracklistField
+    from mopidy.types import Query, TracklistField, Uri
 
 
 class TracklistController:
@@ -357,7 +357,7 @@ class TracklistController:
         self,
         tracks: Optional[list[Track]] = None,
         at_position: Optional[int] = None,
-        uris: Optional[list[str]] = None,
+        uris: Optional[list[Uri]] = None,
     ) -> list[TlTrack]:
         """Add tracks to the tracklist.
 

--- a/mopidy/internal/validation.py
+++ b/mopidy/internal/validation.py
@@ -132,7 +132,7 @@ def check_integer(
 
 
 def check_query(
-    arg: Union[Query[DistinctField], Query[SearchField], Query[TracklistField]],
+    arg: Union[Query[SearchField], Query[TracklistField]],
     fields: Optional[Iterable[str]] = None,
 ) -> None:
     if fields is None:

--- a/mopidy/internal/validation.py
+++ b/mopidy/internal/validation.py
@@ -1,45 +1,67 @@
+from __future__ import annotations
+
 import urllib.parse
 from collections.abc import Iterable, Mapping
-from typing import Any, Optional, TypeVar, Union
+from typing import Any, Literal, Optional, TypeVar, Union, get_args
 
 from mopidy import exceptions
+from mopidy.audio.constants import PlaybackState
+from mopidy.types import (
+    DistinctField,
+    Query,
+    QueryValue,
+    SearchField,
+    TracklistField,
+)
+
+
+def get_literals(literal_type: Any) -> set[str]:
+    # Check if it's a union
+    if hasattr(literal_type, "__origin__") and literal_type.__origin__ is Union:
+        literals = set()
+        for arg in get_args(literal_type):
+            literals.update(get_literals(arg))
+        return literals
+
+    # Check if it's a literal
+    if hasattr(literal_type, "__origin__") and literal_type.__origin__ is Literal:
+        return set(get_args(literal_type))
+
+    raise ValueError("Provided type is neither a Union nor a Literal type.")
+
 
 T = TypeVar("T")
 
-PLAYBACK_STATES = {"paused", "stopped", "playing"}
+PLAYBACK_STATES: set[str] = {ps.value for ps in PlaybackState}
 
-TRACK_FIELDS_WITH_TYPES: dict[str, Union[type[str], type[int]]] = {
-    "uri": str,
-    "track_name": str,
+FIELD_TYPES: dict[str, type] = {
     "album": str,
-    "artist": str,
     "albumartist": str,
-    "composer": str,
-    "performer": str,
-    "track_no": int,
-    "genre": str,
-    "date": str,
+    "any": Union[int, str],
+    "artist": str,
     "comment": str,
+    "composer": str,
+    "date": str,
     "disc_no": int,
+    "genre": str,
+    "musicbrainz_id": str,
     "musicbrainz_albumid": str,
     "musicbrainz_artistid": str,
     "musicbrainz_trackid": str,
+    "name": str,
+    "performer": str,
+    "tlid": int,
+    "track_name": str,
+    "track_no": int,
+    "uri": str,
 }
-
-SEARCH_FIELDS = set(TRACK_FIELDS_WITH_TYPES).union({"any"})
-
-PLAYLIST_FIELDS = {"uri", "name"}  # TODO: add length and last_modified?
-
-TRACKLIST_FIELDS = {  # TODO: add bitrate, length, disc_no, track_no, modified?
-    "uri",
-    "name",
-    "genre",
-    "date",
-    "comment",
-    "musicbrainz_id",
+DISTINCT_FIELDS: dict[str, type] = {
+    x: FIELD_TYPES[x] for x in get_literals(DistinctField)
 }
-
-DISTINCT_FIELDS = dict(TRACK_FIELDS_WITH_TYPES)
+SEARCH_FIELDS: dict[str, type] = {x: FIELD_TYPES[x] for x in get_literals(SearchField)}
+TRACKLIST_FIELDS: dict[str, type] = {
+    x: FIELD_TYPES[x] for x in get_literals(TracklistField) - {"tlid"}
+}
 
 
 # TODO: _check_iterable(check, msg, **kwargs) + [check(a) for a in arg]?
@@ -110,16 +132,14 @@ def check_integer(
 
 
 def check_query(
-    arg: dict[str, Any],
-    fields: Optional[set[str]] = None,
-    list_values: bool = True,
+    arg: Union[Query[DistinctField], Query[SearchField], Query[TracklistField]],
+    fields: Optional[Iterable[str]] = None,
 ) -> None:
     if fields is None:
-        fields = SEARCH_FIELDS
+        fields = SEARCH_FIELDS.keys()
     # TODO: normalize name  -> track_name
     # TODO: normalize value -> [value]
     # TODO: normalize blank -> [] or just remove field?
-    # TODO: remove list_values?
 
     if not isinstance(arg, Mapping):
         raise exceptions.ValidationError(f"Expected a query dictionary, not {arg!r}")
@@ -130,19 +150,14 @@ def check_query(
             fields,
             msg="Expected query field to be one of {choices}, not {arg!r}",
         )
-        if list_values:
-            msg = 'Expected "{key}" to be list of strings, not {arg!r}'
-            _check_iterable(value, msg, key=key)
-            [_check_query_value(key, v, msg) for v in value]
-        else:
-            _check_query_value(
-                key, value, 'Expected "{key}" to be a string, not {arg!r}'
-            )
+        msg = 'Expected "{key}" to be list of strings, not {arg!r}'
+        _check_iterable(value, msg, key=key)
+        [_check_query_value(key, v, msg) for v in value]
 
 
 def _check_query_value(
-    key: str,
-    arg: Any,
+    key: Union[DistinctField, SearchField, TracklistField],
+    arg: QueryValue,
     msg: str,
 ) -> None:
     if not isinstance(arg, str) or not arg.strip():

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
@@ -11,9 +11,9 @@ from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing import Any, Literal, Optional
+    from typing_extensions import TypeAlias
 
-    MixerEvent = Literal["mute_changed", "volume_changed"]
+    from mopidy.types import Percentage
 
 
 logger = logging.getLogger(__name__)
@@ -43,7 +43,7 @@ class Mixer:
     def __init__(self, config: dict) -> None:
         pass
 
-    def get_volume(self) -> Optional[int]:
+    def get_volume(self) -> Optional[Percentage]:
         """Get volume level of the mixer on a linear scale from 0 to 100.
 
         Example values:
@@ -61,7 +61,7 @@ class Mixer:
         """
         return None
 
-    def set_volume(self, volume: int) -> bool:
+    def set_volume(self, volume: Percentage) -> bool:
         """Set volume level of the mixer.
 
         *MAY be implemented by subclass.*
@@ -72,7 +72,7 @@ class Mixer:
         """
         return False
 
-    def trigger_volume_changed(self, volume: int) -> None:
+    def trigger_volume_changed(self, volume: Percentage) -> None:
         """Send ``volume_changed`` event to all mixer listeners.
 
         This method should be called by subclasses when the volume is changed,
@@ -116,6 +116,9 @@ class Mixer:
     def ping(self) -> bool:
         """Called to check if the actor is still alive."""
         return True
+
+
+MixerEvent: TypeAlias = Literal["mute_changed", "volume_changed"]
 
 
 class MixerListener(listener.Listener):

--- a/mopidy/models/__init__.py
+++ b/mopidy/models/__init__.py
@@ -3,17 +3,17 @@ from mopidy.models.immutable import ImmutableObject, ValidatedImmutableObject
 from mopidy.models.serialize import ModelJSONEncoder, model_json_decoder
 
 __all__ = [
-    "ImmutableObject",
-    "Ref",
-    "Image",
-    "Artist",
     "Album",
-    "Track",
-    "TlTrack",
-    "Playlist",
-    "SearchResult",
+    "Artist",
+    "Image",
+    "ImmutableObject",
     "model_json_decoder",
     "ModelJSONEncoder",
+    "Playlist",
+    "Ref",
+    "SearchResult",
+    "TlTrack",
+    "Track",
     "ValidatedImmutableObject",
 ]
 

--- a/mopidy/models/fields.py
+++ b/mopidy/models/fields.py
@@ -13,6 +13,8 @@ from typing import (
     overload,
 )
 
+from mopidy.types import Uri
+
 if TYPE_CHECKING:
     from collections.abc import Iterable
 
@@ -133,7 +135,7 @@ class Identifier(String):
         return sys.intern(value)
 
 
-class URI(Identifier):
+class URI(Field[Uri]):
     """:class:`Field` for storing URIs.
 
     Values will be interned, currently not validated.
@@ -141,7 +143,12 @@ class URI(Identifier):
     :param default: default value for field
     """
 
-    # TODO: validate URIs?
+    def validate(self, value: Uri) -> Uri:
+        value = super().validate(value)
+        if isinstance(value, bytes):
+            value = value.decode()
+        # TODO: validate URIs?
+        return Uri(sys.intern(value))
 
 
 class Integer(Field[int]):

--- a/mopidy/types.py
+++ b/mopidy/types.py
@@ -49,3 +49,6 @@ QueryField: TypeAlias = Union[DistinctField, SearchField, TracklistField]
 # URI types
 Uri = NewType("Uri", str)
 UriScheme = NewType("UriScheme", str)
+
+# Integer types
+DurationMs = NewType("DurationMs", int)

--- a/mopidy/types.py
+++ b/mopidy/types.py
@@ -51,4 +51,5 @@ Uri = NewType("Uri", str)
 UriScheme = NewType("UriScheme", str)
 
 # Integer types
+Percentage = NewType("Percentage", int)
 DurationMs = NewType("DurationMs", int)

--- a/mopidy/types.py
+++ b/mopidy/types.py
@@ -27,7 +27,6 @@ DistinctField: TypeAlias = Literal[
     "musicbrainz_artistid",
     "musicbrainz_trackid",
 ]
-DistinctQuery: TypeAlias = dict[DistinctField, list[QueryValue]]
 
 # Types for search queries
 SearchField: TypeAlias = Union[DistinctField, Literal["any"]]

--- a/mopidy/types.py
+++ b/mopidy/types.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Literal, TypeVar, Union
+from typing import TYPE_CHECKING, Literal, NewType, TypeVar, Union
 
 if TYPE_CHECKING:
     from typing_extensions import TypeAlias
@@ -47,5 +47,5 @@ TracklistField: TypeAlias = Literal[
 QueryField: TypeAlias = Union[DistinctField, SearchField, TracklistField]
 
 # URI types
-Uri: TypeAlias = str
-UriScheme: TypeAlias = str
+Uri = NewType("Uri", str)
+UriScheme = NewType("UriScheme", str)

--- a/mopidy/types.py
+++ b/mopidy/types.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Literal, NewType, TypeVar, Union
 
 if TYPE_CHECKING:
@@ -7,7 +8,7 @@ if TYPE_CHECKING:
 
 F = TypeVar("F")
 QueryValue: TypeAlias = Union[str, int]
-Query: TypeAlias = dict[F, list[QueryValue]]
+Query: TypeAlias = dict[F, Iterable[QueryValue]]
 
 # Types for distinct queries
 DistinctField: TypeAlias = Literal[
@@ -30,7 +31,7 @@ DistinctField: TypeAlias = Literal[
 
 # Types for search queries
 SearchField: TypeAlias = Union[DistinctField, Literal["any"]]
-SearchQuery: TypeAlias = dict[SearchField, list[QueryValue]]
+SearchQuery: TypeAlias = dict[SearchField, Iterable[QueryValue]]
 
 # Types for tracklist filtering
 TracklistField: TypeAlias = Literal[

--- a/mopidy/types.py
+++ b/mopidy/types.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Literal, TypeVar, Union
+
+if TYPE_CHECKING:
+    from typing_extensions import TypeAlias
+
+F = TypeVar("F")
+QueryValue: TypeAlias = Union[str, int]
+Query: TypeAlias = dict[F, list[QueryValue]]
+
+# Types for distinct queries
+DistinctField: TypeAlias = Literal[
+    "uri",
+    "track_name",
+    "album",
+    "artist",
+    "albumartist",
+    "composer",
+    "performer",
+    "track_no",
+    "genre",
+    "date",
+    "comment",
+    "disc_no",
+    "musicbrainz_albumid",
+    "musicbrainz_artistid",
+    "musicbrainz_trackid",
+]
+DistinctQuery: TypeAlias = dict[DistinctField, list[QueryValue]]
+
+# Types for search queries
+SearchField: TypeAlias = Union[DistinctField, Literal["any"]]
+SearchQuery: TypeAlias = dict[SearchField, list[QueryValue]]
+
+# Types for tracklist filtering
+TracklistField: TypeAlias = Literal[
+    "tlid",
+    "uri",
+    "name",
+    "genre",
+    "comment",
+    "musicbrainz_id",
+]
+
+# Superset of all fields that can be used in a query
+QueryField: TypeAlias = Union[DistinctField, SearchField, TracklistField]
+
+# URI types
+Uri: TypeAlias = str
+UriScheme: TypeAlias = str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,6 +62,7 @@ ignore = [
     "A003",    # builtin-attribute-shadowing
     "ANN101",  # missing-type-self
     "ANN102",  # missing-type-cls
+    "ANN401",  # any-type
     "D100",    # undocumented-public-module  # TODO
     "D101",    # undocumented-public-class  # TODO
     "D102",    # undocumented-public-method  # TODO


### PR DESCRIPTION
This adds type hints to all of the Core API, which will hopefully be helpful in both Core API tests and frontends.

---

Example of type hints in action in VS Code in the Core API test suite. The `dict[str, tuple[Image, ...]]` part is visually inserted by VS Code on the fly.

![screenshot_2023-08-14_00-32-49](https://github.com/mopidy/mopidy/assets/43726/1cbb794f-6749-4d9f-b95a-724f1a1c1180)

