### PR TITLE
Show type hints in API docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -9,42 +9,6 @@ sys.path.insert(0, str(Path(__file__).parent.parent.resolve()))
 
 from mopidy.internal.versioning import get_version  # noqa: E402
 
-# -- Workarounds to have autodoc generate API docs ----------------------------
-
-
-class Mock:
-    def __init__(self, *args, **kwargs):
-        pass
-
-    def __call__(self, *_args, **_kwargs):
-        return Mock()
-
-    def __or__(self, other):
-        return Mock()
-
-    def __mro_entries__(self, bases):
-        return ()
-
-    @classmethod
-    def __getattr__(cls, name):
-        if name == "get_system_config_dirs":  # GLib.get_system_config_dirs()
-            return list
-        if name == "get_user_config_dir":  # GLib.get_user_config_dir()
-            return str
-        return Mock()
-
-
-MOCK_MODULES = [
-    "dbus",
-    "dbus.mainloop",
-    "dbus.mainloop.glib",
-    "dbus.service",
-    "mopidy.internal.gi",
-]
-for mod_name in MOCK_MODULES:
-    sys.modules[mod_name] = Mock()
-
-
 # -- Custom Sphinx setup ------------------------------------------------------
 
 
@@ -60,7 +24,7 @@ def setup(app):
 
 # -- General configuration ----------------------------------------------------
 
-needs_sphinx = "1.3"
+needs_sphinx = "1.6"
 
 extensions = [
     "sphinx.ext.autodoc",
@@ -121,6 +85,14 @@ latex_documents = [
 
 man_pages = [
     ("command", "mopidy", "music server", "", "1"),
+]
+
+
+# -- Options for autodoc extension --------------------------------------------
+
+autodoc_mock_imports = [
+    "dbus",
+    "mopidy.internal.gi",
 ]
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_autodoc_typehints",
     "sphinx_rtd_theme",
 ]
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -45,13 +45,11 @@ for mod_name in MOCK_MODULES:
     sys.modules[mod_name] = Mock()
 
 
-# -- Custom Sphinx object types -----------------------------------------------
+# -- Custom Sphinx setup ------------------------------------------------------
 
 
 def setup(app):
-    from sphinx.ext.autodoc import cut_lines
-
-    app.connect("autodoc-process-docstring", cut_lines(4, what=["module"]))
+    # Add custom Sphinx object type for Mopidy's config values
     app.add_object_type(
         "confval",
         "confval",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -32,6 +32,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "sphinx.ext.intersphinx",
     "sphinx.ext.viewcode",
+    "sphinx_rtd_theme",
 ]
 
 templates_path = ["_templates"]

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ def setup(app):
 
 # -- General configuration ----------------------------------------------------
 
-needs_sphinx = "1.6"
+needs_sphinx = "3.4"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -33,12 +33,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-_default_config: list[Path] = [
-    (Path(base) / "mopidy" / "mopidy.conf").resolve()
-    for base in [*GLib.get_system_config_dirs(), GLib.get_user_config_dir()]
-]
-DEFAULT_CONFIG = ":".join(map(str, _default_config))
-
 
 def config_files_type(value: str) -> list[str]:
     return value.split(":")
@@ -319,7 +313,6 @@ class RootCommand(Command):
             action="store",
             dest="config_files",
             type=config_files_type,
-            default=DEFAULT_CONFIG,
             metavar="FILES",
             help="config files to use, colon seperated, later files override",
         )

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -151,13 +151,13 @@ _INITIAL_HELP = """
 """
 
 
-def read(config_file: Union[str, os.PathLike[str]]) -> str:
+def read(config_file: pathlib.Path) -> str:
     """Helper to load config defaults in same way across core and extensions."""
     return pathlib.Path(config_file).read_text(errors="surrogateescape")
 
 
 def load(
-    files: list[os.PathLike],
+    files: list[pathlib.Path],
     ext_schemas: list[ConfigSchema],
     ext_defaults: list[str],
     overrides: list[Any],
@@ -207,7 +207,7 @@ def format_initial(extensions_data: list[ExtensionData]) -> str:
 
 
 def _load(
-    files: list[os.PathLike],
+    files: list[pathlib.Path],
     defaults: list[str],
     overrides: list[tuple[str, str, Any]],
 ) -> RawConfig:

--- a/setup.cfg
+++ b/setup.cfg
@@ -44,9 +44,9 @@ install_requires =
 [options.extras_require]
 docs =
     pygraphviz
-    sphinx
-    sphinx_autodoc_typehints
-    sphinx_rtd_theme
+    sphinx >= 3.4.3, < 7
+    sphinx_autodoc_typehints >= 1.9.0
+    sphinx_rtd_theme >= 0.5.1
 lint =
     black
     check-manifest

--- a/setup.cfg
+++ b/setup.cfg
@@ -45,6 +45,7 @@ install_requires =
 docs =
     pygraphviz
     sphinx
+    sphinx_autodoc_typehints
     sphinx_rtd_theme
 lint =
     black


### PR DESCRIPTION
This PR modernizes the Sphinx setup a bit to get to the point where `sphinx-autodoc-typehints` can successfully build API docs with type hints.

![screenshot_2023-08-16_00-16-28](https://github.com/mopidy/mopidy/assets/43726/9c6b8f70-6eb7-41c9-b130-f817696cbdb0)

