### PR TITLE
Bump all deps to Debian Bookworm version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,30 +13,27 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - name: "Test: Python 3.9"
-            python: "3.9"
-            tox: py39
-          - name: "Test: Python 3.10"
-            python: "3.10"
-            tox: py310
           - name: "Test: Python 3.11"
             python: "3.11"
             tox: py311
+          - name: "Test: Python 3.12"
+            python: "3.12"
+            tox: py312
             coverage: true
           - name: "Lint: black"
-            python: "3.11"
+            python: "3.12"
             tox: black
           - name: "Lint: check-manifest"
-            python: "3.11"
+            python: "3.12"
             tox: check-manifest
           - name: "Lint: pyright"
-            python: "3.11"
+            python: "3.12"
             tox: pyright
           - name: "Lint: ruff"
-            python: "3.11"
+            python: "3.12"
             tox: ruff
           - name: "Docs"
-            python: "3.11"
+            python: "3.12"
             tox: docs
 
     name: ${{ matrix.name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: "3.11"
+          python-version: "3.12"
       - name: "Install dependencies"
         run: python3 -m pip install build
       - name: "Build package"

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Dependencies
 
 - Pykka >= 4.0 is now required.
 
+- Requests >= 2.28 is now required.
+
 - Tornado >= 6.2 is now required.
 
 - Replaced :mod:`pkg_resources`` with :mod:`importlib.metadata`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,8 @@ Dependencies
 
 - Requests >= 2.28 is now required.
 
+- Setuptools >= 66 is now required.
+
 - Tornado >= 6.2 is now required.
 
 - Replaced :mod:`pkg_resources`` with :mod:`importlib.metadata`.

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Dependencies
 
 - Pykka >= 4.0 is now required.
 
+- Tornado >= 6.2 is now required.
+
 - Replaced :mod:`pkg_resources`` with :mod:`importlib.metadata`.
 
 Audio

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,9 +18,11 @@ old versions of our dependencies and a number of deprecated APIs.
 Dependencies
 ------------
 
-- Python >= 3.9 is now required. Python 3.7 and 3.8 are no longer supported.
+- Python >= 3.11 is now required. Python 3.7-3.10 are no longer supported.
 
 - GStreamer >= 1.18.0 is now required.
+
+- Pykka >= 4.0 is now required.
 
 - Replaced :mod:`pkg_resources`` with :mod:`importlib.metadata`.
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -9,8 +9,20 @@ This changelog is used to track all major changes to Mopidy.
 For older releases, see :ref:`history`.
 
 
-v3.5.0 (UNRELEASED)
+v4.0.0 (UNRELEASED)
 ===================
+
+Mopidy 4.0 is a backward-incompatible release because we've dropped support for
+old versions of our dependencies and a number of deprecated APIs.
+
+Dependencies
+------------
+
+- Python >= 3.9 is now required. Python 3.7 and 3.8 are no longer supported.
+
+- GStreamer >= 1.18.0 is now required.
+
+- Replaced :mod:`pkg_resources`` with :mod:`importlib.metadata`.
 
 Audio
 -----
@@ -22,15 +34,6 @@ Audio
   - :func:`mopidy.audio.calculate_duration`
   - :func:`mopidy.audio.create_buffer`
   - :func:`mopidy.audio.millisecond_to_clocktime`
-
-Dependencies
-------------
-
-- Python >= 3.9 is now required. Python 3.7 and 3.8 are no longer supported.
-
-- GStreamer >= 1.18.0 is now required.
-
-- Replaced :mod:`pkg_resources`` with :mod:`importlib.metadata`.
 
 Internals
 ---------

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,7 @@ Dependencies
 
 - Python >= 3.11 is now required. Python 3.7-3.10 are no longer supported.
 
-- GStreamer >= 1.18.0 is now required.
+- GStreamer >= 1.22.0 is now required.
 
 - Pykka >= 4.0 is now required.
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -24,7 +24,7 @@ def setup(app):
 
 # -- General configuration ----------------------------------------------------
 
-needs_sphinx = "3.4"
+needs_sphinx = "5.3"
 
 extensions = [
     "sphinx.ext.autodoc",

--- a/docs/installation/debian.rst
+++ b/docs/installation/debian.rst
@@ -10,7 +10,7 @@ easiest way to install Mopidy is from the
 When installing from the APT archive, you will automatically get updates to
 Mopidy in the same way as you get updates to the rest of your system.
 
-If you're on a Raspberry Pi running Debian or Raspbian, the following
+If you're on a Raspberry Pi running Debian or Raspberry Pi OS, the following
 instructions will work for you as well. If you're setting up a Raspberry Pi
 from scratch, we have a guide for installing Debian/Raspbian and Mopidy. See
 :ref:`raspberrypi-installation`.
@@ -21,8 +21,8 @@ Distribution and architecture support
 
 The packages in the apt.mopidy.com archive are built for:
 
-- **Debian 11 (Bullseye)**,
-  which also works for Raspbian Bullseye and Ubuntu 22.04 and newer.
+- **Debian 12 (Bookworm)**,
+  which also works for Ubuntu 23.10 and Raspberry Pi OS 2023-10-10 or newer.
 
 The few packages that are compiled are available for multiple CPU
 architectures:
@@ -48,7 +48,7 @@ Install from apt.mopidy.com
 
 #. Add the APT repo to your package sources::
 
-       sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/bullseye.list
+       sudo wget -q -O /etc/apt/sources.list.d/mopidy.list https://apt.mopidy.com/bookworm.list
 
 #. Install Mopidy and all dependencies::
 

--- a/mopidy/audio/actor.py
+++ b/mopidy/audio/actor.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 import os
 import threading
-from typing import TYPE_CHECKING, Any, Callable, Optional, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, Optional, cast
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method

--- a/mopidy/audio/listener.py
+++ b/mopidy/audio/listener.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal, Optional
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from mopidy.audio import PlaybackState
     from mopidy.types import DurationMs, Uri

--- a/mopidy/audio/tags.py
+++ b/mopidy/audio/tags.py
@@ -76,7 +76,7 @@ gstreamer-GstTagList.html
                 result[tag].append(value.to_iso8601_string())
             elif isinstance(value, bytes):
                 result[tag].append(value.decode(errors="replace"))
-            elif isinstance(value, (str, bool, numbers.Number)):
+            elif isinstance(value, str | bool | numbers.Number):
                 result[tag].append(value)
             elif isinstance(value, Gst.Sample):
                 data = _extract_sample_data(value)

--- a/mopidy/audio/utils.py
+++ b/mopidy/audio/utils.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Callable, cast
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any, cast
 
 from mopidy import httpclient
 from mopidy.internal.gi import Gst

--- a/mopidy/backend.py
+++ b/mopidy/backend.py
@@ -11,7 +11,7 @@ from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from mopidy.audio.actor import AudioProxy
     from mopidy.internal.gi import Gst

--- a/mopidy/commands.py
+++ b/mopidy/commands.py
@@ -94,7 +94,7 @@ class Command:
     #: Help text to display in help output.
 
     _children: dict[str, Command]
-    _arguments: list[tuple[tuple[Any], dict[str, Any]]]
+    _arguments: list[tuple[tuple[Any, ...], dict[str, Any]]]
     _overrides: dict[str, Any]
 
     def __init__(self) -> None:

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -31,7 +31,7 @@ from mopidy.config.types import (
 from mopidy.internal import path, versioning
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from mopidy.ext import ExtensionData
     from mopidy.internal.log import LogColorName, LogLevelName

--- a/mopidy/config/__init__.py
+++ b/mopidy/config/__init__.py
@@ -349,12 +349,14 @@ def _preprocess(config_string: str) -> str:
     def newlines(_match) -> str:
         return f"__BLANK{next(counter):d}__ ="
 
-    def comments(match) -> Optional[str]:
-        if match.group(1) == "#":
-            return f"__HASH{next(counter):d}__ ="
-        if match.group(1) == ";":
-            return f"__SEMICOLON{next(counter):d}__ ="
-        return None
+    def comments(match) -> str:
+        match match.group(1):
+            case "#":
+                return f"__HASH{next(counter):d}__ ="
+            case ";":
+                return f"__SEMICOLON{next(counter):d}__ ="
+            case _:
+                raise AssertionError(f"Unexpected comment type: {match.group(1)!r}")
 
     def inlinecomments(_match) -> str:
         return f"\n__INLINE{next(counter):d}__ ="

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -505,4 +505,4 @@ class Path(ConfigValue[_ExpandedPath]):
             result = result.original
         if isinstance(result, bytes):
             result = result.decode(errors="surrogateescape")
-        return result
+        return str(result)

--- a/mopidy/config/types.py
+++ b/mopidy/config/types.py
@@ -6,11 +6,11 @@ import logging
 import re
 import socket
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
     AnyStr,
-    Callable,
     ClassVar,
     Generic,
     Literal,
@@ -280,7 +280,7 @@ class Pair(ConfigValue[tuple[K, V]]):
         optional: bool = False,
         optional_pair: bool = False,
         separator: str = "|",
-        subtypes: tuple[K, V] = (String(), String()),  # noqa: B008
+        subtypes: tuple[K, V] = (String(), String()),
     ) -> None:
         self._required = not optional
         self._optional_pair = optional_pair

--- a/mopidy/core/history.py
+++ b/mopidy/core/history.py
@@ -12,7 +12,7 @@ from mopidy.internal.models import HistoryState, HistoryTrack
 from mopidy.models import Ref, Track
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 logger = logging.getLogger(__name__)
 

--- a/mopidy/core/library.py
+++ b/mopidy/core/library.py
@@ -205,7 +205,7 @@ class LibraryController:
             if backend_uris
         }
 
-        results = {uri: () for uri in uris}
+        results: dict[Uri, tuple[Image, ...]] = {uri: () for uri in uris}
         for backend, future in futures.items():
             with _backend_error_handling(backend):
                 if future.get() is None:

--- a/mopidy/core/listener.py
+++ b/mopidy/core/listener.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING, Any, Literal
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from mopidy.audio import PlaybackState
     from mopidy.models import Playlist, TlTrack

--- a/mopidy/ext.py
+++ b/mopidy/ext.py
@@ -1,14 +1,9 @@
 from __future__ import annotations
 
 import logging
-import sys
 from collections.abc import Mapping
+from importlib import metadata
 from typing import TYPE_CHECKING, NamedTuple, Union
-
-if sys.version_info < (3, 10):
-    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
-else:
-    from importlib import metadata
 
 from mopidy import config as config_lib
 from mopidy import exceptions
@@ -17,9 +12,7 @@ from mopidy.internal import path
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
-    from typing import Any, Optional
-
-    from typing_extensions import TypeAlias
+    from typing import Any, Optional, TypeAlias
 
     from mopidy.commands import Command
     from mopidy.config import ConfigSchema

--- a/mopidy/http/handlers.py
+++ b/mopidy/http/handlers.py
@@ -3,8 +3,9 @@ from __future__ import annotations
 import functools
 import logging
 import urllib.parse
+from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Callable, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, Optional, Union, cast
 
 import tornado.escape
 import tornado.ioloop

--- a/mopidy/http/types.py
+++ b/mopidy/http/types.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from collections.abc import Callable
 from os import PathLike
-from typing import TYPE_CHECKING, Any, Callable, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, Optional, TypedDict
 
 import tornado.web
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from mopidy.core.actor import CoreProxy
     from mopidy.ext import Config

--- a/mopidy/internal/deps.py
+++ b/mopidy/internal/deps.py
@@ -4,19 +4,16 @@ import functools
 import platform
 import re
 import sys
+from collections.abc import Callable
+from importlib import metadata
 from pathlib import Path
-from typing import TYPE_CHECKING, Callable, Optional, TypedDict
-
-if sys.version_info < (3, 10):
-    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
-else:
-    from importlib import metadata
+from typing import TYPE_CHECKING, Optional, TypedDict
 
 from mopidy.internal import formatting
 from mopidy.internal.gi import Gst, gi
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     class DepInfo(TypedDict, total=False):
         name: str

--- a/mopidy/internal/deps.py
+++ b/mopidy/internal/deps.py
@@ -6,6 +6,7 @@ import re
 import sys
 from collections.abc import Callable
 from importlib import metadata
+from os import PathLike
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional, TypedDict
 
@@ -18,7 +19,7 @@ if TYPE_CHECKING:
     class DepInfo(TypedDict, total=False):
         name: str
         version: str
-        path: Path
+        path: PathLike[str]
         dependencies: list[DepInfo]
         other: str
 
@@ -30,7 +31,7 @@ def format_dependency_list(adapters: Optional[list[Adapter]] = None) -> str:
         dist_names = {
             ep.dist.name
             for ep in metadata.entry_points(group="mopidy.ext")
-            if ep.dist.name != "Mopidy"
+            if ep.dist is not None and ep.dist.name != "Mopidy"
         }
         dist_infos = [
             functools.partial(pkg_info, dist_name) for dist_name in dist_names

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -32,7 +32,7 @@ else:
 GLib.set_prgname("mopidy")
 GLib.set_application_name("Mopidy")
 
-REQUIRED_GST_VERSION = (1, 18, 0)
+REQUIRED_GST_VERSION = (1, 22, 0)
 REQUIRED_GST_VERSION_DISPLAY = ".".join(map(str, REQUIRED_GST_VERSION))
 
 if Gst.version() < REQUIRED_GST_VERSION:

--- a/mopidy/internal/jsonrpc.py
+++ b/mopidy/internal/jsonrpc.py
@@ -355,7 +355,7 @@ class JsonRpcInspector:
 
         params = []
 
-        for arg, _default in zip(argspec.args, defaults):
+        for arg, _default in zip(argspec.args, defaults, strict=True):
             if arg == "self":
                 continue
             params.append({"name": arg})

--- a/mopidy/mixer.py
+++ b/mopidy/mixer.py
@@ -11,7 +11,7 @@ from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
 from mopidy import listener
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
     from mopidy.types import Percentage
 

--- a/mopidy/models/fields.py
+++ b/mopidy/models/fields.py
@@ -1,10 +1,10 @@
 from __future__ import annotations
 
 import sys
+from collections.abc import Callable
 from typing import (
     TYPE_CHECKING,
     Any,
-    Callable,
     Generic,
     Optional,
     TypeVar,

--- a/mopidy/models/immutable.py
+++ b/mopidy/models/immutable.py
@@ -65,7 +65,7 @@ class ImmutableObject:
     def __repr__(self):
         kwarg_pairs = []
         for key, value in sorted(self._items()):
-            if isinstance(value, (frozenset, tuple)):
+            if isinstance(value, frozenset | tuple):
                 if not value:
                     continue
                 value = list(value)
@@ -116,7 +116,7 @@ class ImmutableObject:
         data = {}
         data["__model__"] = self.__class__.__name__
         for key, value in self._items():
-            if isinstance(value, (set, frozenset, list, tuple)):
+            if isinstance(value, set | frozenset | list | tuple):
                 value = [
                     v.serialize() if isinstance(v, ImmutableObject) else v
                     for v in value

--- a/mopidy/types.py
+++ b/mopidy/types.py
@@ -4,7 +4,7 @@ from collections.abc import Iterable
 from typing import TYPE_CHECKING, Literal, NewType, TypeVar, Union
 
 if TYPE_CHECKING:
-    from typing_extensions import TypeAlias
+    from typing import TypeAlias
 
 F = TypeVar("F")
 QueryValue: TypeAlias = Union[str, int]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ target-version = ["py311", "py312"]
 
 
 [tool.pyright]
-pythonVersion = "3.9"
+pythonVersion = "3.11"
 # Use venv from parent directory, to share it with any extensions:
 venvPath = "../"
 venv = ".venv"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools >= 30.3.0", "wheel"]
 
 
 [tool.black]
-target-version = ["py39", "py310", "py311"]
+target-version = ["py311", "py312"]
 
 
 [tool.pyright]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,7 @@ ignore = [
     "UP006", # deprecated-collection-type
     "UP007", # typing-union
 ]
-target-version = "py39"
+target-version = "py311"
 
 [tool.ruff.per-file-ignores]
 "docs/*" = [

--- a/setup.cfg
+++ b/setup.cfg
@@ -35,7 +35,7 @@ python_requires = >= 3.11
 install_requires =
     Pykka >= 4.0
     requests >= 2.28
-    setuptools
+    setuptools >= 66
     tornado >= 6.2
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ packages = find:
 python_requires = >= 3.11
 install_requires =
     Pykka >= 4.0
-    requests >= 2.0
+    requests >= 2.28
     setuptools
     tornado >= 6.2
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -49,7 +49,7 @@ docs =
 lint =
     black
     check-manifest
-    ruff == 0.0.285
+    ruff == 0.1.0
 test =
     pytest
     pytest-cov

--- a/setup.cfg
+++ b/setup.cfg
@@ -41,11 +41,10 @@ install_requires =
 
 [options.extras_require]
 docs =
-    pygraphviz
-    sphinx >= 3.4.3, < 7
-    sphinx_autodoc_typehints >= 1.9.0
-    sphinx_rtd_theme >= 0.5.1
-    typing-extensions
+    pygraphviz >= 0.20
+    sphinx >= 5.3
+    sphinx_autodoc_typehints >= 1.12
+    sphinx_rtd_theme >= 1.2
 lint =
     black
     check-manifest

--- a/setup.cfg
+++ b/setup.cfg
@@ -22,9 +22,8 @@ classifiers =
     Operating System :: MacOS :: MacOS X
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3
-    Programming Language :: Python :: 3.9
-    Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Multimedia :: Sound/Audio :: Players
 
 
@@ -32,13 +31,12 @@ classifiers =
 zip_safe = False
 include_package_data = True
 packages = find:
-python_requires = >= 3.9
+python_requires = >= 3.11
 install_requires =
     Pykka >= 4.0
     requests >= 2.0
     setuptools
     tornado >= 4.4
-    importlib_metadata >= 4.6; python_version < "3.10"
 
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ install_requires =
     Pykka >= 4.0
     requests >= 2.0
     setuptools
-    tornado >= 4.4
+    tornado >= 6.2
 
 
 [options.extras_require]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = Mopidy
-version = 3.4.1
+version = 4.0.0a1
 url = https://mopidy.com/
 project_urls =
     Documentation = https://docs.mopidy.com/

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -26,7 +26,7 @@ class TestConvertTaglist:
         taglist = Gst.TagList.new_empty()
 
         for value in values:
-            if isinstance(value, (GLib.Date, Gst.DateTime)):
+            if isinstance(value, GLib.Date | Gst.DateTime):
                 taglist.add_value(Gst.TagMergeMode.APPEND, tag, value)
                 continue
 

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -1,12 +1,8 @@
 import platform
 import sys
+from importlib import metadata
 from pathlib import Path
 from unittest import mock
-
-if sys.version_info < (3, 10):
-    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
-else:
-    from importlib import metadata
 
 import pytest
 

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -61,7 +61,7 @@ class TestDeps:
     def test_format_dependency_list_real(self):
         result = deps.format_dependency_list()
         assert "Python 3." in result
-        assert "Mopidy: 3." in result
+        assert "Mopidy: 4." in result
         assert "setuptools: 6" in result
 
     def test_executable_info(self):

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -1,11 +1,6 @@
 import pathlib
-import sys
+from importlib import metadata
 from unittest import mock
-
-if sys.version_info < (3, 10):
-    import importlib_metadata as metadata  # pyright: ignore[reportMissingImports]
-else:
-    from importlib import metadata
 
 import pytest
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,9 +29,7 @@ changedir = docs
 commands = python -m sphinx -b linkcheck -d {envtmpdir}/doctrees . {envtmpdir}/html
 
 [testenv:pyright]
-deps =
-    .[typing]
-    tornado >= 6  # First version to ship type information
+deps = .[typing]
 commands = python -m pyright mopidy
 
 [testenv:ruff]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py39, py310, py311, black, check-manifest, docs, pyright, ruff
+envlist = py311, py312, black, check-manifest, docs, pyright, ruff
 
 [testenv]
 sitepackages = true


### PR DESCRIPTION
This PR bumps all of our dependencies to the version released in Debian 12 (Bookworm). These versions are now widely available through:

- Debian 12 (Bookworm) released 2023-07-10
- Raspberry Pi OS (Bookworm) released 2023-10-10
- Ubuntu 23.10 released 2023-10-12

### TODO

- [x] Update apt.mopidy.com to have a Bookworm dist
- [x] Update CI image to Ubuntu 23.10 with GStreamer 1.22, using Bookworm dist from apt.mopidy.com