### PR TITLE
Remove appsrc support

### DIFF
--- a/docs/api/backend.rst
+++ b/docs/api/backend.rst
@@ -27,8 +27,7 @@ GStreamer knows how to play right before playback. For example:
 
 - Spotify already has its own URI scheme (``spotify:track:...``,
   ``spotify:playlist:...``, etc.) used throughout their applications, and thus
-  Mopidy-Spotify simply uses the same URI scheme. Playback is handled by
-  pushing raw audio data into a GStreamer ``appsrc`` element.
+  Mopidy-Spotify simply uses the same URI scheme.
 
 - Mopidy-SoundCloud created it's own URI scheme, after the model of Spotify,
   and uses URIs of the following forms: ``soundcloud:search``,

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -39,6 +39,9 @@ Audio
   which has not been used since Spotify shut down their libspotify APIs in
   May 2022. The removed functions/methods are:
 
+  - :meth:`mopidy.audio.Audio.emit_data`
+  - :meth:`mopidy.audio.Audio.set_appsrc`
+  - :meth:`mopidy.audio.Audio.set_metadata`
   - :func:`mopidy.audio.calculate_duration`
   - :func:`mopidy.audio.create_buffer`
   - :func:`mopidy.audio.millisecond_to_clocktime`

--- a/mopidy/internal/deps.py
+++ b/mopidy/internal/deps.py
@@ -170,8 +170,6 @@ def _gstreamer_check_elements():
         "uridecodebin",
         # External HTTP streams
         "souphttpsrc",
-        # Spotify
-        "appsrc",
         # Audio sinks
         "alsasink",
         "osssink",

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -648,8 +648,6 @@ class AudioLiveTest(unittest.TestCase):
         self.audio._playbin = mock.Mock(spec=["set_property"])
 
         self.source = mock.MagicMock()
-        # Avoid appsrc.configure()
-        self.source.get_factory.get_name = mock.Mock(return_value="not_appsrc")
         self.source.props = mock.Mock(spec=["is_live"])
 
     def test_not_live_mode(self):
@@ -665,17 +663,6 @@ class AudioLiveTest(unittest.TestCase):
         self.audio._on_source_setup("dummy", self.source)
 
         self.source.set_live.assert_called_with(True)
-
-    def test_not_live_mode_after_set_appsrc(self):
-        self.audio._live_stream = True
-
-        # Embrace appsrc.configure()
-        self.source.get_factory.get_name.return_value = "appsrc"
-
-        self.audio.set_appsrc("")
-        self.audio._on_source_setup("dummy", self.source)
-
-        self.source.set_live.assert_not_called()
 
 
 class DownloadBufferingTest(unittest.TestCase):
@@ -701,15 +688,6 @@ class DownloadBufferingTest(unittest.TestCase):
 
         playbin.set_property.assert_has_calls([mock.call("flags", 0x02)])
 
-    def test_download_flag_is_not_passed_to_playbin_if_set_appsrc(
-        self,
-    ):
-        playbin = self.audio._playbin
-
-        self.audio.set_appsrc("")
-
-        playbin.set_property.assert_has_calls([mock.call("flags", 0x02)])
-
 
 class SourceSetupCallbackTest(unittest.TestCase):
     def setUp(self):
@@ -718,8 +696,6 @@ class SourceSetupCallbackTest(unittest.TestCase):
         self.audio._playbin = mock.Mock(spec=["set_property"])
 
         self.source = mock.MagicMock()
-        # Avoid appsrc.configure()
-        self.source.get_factory.get_name = mock.Mock(return_value="not_appsrc")
 
     def test_source_setup_callback(self):
         mock_callback = mock.MagicMock()

--- a/tests/dummy_audio.py
+++ b/tests/dummy_audio.py
@@ -37,12 +37,6 @@ class DummyAudio(pykka.ThreadingActor):
         self._live_stream = live_stream
         self._tags = {}
 
-    def set_appsrc(self, *args, **kwargs):
-        pass
-
-    def emit_data(self, buffer_):
-        pass
-
     def get_position(self):
         return self._position
 
@@ -71,9 +65,6 @@ class DummyAudio(pykka.ThreadingActor):
     def set_volume(self, volume):
         self._volume = volume
         return True
-
-    def set_metadata(self, track):
-        pass
 
     def get_current_tags(self):
         return self._tags


### PR DESCRIPTION
This has previously been used by Mopidy-Spotify. Removing this will make
it easier to maintain the remaining audio layer because there will be
fewer corner cases to think about and test.

Fixes #2114
