### PR TITLE
Update README.rst - fix two grammar issues.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -33,7 +33,7 @@ systems, you can control the music from any phone, tablet, or computer.
 
 **Mopidy on Raspberry Pi**
 
-The `Raspberry Pi`_ is an popular device to run Mopidy on, either using
+The `Raspberry Pi`_ is a popular device to run Mopidy on, either using
 Raspbian, Ubuntu, or Arch Linux.
 Pimoroni recommends Mopidy for use with their `Pirate Audio`_ audio gear for
 Raspberry Pi.
@@ -45,7 +45,7 @@ audio jukebox system for Raspberry Pi.
 Mopidy's extension support and Python, JSON-RPC, and JavaScript APIs make
 Mopidy a perfect base for your projects.
 In one hack, a Raspberry Pi was embedded in an old cassette player. The buttons
-and volume control are wired up with GPIO on the Raspberry Pi, and is used to
+and volume control are wired up with GPIO on the Raspberry Pi, and are used to
 control playback through a custom Mopidy extension. The cassettes have NFC tags
 used to select playlists from Spotify.
 


### PR DESCRIPTION
I have noticed some grammatical mistakes in **README** inside section "**Mopidy on Raspberry Pi**" and "**Mopidy is hackable**"

"**The Raspberry Pi is an popular device**"  should be "**The Raspberry Pi is a popular device**"

" **and is used to control playback**"  should be " **and are used to control playback**"

Screenshot-

![Screenshot (125)](https://github.com/mopidy/mopidy/assets/115995339/67e8f054-1f9e-49d6-baba-34808c6f2583)

