### PR TITLE
PyGObject as explicit dependency

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -22,6 +22,9 @@ Dependencies
 
 - GStreamer >= 1.22.0 is now required.
 
+- PyGObject >= 3.42 is now an explicit Python dependency, and not something we
+  assume you'll install together with GStreamer.
+
 - Pykka >= 4.0 is now required.
 
 - Requests >= 2.28 is now required.

--- a/docs/devenv.rst
+++ b/docs/devenv.rst
@@ -58,12 +58,10 @@ Most of us use the `virtualenvwrapper
 virtualenvs, so that's what we'll be using for the examples here. First,
 install and setup virtualenvwrapper as described in their docs.
 
-To create a virtualenv named ``mopidy``, which allows access to
-system-wide packages like GStreamer, and uses the Mopidy workspace directory as
-the "project path", run::
+To create a virtualenv named ``mopidy`` and uses the Mopidy workspace directory
+as the "project path", run::
 
-    mkvirtualenv -a ~/mopidy-dev --python $(which python3) \
-      --system-site-packages mopidy
+    mkvirtualenv -a ~/mopidy-dev --python $(which python3) mopidy
 
 Now, each time you open a terminal and want to activate the ``mopidy``
 virtualenv, run::

--- a/mopidy/internal/gi.py
+++ b/mopidy/internal/gi.py
@@ -3,12 +3,12 @@
 import sys
 import textwrap
 
-try:
-    import gi
+import gi
 
+try:
     gi.require_version("Gst", "1.0")
-    from gi.repository import GLib, GObject, Gst
-except ImportError:
+    gi.require_version("GstPbutils", "1.0")
+except ValueError:
     print(  # noqa: T201
         textwrap.dedent(
             """
@@ -24,11 +24,10 @@ except ImportError:
         )
     )
     raise
-else:
-    Gst.init([])
-    gi.require_version("GstPbutils", "1.0")
-    from gi.repository import GstPbutils
 
+from gi.repository import GLib, GObject, Gst, GstPbutils
+
+Gst.init([])
 GLib.set_prgname("mopidy")
 GLib.set_application_name("Mopidy")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,8 @@ include_package_data = True
 packages = find:
 python_requires = >= 3.11
 install_requires =
-    Pykka >= 4.0
+    pygobject >= 3.42
+    pykka >= 4.0
     requests >= 2.28
     setuptools >= 66
     tornado >= 6.2


### PR DESCRIPTION
This makes PyGObject (the `gi` module) an explicit dependency, so that we no longer need to make sure our development virtualenv is created with `--system-site-packages` to get access to the globally installed PyGObject (`python3-gi` on Debian/Ubuntu).

The only downside I can think of right now is that extensions, which depends on Mopidy, will have to have PyGObject's system library dependencies installed to be able to run tests. As long as they make use of the `mopidy/ci:latest` image to run tests on CI, this should already be handled for them.