### PR TITLE
Use new union type from Python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -157,10 +157,6 @@ ignore = [
     "TCH003",  # typing-only-standard-library-import
     "TRY003",  # raise-vanilla-args
     "TRY400",  # error-instead-of-exception
-    #
-    # Equivalent to `pyupgrade --keep-runtime-typing`:
-    "UP006", # deprecated-collection-type
-    "UP007", # typing-union
 ]
 target-version = "py311"
 

--- a/src/mopidy/audio/actor.py
+++ b/src/mopidy/audio/actor.py
@@ -4,7 +4,7 @@ import logging
 import os
 import threading
 from collections.abc import Callable
-from typing import TYPE_CHECKING, Any, Optional, cast
+from typing import TYPE_CHECKING, Any, cast
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
@@ -87,9 +87,9 @@ class _Outputs(Gst.Bin):
 
 class SoftwareMixerAdapter:
     _mixer: SoftwareMixerProxy
-    _element: Optional[Gst.Element]
-    _last_volume: Optional[int]
-    _last_mute: Optional[bool]
+    _element: Gst.Element | None
+    _last_volume: int | None
+    _last_mute: bool | None
     _signals: utils.Signals
 
     def __init__(self, mixer: SoftwareMixerProxy) -> None:
@@ -375,12 +375,12 @@ class Audio(pykka.ThreadingActor):
     state: PlaybackState = PlaybackState.STOPPED
 
     #: The software mixing interface :class:`mopidy.audio.actor.SoftwareMixerAdapter`
-    mixer: Optional[SoftwareMixerAdapter] = None
+    mixer: SoftwareMixerAdapter | None = None
 
     def __init__(
         self,
         config: Config,
-        mixer: Optional[MixerProxy],
+        mixer: MixerProxy | None,
     ) -> None:
         super().__init__()
 
@@ -389,15 +389,15 @@ class Audio(pykka.ThreadingActor):
         self._buffering: bool = False
         self._live_stream: bool = False
         self._tags: dict[str, list[Any]] = {}
-        self._pending_uri: Optional[str] = None
-        self._pending_tags: Optional[dict[str, list[Any]]] = None
+        self._pending_uri: str | None = None
+        self._pending_tags: dict[str, list[Any]] | None = None
         self._pending_metadata = None
 
-        self._playbin: Optional[Gst.Element] = None
+        self._playbin: Gst.Element | None = None
         self._outputs = None
         self._queue = None
-        self._about_to_finish_callback: Optional[Callable] = None
-        self._source_setup_callback: Optional[Callable] = None
+        self._about_to_finish_callback: Callable | None = None
+        self._source_setup_callback: Callable | None = None
 
         self._handler = _Handler(self)
         self._signals = utils.Signals()

--- a/src/mopidy/audio/listener.py
+++ b/src/mopidy/audio/listener.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 from mopidy import listener
 
@@ -61,7 +61,7 @@ class AudioListener(listener.Listener):
         self,
         old_state: PlaybackState,
         new_state: PlaybackState,
-        target_state: Optional[PlaybackState],
+        target_state: PlaybackState | None,
     ) -> None:
         """Called after the playback state have changed.
 

--- a/src/mopidy/audio/scan.py
+++ b/src/mopidy/audio/scan.py
@@ -3,7 +3,7 @@ import logging
 import time
 from enum import IntEnum
 from pathlib import Path
-from typing import Any, Optional, cast
+from typing import Any, cast
 
 from mopidy import exceptions
 from mopidy.audio import tags as tags_lib
@@ -240,7 +240,7 @@ def _start_pipeline(pipeline: Gst.Pipeline) -> None:
         pipeline.set_state(Gst.State.PLAYING)
 
 
-def _query_duration(pipeline: Gst.Pipeline) -> tuple[bool, Optional[int]]:
+def _query_duration(pipeline: Gst.Pipeline) -> tuple[bool, int | None]:
     success, duration = pipeline.query_duration(Gst.Format.TIME)
     if not success:
         duration = None  # Make sure error case preserves None.
@@ -260,10 +260,10 @@ def _query_seekable(pipeline: Gst.Pipeline) -> bool:
 def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
     pipeline: Gst.Pipeline,
     timeout_ms: int,
-) -> tuple[dict[str, Any], Optional[str], bool, Optional[int]]:
+) -> tuple[dict[str, Any], str | None, bool, int | None]:
     bus = pipeline.get_bus()
     tags = {}
-    mime: Optional[str] = None
+    mime: str | None = None
     have_audio = False
     missing_message = None
     duration = None
@@ -298,7 +298,7 @@ def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 missing_message = msg
         elif msg.type == Gst.MessageType.APPLICATION:
             if structure and structure.get_name() == "have-type":
-                caps = cast(Optional[Gst.Caps], structure.get_value("caps"))
+                caps = cast(Gst.Caps | None, structure.get_value("caps"))
                 if caps:
                     mime = cast(
                         str,

--- a/src/mopidy/backend.py
+++ b/src/mopidy/backend.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Literal, Optional
+from typing import TYPE_CHECKING, Any, Literal
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
@@ -50,17 +50,17 @@ class Backend:
     #: The library provider. An instance of
     #: :class:`~mopidy.backend.LibraryProvider`, or :class:`None` if
     #: the backend doesn't provide a library.
-    library: Optional[LibraryProvider] = None
+    library: LibraryProvider | None = None
 
     #: The playback provider. An instance of
     #: :class:`~mopidy.backend.PlaybackProvider`, or :class:`None` if
     #: the backend doesn't provide playback.
-    playback: Optional[PlaybackProvider] = None
+    playback: PlaybackProvider | None = None
 
     #: The playlists provider. An instance of
     #: :class:`~mopidy.backend.PlaylistsProvider`, or class:`None` if
     #: the backend doesn't provide playlists.
-    playlists: Optional[PlaylistsProvider] = None
+    playlists: PlaylistsProvider | None = None
 
     #: List of URI schemes this backend can handle.
     uri_schemes: list[UriScheme] = []  # noqa: RUF012
@@ -93,7 +93,7 @@ class LibraryProvider:
     :param backend: backend the controller is a part of
     """
 
-    root_directory: Optional[Ref] = None
+    root_directory: Ref | None = None
     """
     :class:`mopidy.models.Ref.directory` instance with a URI and name set
     representing the root of this library's browse tree. URIs must
@@ -117,7 +117,7 @@ class LibraryProvider:
         return []
 
     def get_distinct(
-        self, field: DistinctField, query: Optional[Query[SearchField]] = None
+        self, field: DistinctField, query: Query[SearchField] | None = None
     ) -> set[str]:
         """See :meth:`mopidy.core.LibraryController.get_distinct`.
 
@@ -146,7 +146,7 @@ class LibraryProvider:
         """
         raise NotImplementedError
 
-    def refresh(self, uri: Optional[Uri] = None) -> None:
+    def refresh(self, uri: Uri | None = None) -> None:
         """See :meth:`mopidy.core.LibraryController.refresh`.
 
         *MAY be implemented by subclass.*
@@ -155,7 +155,7 @@ class LibraryProvider:
     def search(
         self,
         query: Query[SearchField],
-        uris: Optional[list[Uri]] = None,
+        uris: list[Uri] | None = None,
         exact: bool = False,
     ) -> list[SearchResult]:
         """See :meth:`mopidy.core.LibraryController.search`.
@@ -209,7 +209,7 @@ class PlaybackProvider:
         """
         self.audio.prepare_change().get()
 
-    def translate_uri(self, uri: Uri) -> Optional[Uri]:
+    def translate_uri(self, uri: Uri) -> Uri | None:
         """Convert custom URI scheme to real playable URI.
 
         *MAY be reimplemented by subclass.*
@@ -349,7 +349,7 @@ class PlaylistsProvider:
         """
         raise NotImplementedError
 
-    def get_items(self, uri: Uri) -> Optional[list[Ref]]:
+    def get_items(self, uri: Uri) -> list[Ref] | None:
         """Get the items in a playlist specified by ``uri``.
 
         Returns a list of :class:`~mopidy.models.Ref` objects referring to the
@@ -362,7 +362,7 @@ class PlaylistsProvider:
         """
         raise NotImplementedError
 
-    def create(self, name: str) -> Optional[Playlist]:
+    def create(self, name: str) -> Playlist | None:
         """Create a new empty playlist with the given name.
 
         Returns a new playlist with the given name and an URI, or :class:`None`
@@ -388,7 +388,7 @@ class PlaylistsProvider:
         """
         raise NotImplementedError
 
-    def lookup(self, uri: Uri) -> Optional[Playlist]:
+    def lookup(self, uri: Uri) -> Playlist | None:
         """Lookup playlist with given URI in both the set of playlists and in any
         other playlist source.
 
@@ -407,7 +407,7 @@ class PlaylistsProvider:
         """
         raise NotImplementedError
 
-    def save(self, playlist: Playlist) -> Optional[Playlist]:
+    def save(self, playlist: Playlist) -> Playlist | None:
         """Save the given playlist.
 
         The playlist must have an ``uri`` attribute set. To create a new

--- a/src/mopidy/commands.py
+++ b/src/mopidy/commands.py
@@ -11,7 +11,6 @@ from pathlib import Path
 from typing import (
     Any,
     NoReturn,
-    Optional,
     cast,
 )
 
@@ -65,8 +64,8 @@ class _HelpAction(argparse.Action):
     def __init__(
         self,
         option_strings: Sequence[str],
-        dest: Optional[str] = None,
-        help: Optional[str] = None,
+        dest: str | None = None,
+        help: str | None = None,
     ) -> None:
         super().__init__(
             option_strings=option_strings,
@@ -90,7 +89,7 @@ class Command:
     argprases own sub-parser handling.
     """
 
-    help: Optional[str] = None
+    help: str | None = None
     #: Help text to display in help output.
 
     _children: dict[str, Command]
@@ -135,14 +134,14 @@ class Command:
     def exit(
         self,
         status_code: int = 0,
-        message: Optional[str] = None,
-        usage: Optional[str] = None,
+        message: str | None = None,
+        usage: str | None = None,
     ) -> NoReturn:
         """Optionally print a message and exit."""
         print("\n\n".join(m for m in (usage, message) if m))  # noqa: T201
         sys.exit(status_code)
 
-    def format_usage(self, prog: Optional[str] = None) -> str:
+    def format_usage(self, prog: str | None = None) -> str:
         """Format usage for current parser."""
         actions = self._build()[1]
         prog = prog or Path(sys.argv[0]).name
@@ -153,7 +152,7 @@ class Command:
         formatter.add_usage(None, actions, [])
         return formatter.format_help().strip()
 
-    def format_help(self, prog: Optional[str] = None) -> str:
+    def format_help(self, prog: str | None = None) -> str:
         """Format help for current parser and children."""
         actions = self._build()[1]
         prog = prog or Path(sys.argv[0]).name
@@ -197,7 +196,7 @@ class Command:
         for childname, child in self._children.items():
             child._subhelp(" ".join((name, childname)), result)
 
-    def parse(self, args: list[str], prog: Optional[str] = None) -> argparse.Namespace:
+    def parse(self, args: list[str], prog: str | None = None) -> argparse.Namespace:
         """Parse command line arguments.
 
         Will recursively parse commands until a final parser is found or an
@@ -373,7 +372,7 @@ class RootCommand(Command):
         self,
         config: config_lib.Config,
         mixer_classes: list[type[MixerActor]],
-    ) -> Optional[type[MixerActor]]:
+    ) -> type[MixerActor] | None:
         logger.debug(
             "Available Mopidy mixers: %s",
             ", ".join(m.__name__ for m in mixer_classes) or "none",
@@ -399,7 +398,7 @@ class RootCommand(Command):
         self,
         config: config_lib.Config,
         mixer_class: type[MixerActor],
-    ) -> Optional[MixerProxy]:
+    ) -> MixerProxy | None:
         logger.info("Starting Mopidy mixer: %s", mixer_class.__name__)
         with _actor_error_handling(mixer_class.__name__):
             mixer = cast(MixerProxy, mixer_class.start(config=config).proxy())
@@ -426,7 +425,7 @@ class RootCommand(Command):
     def start_audio(
         self,
         config: config_lib.Config,
-        mixer: Optional[MixerProxy],
+        mixer: MixerProxy | None,
     ) -> AudioProxy:
         logger.info("Starting Mopidy audio")
         return cast(AudioProxy, Audio.start(config=config, mixer=mixer).proxy())
@@ -466,7 +465,7 @@ class RootCommand(Command):
     def start_core(
         self,
         config: config_lib.Config,
-        mixer: Optional[MixerProxy],
+        mixer: MixerProxy | None,
         backends: list[BackendProxy],
         audio: AudioProxy,
     ) -> CoreProxy:
@@ -503,7 +502,7 @@ class RootCommand(Command):
         for frontend_class in frontend_classes:
             process.stop_actors_by_class(frontend_class)
 
-    def stop_core(self, core: Optional[CoreProxy]) -> None:
+    def stop_core(self, core: CoreProxy | None) -> None:
         logger.info("Stopping Mopidy core")
         if core is not None:
             call = ProxyCall(attr_path=("_teardown",), args=(), kwargs={})

--- a/src/mopidy/config/__init__.py
+++ b/src/mopidy/config/__init__.py
@@ -7,7 +7,7 @@ import os
 import pathlib
 import re
 from collections.abc import Iterator, Mapping
-from typing import TYPE_CHECKING, Any, Optional, TypedDict, Union, cast
+from typing import TYPE_CHECKING, Any, TypedDict, cast
 
 from mopidy.config import keyring
 from mopidy.config.schemas import ConfigSchema, MapConfigSchema
@@ -37,7 +37,7 @@ if TYPE_CHECKING:
     from mopidy.internal.log import LogColorName, LogLevelName
 
     ConfigErrors: TypeAlias = dict[str, dict[str, Any]]
-    ConfigSchemas: TypeAlias = list[Union[ConfigSchema, MapConfigSchema]]
+    ConfigSchemas: TypeAlias = list[ConfigSchema | MapConfigSchema]
     RawConfig: TypeAlias = dict[str, dict[str, Any]]
 
 
@@ -73,22 +73,22 @@ class LoggingConfig(TypedDict):
     verbosity: int
     format: str
     color: bool
-    config_file: Optional[pathlib.Path]
+    config_file: pathlib.Path | None
 
 
 class AudioConfig(TypedDict):
     mixer: str
-    mixer_volume: Optional[int]
+    mixer_volume: int | None
     output: str
-    buffer_time: Optional[int]
+    buffer_time: int | None
 
 
 class ProxyConfig(TypedDict):
-    scheme: Optional[str]
-    hostname: Optional[str]
-    port: Optional[int]
-    username: Optional[str]
-    password: Optional[str]
+    scheme: str | None
+    hostname: str | None
+    port: int | None
+    username: str | None
+    password: str | None
 
 
 _core_schema = ConfigSchema("core")
@@ -175,7 +175,7 @@ def load(
 def format(  # noqa: A001
     config: Config,
     ext_schemas: ConfigSchemas,
-    comments: Optional[dict] = None,
+    comments: dict | None = None,
     display: bool = True,
 ) -> str:
     schemas = _schemas[:]
@@ -385,7 +385,7 @@ def _postprocess(config_string: str) -> str:
 
 
 class Proxy(Mapping):
-    def __init__(self, data: Union[Config, dict[str, Any]]) -> None:
+    def __init__(self, data: Config | dict[str, Any]) -> None:
         self._data = data
 
     def __getitem__(self, key) -> Any:

--- a/src/mopidy/config/keyring.py
+++ b/src/mopidy/config/keyring.py
@@ -1,5 +1,4 @@
 import logging
-from typing import Union
 
 logger = logging.getLogger(__name__)
 
@@ -68,7 +67,7 @@ def fetch() -> list[tuple[str, str, bytes]]:  # noqa: PLR0911
 def set(  # noqa: A001, PLR0911
     section: str,
     key: str,
-    value: Union[str, bytes],
+    value: str | bytes,
 ) -> bool:
     """Store a secret config value for a given section/key.
 

--- a/src/mopidy/config/validators.py
+++ b/src/mopidy/config/validators.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any, Optional, Protocol, TypeVar
+from typing import TYPE_CHECKING, Any, Protocol, TypeVar
 
 if TYPE_CHECKING:
     from abc import abstractmethod
@@ -28,7 +28,7 @@ def validate_required(value: Any, required: bool) -> None:
         raise ValueError("must be set.")
 
 
-def validate_choice(value: T, choices: Optional[Iterable[T]]) -> None:
+def validate_choice(value: T, choices: Iterable[T] | None) -> None:
     """Validate that ``value`` is one of the ``choices``.
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
@@ -38,7 +38,7 @@ def validate_choice(value: T, choices: Optional[Iterable[T]]) -> None:
         raise ValueError(f"must be one of {names}, not {value}.")
 
 
-def validate_minimum(value: CT, minimum: Optional[CT]) -> None:
+def validate_minimum(value: CT, minimum: CT | None) -> None:
     """Validate that ``value`` is at least ``minimum``.
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
@@ -47,7 +47,7 @@ def validate_minimum(value: CT, minimum: Optional[CT]) -> None:
         raise ValueError(f"{value!r} must be larger than {minimum!r}.")
 
 
-def validate_maximum(value: CT, maximum: Optional[CT]) -> None:
+def validate_maximum(value: CT, maximum: CT | None) -> None:
     """Validate that ``value`` is at most ``maximum``.
 
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.

--- a/src/mopidy/core/actor.py
+++ b/src/mopidy/core/actor.py
@@ -6,7 +6,7 @@ import itertools
 import logging
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_method
@@ -65,9 +65,9 @@ class Core(
         self,
         config: Config,
         *,
-        mixer: Optional[mixer.MixerProxy] = None,
+        mixer: mixer.MixerProxy | None = None,
         backends: Iterable[backend.BackendProxy],
-        audio: Optional[audio.AudioProxy] = None,
+        audio: audio.AudioProxy | None = None,
     ) -> None:
         super().__init__()
 
@@ -114,7 +114,7 @@ class Core(
         self,
         old_state: PlaybackState,
         new_state: PlaybackState,
-        target_state: Optional[PlaybackState],
+        target_state: PlaybackState | None,
     ) -> None:
         # XXX: This is a temporary fix for issue #232 while we wait for a more
         # permanent solution with the implementation of issue #234. When the

--- a/src/mopidy/core/library.py
+++ b/src/mopidy/core/library.py
@@ -6,7 +6,7 @@ import logging
 import operator
 import urllib.parse
 from collections.abc import Generator, Iterable, Mapping
-from typing import TYPE_CHECKING, Any, Optional, Union, cast
+from typing import TYPE_CHECKING, Any, cast
 
 from pykka.typing import proxy_method
 
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 @contextlib.contextmanager
 def _backend_error_handling(
     backend: BackendProxy,
-    reraise: Union[None, type[Exception], tuple[type[Exception], ...]] = None,
+    reraise: None | (type[Exception] | tuple[type[Exception], ...]) = None,
 ) -> Generator[None, Any, None]:
     try:
         yield
@@ -49,18 +49,18 @@ class LibraryController:
         self.backends = backends
         self.core = core
 
-    def _get_backend(self, uri: Uri) -> Optional[BackendProxy]:
+    def _get_backend(self, uri: Uri) -> BackendProxy | None:
         uri_scheme = UriScheme(urllib.parse.urlparse(uri).scheme)
         return self.backends.with_library.get(uri_scheme, None)
 
     def _get_backends_to_uris(
         self,
-        uris: Optional[Iterable[Uri]],
-    ) -> dict[BackendProxy, Optional[list[Uri]]]:
+        uris: Iterable[Uri] | None,
+    ) -> dict[BackendProxy, list[Uri] | None]:
         if not uris:
             return {b: None for b in self.backends.with_library.values()}
 
-        result: dict[BackendProxy, Optional[list[Uri]]] = collections.defaultdict(list)
+        result: dict[BackendProxy, list[Uri] | None] = collections.defaultdict(list)
         for uri in uris:
             backend = self._get_backend(uri)
             if backend is not None:
@@ -135,7 +135,7 @@ class LibraryController:
     def get_distinct(
         self,
         field: DistinctField,
-        query: Optional[Query[SearchField]] = None,
+        query: Query[SearchField] | None = None,
     ) -> set[Any]:
         """List distinct values for a given field from the library.
 
@@ -250,7 +250,7 @@ class LibraryController:
 
         return results
 
-    def refresh(self, uri: Optional[Uri] = None) -> None:
+    def refresh(self, uri: Uri | None = None) -> None:
         """Refresh library. Limit to URI and below if an URI is given.
 
         :param uri: directory or track URI
@@ -276,7 +276,7 @@ class LibraryController:
     def search(
         self,
         query: Query[SearchField],
-        uris: Optional[Iterable[Uri]] = None,
+        uris: Iterable[Uri] | None = None,
         exact: bool = False,
     ) -> list[SearchResult]:
         """Search the library for tracks where ``field`` contains ``values``.

--- a/src/mopidy/core/mixer.py
+++ b/src/mopidy/core/mixer.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import contextlib
 import logging
 from collections.abc import Generator, Iterable
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from pykka.typing import proxy_method
 
@@ -36,10 +36,10 @@ def _mixer_error_handling(mixer: MixerProxy) -> Generator[None, Any, None]:
 
 
 class MixerController:
-    def __init__(self, mixer: Optional[MixerProxy]) -> None:
+    def __init__(self, mixer: MixerProxy | None) -> None:
         self._mixer = mixer
 
-    def get_volume(self) -> Optional[Percentage]:
+    def get_volume(self) -> Percentage | None:
         """Get the volume.
 
         Integer in range [0..100] or :class:`None` if unknown.
@@ -78,7 +78,7 @@ class MixerController:
 
         return False
 
-    def get_mute(self) -> Optional[bool]:
+    def get_mute(self) -> bool | None:
         """Get mute state.
 
         :class:`True` if muted, :class:`False` unmuted, :class:`None` if

--- a/src/mopidy/core/playback.py
+++ b/src/mopidy/core/playback.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import urllib.parse
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pykka.messages import ProxyCall
 from pykka.typing import proxy_method
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 class PlaybackController:
     def __init__(
         self,
-        audio: Optional[AudioProxy],
+        audio: AudioProxy | None,
         backends: Backends,
         core: Core,
     ) -> None:
@@ -36,43 +36,43 @@ class PlaybackController:
         self.core = core
         self._audio = audio
 
-        self._stream_title: Optional[str] = None
+        self._stream_title: str | None = None
         self._state = PlaybackState.STOPPED
 
-        self._current_tl_track: Optional[TlTrack] = None
-        self._pending_tl_track: Optional[TlTrack] = None
+        self._current_tl_track: TlTrack | None = None
+        self._pending_tl_track: TlTrack | None = None
 
-        self._pending_position: Optional[DurationMs] = None
-        self._last_position: Optional[DurationMs] = None
+        self._pending_position: DurationMs | None = None
+        self._last_position: DurationMs | None = None
         self._previous: bool = False
 
-        self._start_at_position: Optional[DurationMs] = None
+        self._start_at_position: DurationMs | None = None
         self._start_paused: bool = False
 
         if self._audio:
             self._audio.set_about_to_finish_callback(self._on_about_to_finish_callback)
 
-    def _get_backend(self, tl_track: Optional[TlTrack]) -> Optional[BackendProxy]:
+    def _get_backend(self, tl_track: TlTrack | None) -> BackendProxy | None:
         if tl_track is None:
             return None
         uri_scheme = UriScheme(urllib.parse.urlparse(tl_track.track.uri).scheme)
         return self.backends.with_playback.get(uri_scheme, None)
 
-    def get_current_tl_track(self) -> Optional[TlTrack]:
+    def get_current_tl_track(self) -> TlTrack | None:
         """Get the currently playing or selected track.
 
         Returns a :class:`mopidy.models.TlTrack` or :class:`None`.
         """
         return self._current_tl_track
 
-    def _set_current_tl_track(self, value: Optional[TlTrack]) -> None:
+    def _set_current_tl_track(self, value: TlTrack | None) -> None:
         """Set the currently playing or selected track.
 
         *Internal:* This is only for use by Mopidy's test suite.
         """
         self._current_tl_track = value
 
-    def get_current_track(self) -> Optional[Track]:
+    def get_current_track(self) -> Track | None:
         """Get the currently playing or selected track.
 
         Extracted from :meth:`get_current_tl_track` for convenience.
@@ -81,7 +81,7 @@ class PlaybackController:
         """
         return getattr(self.get_current_tl_track(), "track", None)
 
-    def get_current_tlid(self) -> Optional[int]:
+    def get_current_tlid(self) -> int | None:
         """Get the currently playing or selected TLID.
 
         Extracted from :meth:`get_current_tl_track` for convenience.
@@ -92,7 +92,7 @@ class PlaybackController:
         """
         return getattr(self.get_current_tl_track(), "tlid", None)
 
-    def get_stream_title(self) -> Optional[str]:
+    def get_stream_title(self) -> str | None:
         """Get the current stream title or :class:`None`."""
         return self._stream_title
 
@@ -282,8 +282,8 @@ class PlaybackController:
 
     def play(  # noqa: C901, PLR0912
         self,
-        tl_track: Optional[TlTrack] = None,
-        tlid: Optional[int] = None,
+        tl_track: TlTrack | None = None,
+        tlid: int | None = None,
     ) -> None:
         """Play the given track, or if the given tl_track and tlid is
         :class:`None`, play the currently active track.
@@ -343,7 +343,7 @@ class PlaybackController:
 
     def _change(  # noqa: PLR0911
         self,
-        pending_tl_track: Optional[TlTrack],
+        pending_tl_track: TlTrack | None,
         state: PlaybackState,
     ) -> bool:
         self._pending_tl_track = pending_tl_track

--- a/src/mopidy/core/playlists.py
+++ b/src/mopidy/core/playlists.py
@@ -4,7 +4,7 @@ import contextlib
 import logging
 import urllib.parse
 from collections.abc import Generator
-from typing import TYPE_CHECKING, Any, Optional, Union
+from typing import TYPE_CHECKING, Any
 
 from pykka.typing import proxy_method
 
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
 @contextlib.contextmanager
 def _backend_error_handling(
     backend: BackendProxy,
-    reraise: Union[None, type[Exception], tuple[type[Exception], ...]] = None,
+    reraise: None | (type[Exception] | tuple[type[Exception], ...]) = None,
 ) -> Generator[None, Any, None]:
     try:
         yield
@@ -87,7 +87,7 @@ class PlaylistsController:
 
         return results
 
-    def get_items(self, uri: Uri) -> Optional[list[Ref]]:
+    def get_items(self, uri: Uri) -> list[Ref] | None:
         """Get the items in a playlist specified by ``uri``.
 
         Returns a list of :class:`~mopidy.models.Ref` objects referring to the
@@ -117,8 +117,8 @@ class PlaylistsController:
     def create(
         self,
         name: str,
-        uri_scheme: Optional[UriScheme] = None,
-    ) -> Optional[Playlist]:
+        uri_scheme: UriScheme | None = None,
+    ) -> Playlist | None:
         """Create a new playlist.
 
         If ``uri_scheme`` matches an URI scheme handled by a current backend,
@@ -182,7 +182,7 @@ class PlaylistsController:
 
         return success
 
-    def lookup(self, uri: Uri) -> Optional[Playlist]:
+    def lookup(self, uri: Uri) -> Playlist | None:
         """Lookup playlist with given URI in both the set of playlists and in any
         other playlist sources. Returns :class:`None` if not found.
 
@@ -203,7 +203,7 @@ class PlaylistsController:
 
     # TODO: there is an inconsistency between library.refresh(uri) and this
     # call, not sure how to sort this out.
-    def refresh(self, uri_scheme: Optional[UriScheme] = None) -> None:
+    def refresh(self, uri_scheme: UriScheme | None = None) -> None:
         """Refresh the playlists in :attr:`playlists`.
 
         If ``uri_scheme`` is :class:`None`, all backends are asked to refresh.
@@ -234,7 +234,7 @@ class PlaylistsController:
         if playlists_loaded:
             listener.CoreListener.send("playlists_loaded")
 
-    def save(self, playlist: Playlist) -> Optional[Playlist]:
+    def save(self, playlist: Playlist) -> Playlist | None:
         """Save the playlist.
 
         For a playlist to be saveable, it must have the ``uri`` attribute set.

--- a/src/mopidy/core/tracklist.py
+++ b/src/mopidy/core/tracklist.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import random
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from pykka.typing import proxy_method
 
@@ -157,9 +157,9 @@ class TracklistController:
 
     def index(
         self,
-        tl_track: Optional[TlTrack] = None,
-        tlid: Optional[int] = None,
-    ) -> Optional[int]:
+        tl_track: TlTrack | None = None,
+        tlid: int | None = None,
+    ) -> int | None:
         """The position of the given track in the tracklist.
 
         If neither *tl_track* or *tlid* is given we return the index of
@@ -190,7 +190,7 @@ class TracklistController:
                     return i
         return None
 
-    def get_eot_tlid(self) -> Optional[int]:
+    def get_eot_tlid(self) -> int | None:
         """The TLID of the track that will be played after the current track.
 
         Not necessarily the same TLID as returned by :meth:`get_next_tlid`.
@@ -204,7 +204,7 @@ class TracklistController:
 
         return getattr(eot_tl_track, "tlid", None)
 
-    def eot_track(self, tl_track: Optional[TlTrack]) -> Optional[TlTrack]:
+    def eot_track(self, tl_track: TlTrack | None) -> TlTrack | None:
         """The track that will be played after the given track.
 
         Not necessarily the same track as :meth:`next_track`.
@@ -227,7 +227,7 @@ class TracklistController:
         # shared.
         return self.next_track(tl_track)
 
-    def get_next_tlid(self) -> Optional[int]:
+    def get_next_tlid(self) -> int | None:
         """The tlid of the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.next()`.
 
@@ -245,7 +245,7 @@ class TracklistController:
 
         return getattr(next_tl_track, "tlid", None)
 
-    def next_track(self, tl_track: Optional[TlTrack]) -> Optional[TlTrack]:
+    def next_track(self, tl_track: TlTrack | None) -> TlTrack | None:
         """The track that will be played if calling
         :meth:`mopidy.core.PlaybackController.next()`.
 
@@ -295,7 +295,7 @@ class TracklistController:
 
         return self._tl_tracks[next_index]
 
-    def get_previous_tlid(self) -> Optional[int]:
+    def get_previous_tlid(self) -> int | None:
         """Returns the TLID of the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.previous()`.
 
@@ -312,7 +312,7 @@ class TracklistController:
 
         return getattr(previous_tl_track, "tlid", None)
 
-    def previous_track(self, tl_track: Optional[TlTrack]) -> Optional[TlTrack]:
+    def previous_track(self, tl_track: TlTrack | None) -> TlTrack | None:
         """Returns the track that will be played if calling
         :meth:`mopidy.core.PlaybackController.previous()`.
 
@@ -343,9 +343,9 @@ class TracklistController:
 
     def add(  # noqa: C901
         self,
-        tracks: Optional[Iterable[Track]] = None,
-        at_position: Optional[int] = None,
-        uris: Optional[Iterable[Uri]] = None,
+        tracks: Iterable[Track] | None = None,
+        at_position: int | None = None,
+        uris: Iterable[Uri] | None = None,
     ) -> list[TlTrack]:
         """Add tracks to the tracklist.
 
@@ -504,7 +504,7 @@ class TracklistController:
         self._increase_version()
         return tl_tracks
 
-    def shuffle(self, start: Optional[int] = None, end: Optional[int] = None) -> None:
+    def shuffle(self, start: int | None = None, end: int | None = None) -> None:
         """Shuffles the entire tracklist. If ``start`` and ``end`` is given only
         shuffles the slice ``[start:end]``.
 
@@ -547,7 +547,7 @@ class TracklistController:
         if self.get_random() and tl_track in self._shuffled:
             self._shuffled.remove(tl_track)
 
-    def _mark_unplayable(self, tl_track: Optional[TlTrack]) -> None:
+    def _mark_unplayable(self, tl_track: TlTrack | None) -> None:
         """Internal method for :class:`mopidy.core.PlaybackController`."""
         logger.warning(
             "Track is not playable: %s",
@@ -558,7 +558,7 @@ class TracklistController:
         if self.get_random() and tl_track in self._shuffled:
             self._shuffled.remove(tl_track)
 
-    def _mark_played(self, tl_track: Optional[TlTrack]) -> bool:
+    def _mark_played(self, tl_track: TlTrack | None) -> bool:
         """Internal method for :class:`mopidy.core.PlaybackController`."""
         if self.get_consume() and tl_track is not None:
             self.remove({"tlid": [tl_track.tlid]})

--- a/src/mopidy/ext.py
+++ b/src/mopidy/ext.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 from collections.abc import Mapping
 from importlib import metadata
-from typing import TYPE_CHECKING, NamedTuple, Union
+from typing import TYPE_CHECKING, NamedTuple
 
 from mopidy import config as config_lib
 from mopidy import exceptions
@@ -12,13 +12,13 @@ from mopidy.internal import path
 if TYPE_CHECKING:
     from collections.abc import Iterator
     from pathlib import Path
-    from typing import Any, Optional, TypeAlias
+    from typing import Any, TypeAlias
 
     from mopidy.commands import Command
     from mopidy.config import ConfigSchema
 
     Config = dict[str, dict[str, Any]]
-    RegistryEntry: TypeAlias = Union[type[Any], dict[str, Any]]
+    RegistryEntry: TypeAlias = type[Any] | dict[str, Any]
 
 logger = logging.getLogger(__name__)
 
@@ -28,7 +28,7 @@ class ExtensionData(NamedTuple):
     entry_point: Any
     config_schema: ConfigSchema
     config_defaults: Any
-    command: Optional[Command]
+    command: Command | None
 
 
 class Extension:
@@ -116,7 +116,7 @@ class Extension:
         path.get_or_create_dir(data_dir_path)
         return data_dir_path
 
-    def get_command(self) -> Optional[Command]:
+    def get_command(self) -> Command | None:
         """Command to expose to command line users running ``mopidy``.
 
         :returns:

--- a/src/mopidy/http/types.py
+++ b/src/mopidy/http/types.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Callable
 from os import PathLike
-from typing import TYPE_CHECKING, Any, Optional, TypedDict
+from typing import TYPE_CHECKING, Any, TypedDict
 
 import tornado.web
 
@@ -19,10 +19,10 @@ RequestRule: TypeAlias = tuple[str, type[tornado.web.RequestHandler], dict[str, 
 class HttpConfig(TypedDict):
     hostname: str
     port: int
-    zeroconf: Optional[str]
+    zeroconf: str | None
     allowed_origins: list[str]
-    csrf_protection: Optional[bool]
-    default_app: Optional[str]
+    csrf_protection: bool | None
+    default_app: str | None
 
 
 class HttpApp(TypedDict):

--- a/src/mopidy/httpclient.py
+++ b/src/mopidy/httpclient.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import platform
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 import mopidy
 
@@ -11,7 +11,7 @@ if TYPE_CHECKING:
     from mopidy.config import ProxyConfig
 
 
-def format_proxy(proxy_config: ProxyConfig, auth: bool = True) -> Optional[str]:
+def format_proxy(proxy_config: ProxyConfig, auth: bool = True) -> str | None:
     """Convert a Mopidy proxy config to the commonly used proxy string format.
 
     Outputs ``scheme://host:port``, ``scheme://user:pass@host:port`` or
@@ -39,7 +39,7 @@ def format_proxy(proxy_config: ProxyConfig, auth: bool = True) -> Optional[str]:
     return f"{scheme}://{hostname}:{port}"
 
 
-def format_user_agent(name: Optional[str] = None) -> str:
+def format_user_agent(name: str | None = None) -> str:
     """Construct a User-Agent suitable for use in client code.
 
     This will identify use by the provided ``name`` (which should be on the

--- a/src/mopidy/internal/deps.py
+++ b/src/mopidy/internal/deps.py
@@ -8,7 +8,7 @@ from collections.abc import Callable
 from importlib import metadata
 from os import PathLike
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, TypedDict
+from typing import TYPE_CHECKING, TypedDict
 
 from mopidy.internal import formatting
 from mopidy.internal.gi import Gst, gi
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     Adapter: TypeAlias = Callable[[], DepInfo]
 
 
-def format_dependency_list(adapters: Optional[list[Adapter]] = None) -> str:
+def format_dependency_list(adapters: list[Adapter] | None = None) -> str:
     if adapters is None:
         dist_names = {
             ep.dist.name
@@ -95,7 +95,7 @@ def python_info() -> DepInfo:
 
 
 def pkg_info(
-    project_name: Optional[str] = None,
+    project_name: str | None = None,
     include_transitive_deps: bool = True,
     include_extras: bool = False,
 ) -> DepInfo:

--- a/src/mopidy/internal/log.py
+++ b/src/mopidy/internal/log.py
@@ -5,7 +5,7 @@ import logging.config
 import logging.handlers
 import platform
 from logging import LogRecord
-from typing import TYPE_CHECKING, ClassVar, Literal, Optional
+from typing import TYPE_CHECKING, ClassVar, Literal
 
 if TYPE_CHECKING:
     from mopidy.config import Config, LoggingConfig
@@ -176,9 +176,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
     """
 
     # Map logging levels to (background, foreground, bold/intense)
-    level_map: ClassVar[
-        dict[int, tuple[Optional[LogColorName], LogColorName, bool]]
-    ] = {
+    level_map: ClassVar[dict[int, tuple[LogColorName | None, LogColorName, bool]]] = {
         TRACE_LOG_LEVEL: (None, "blue", False),
         logging.DEBUG: (None, "blue", False),
         logging.INFO: (None, "white", False),
@@ -227,8 +225,8 @@ class ColorizingStreamHandler(logging.StreamHandler):
     def colorize(
         self,
         message: str,
-        bg: Optional[LogColorName] = None,
-        fg: Optional[LogColorName] = None,
+        bg: LogColorName | None = None,
+        fg: LogColorName | None = None,
         bold: bool = False,
     ) -> str:
         params = []

--- a/src/mopidy/internal/path.py
+++ b/src/mopidy/internal/path.py
@@ -3,7 +3,6 @@ import pathlib
 import re
 import urllib.parse
 from os import PathLike
-from typing import Union
 
 from mopidy.internal import xdg
 
@@ -47,7 +46,7 @@ def get_unix_socket_path(socket_path):
     return match.group(1)
 
 
-def path_to_uri(path: Union[str, PathLike[str]]) -> str:
+def path_to_uri(path: str | PathLike[str]) -> str:
     """
     Convert OS specific path to file:// URI.
 

--- a/src/mopidy/internal/validation.py
+++ b/src/mopidy/internal/validation.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import urllib.parse
 from collections.abc import Iterable, Mapping
-from typing import Any, Literal, Optional, TypeVar, Union, get_args
+from typing import Any, Literal, TypeVar, Union, get_args
 
 from mopidy import exceptions
 from mopidy.audio.constants import PlaybackState
@@ -37,7 +37,7 @@ PLAYBACK_STATES: set[str] = {ps.value for ps in PlaybackState}
 FIELD_TYPES: dict[str, type] = {
     "album": str,
     "albumartist": str,
-    "any": Union[int, str],
+    "any": int | str,
     "artist": str,
     "comment": str,
     "composer": str,
@@ -116,8 +116,8 @@ def check_instances(
 
 def check_integer(
     arg: int,
-    min: Optional[int] = None,
-    max: Optional[int] = None,
+    min: int | None = None,
+    max: int | None = None,
 ) -> None:
     if not isinstance(arg, int):
         raise exceptions.ValidationError(f"Expected an integer, not {arg!r}")
@@ -132,8 +132,8 @@ def check_integer(
 
 
 def check_query(
-    arg: Union[Query[SearchField], Query[TracklistField]],
-    fields: Optional[Iterable[str]] = None,
+    arg: Query[SearchField] | Query[TracklistField],
+    fields: Iterable[str] | None = None,
 ) -> None:
     if fields is None:
         fields = SEARCH_FIELDS.keys()
@@ -156,7 +156,7 @@ def check_query(
 
 
 def _check_query_value(
-    key: Union[DistinctField, SearchField, TracklistField],
+    key: DistinctField | (SearchField | TracklistField),
     arg: QueryValue,
     msg: str,
 ) -> None:

--- a/src/mopidy/m3u/playlists.py
+++ b/src/mopidy/m3u/playlists.py
@@ -8,7 +8,7 @@ import os
 import tempfile
 from collections.abc import Generator
 from pathlib import Path
-from typing import IO, TYPE_CHECKING, Any, Optional, Union, cast
+from typing import IO, TYPE_CHECKING, Any, cast
 
 from mopidy import backend
 from mopidy.exceptions import BackendError
@@ -38,8 +38,8 @@ def log_environment_error(message: str, error: EnvironmentError) -> None:
 def replace(
     path: Path,
     mode: str = "w+b",
-    encoding: Optional[str] = None,
-    errors: Optional[str] = None,
+    encoding: str | None = None,
+    errors: str | None = None,
 ) -> Generator[IO[Any], None, None]:
     (fd, tempname) = tempfile.mkstemp(dir=str(path.parent))
     tempname = Path(tempname)
@@ -92,7 +92,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         result.sort(key=operator.attrgetter("name"))
         return result
 
-    def create(self, name: str) -> Optional[Playlist]:
+    def create(self, name: str) -> Playlist | None:
         path = translator.path_from_name(name.strip(), self._default_extension)
         try:
             with self._open(path, "w"):
@@ -116,7 +116,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         else:
             return True
 
-    def get_items(self, uri: Uri) -> Optional[list[Ref]]:
+    def get_items(self, uri: Uri) -> list[Ref] | None:
         path = translator.uri_to_path(uri)
         if not self._is_in_basedir(path):
             logger.debug("Ignoring path outside playlist dir: %s", uri)
@@ -129,7 +129,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         else:
             return items
 
-    def lookup(self, uri: Uri) -> Optional[Playlist]:
+    def lookup(self, uri: Uri) -> Playlist | None:
         path = translator.uri_to_path(uri)
         if not self._is_in_basedir(path):
             logger.debug("Ignoring path outside playlist dir: %s", uri)
@@ -146,7 +146,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
     def refresh(self) -> None:
         pass  # nothing to do
 
-    def save(self, playlist: Playlist) -> Optional[Playlist]:
+    def save(self, playlist: Playlist) -> Playlist | None:
         path = translator.uri_to_path(playlist.uri)
         if not self._is_in_basedir(path):
             logger.debug("Ignoring path outside playlist dir: %s", playlist.uri)
@@ -177,7 +177,7 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
 
     def _open(
         self, path: Path, mode: str = "r"
-    ) -> Union[contextlib._GeneratorContextManager[IO[Any]], IO[Any]]:
+    ) -> contextlib._GeneratorContextManager[IO[Any]] | IO[Any]:
         encoding = "utf-8" if path.suffix == ".m3u8" else self._default_encoding
         if not path.is_absolute():
             path = self._abspath(path)

--- a/src/mopidy/m3u/translator.py
+++ b/src/mopidy/m3u/translator.py
@@ -4,7 +4,7 @@ import os
 import urllib.parse
 from collections.abc import Iterable
 from pathlib import Path
-from typing import IO, Optional, Union
+from typing import IO
 
 from mopidy.internal import path
 from mopidy.models import Playlist, Ref, Track
@@ -28,7 +28,7 @@ def uri_to_path(uri: Uri) -> Path:
     return path.uri_to_path(uri)
 
 
-def name_from_path(path: Path) -> Optional[str]:
+def name_from_path(path: Path) -> str | None:
     """Extract name from file path."""
     name = bytes(Path(path.stem))
     try:
@@ -39,7 +39,7 @@ def name_from_path(path: Path) -> Optional[str]:
 
 def path_from_name(
     name: str,
-    ext: Optional[str] = None,
+    ext: str | None = None,
     sep: str = "|",
 ) -> Path:
     """Convert name with optional extension to file path."""
@@ -76,7 +76,7 @@ def load_items(
 
 
 def dump_items(
-    items: Iterable[Union[Ref, Track]],
+    items: Iterable[Ref | Track],
     fp: IO[str],
 ) -> None:
     if any(item.name for item in items):
@@ -93,8 +93,8 @@ def dump_items(
 
 def playlist(
     path: Path,
-    items: Optional[Iterable[Union[Ref, Track]]] = None,
-    mtime: Optional[float] = None,
+    items: Iterable[Ref | Track] | None = None,
+    mtime: float | None = None,
 ) -> Playlist:
     if items is None:
         items = []

--- a/src/mopidy/m3u/types.py
+++ b/src/mopidy/m3u/types.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Literal, Optional, TypedDict
+from typing import Literal, TypedDict
 
 
 class M3UConfig(TypedDict):
-    base_dir: Optional[Path]
+    base_dir: Path | None
     default_encoding: str
     default_extension: Literal[".m3u", ".m3u8"]
-    playlists_dir: Optional[Path]
+    playlists_dir: Path | None

--- a/src/mopidy/mixer.py
+++ b/src/mopidy/mixer.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, ClassVar, Literal, Optional
+from typing import TYPE_CHECKING, Any, ClassVar, Literal
 
 import pykka
 from pykka.typing import ActorMemberMixin, proxy_field, proxy_method
@@ -42,7 +42,7 @@ class Mixer:
     def __init__(self, config: dict) -> None:
         pass
 
-    def get_volume(self) -> Optional[Percentage]:
+    def get_volume(self) -> Percentage | None:
         """Get volume level of the mixer on a linear scale from 0 to 100.
 
         Example values:
@@ -79,7 +79,7 @@ class Mixer:
         logger.debug("Mixer event: volume_changed(volume=%d)", volume)
         MixerListener.send("volume_changed", volume=volume)
 
-    def get_mute(self) -> Optional[bool]:
+    def get_mute(self) -> bool | None:
         """Get mute state of the mixer.
 
         *MAY be implemented by subclass.*

--- a/src/mopidy/models/fields.py
+++ b/src/mopidy/models/fields.py
@@ -6,9 +6,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Generic,
-    Optional,
     TypeVar,
-    Union,
     cast,
     overload,
 )
@@ -40,9 +38,9 @@ class Field(Generic[T]):
 
     def __init__(
         self,
-        default: Optional[T] = None,
-        type: Optional[type[T]] = None,
-        choices: Optional[Iterable[T]] = None,
+        default: T | None = None,
+        type: type[T] | None = None,
+        choices: Iterable[T] | None = None,
     ) -> None:
         self._name: str | None = None  # Set by ValidatedImmutableObjectMeta
         self._choices = choices
@@ -74,9 +72,9 @@ class Field(Generic[T]):
 
     def __get__(
         self: TField,
-        obj: Optional[object],
-        objtype: Optional[type[object]],
-    ) -> Union[T, TField]:
+        obj: object | None,
+        objtype: type[object] | None,
+    ) -> T | TField:
         if not obj:
             return self
         return cast(T, getattr(obj, f"_{self._name}", self._default))
@@ -187,7 +185,7 @@ class Boolean(Field[bool]):
         super().__init__(type=bool, default=default)
 
 
-class Collection(Field[Union[tuple, frozenset]]):
+class Collection(Field[tuple | frozenset]):
     """:class:`Field` for storing collections of a given type.
 
     :param type: all items stored in the collection must be of this type
@@ -197,11 +195,11 @@ class Collection(Field[Union[tuple, frozenset]]):
     def __init__(
         self,
         type: type,
-        container: Callable[[], Union[tuple, frozenset]] = tuple,
+        container: Callable[[], tuple | frozenset] = tuple,
     ) -> None:
         super().__init__(type=type, default=container())
 
-    def validate(self, value: Iterable[Any]) -> Optional[Iterable[Any]]:
+    def validate(self, value: Iterable[Any]) -> Iterable[Any] | None:
         assert self._default is not None
         assert self._type is not None
         if isinstance(value, str):

--- a/src/mopidy/stream/actor.py
+++ b/src/mopidy/stream/actor.py
@@ -3,7 +3,6 @@ import logging
 import re
 import time
 import urllib.parse
-from typing import Optional
 
 import pykka
 
@@ -105,7 +104,7 @@ def _unwrap_stream(  # noqa: PLR0911  # TODO: cleanup the return value of this.
     timeout: float,
     scanner: scan.Scanner,
     requests_session,
-) -> tuple[Optional[str], Optional[scan._Result]]:
+) -> tuple[str | None, scan._Result | None]:
     """Get a stream URI from a playlist URI, ``uri``.
 
     Unwraps nested playlists until something that's not a playlist is found or

--- a/src/mopidy/types.py
+++ b/src/mopidy/types.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from typing import TYPE_CHECKING, Literal, NewType, TypeVar, Union
+from typing import TYPE_CHECKING, Literal, NewType, TypeVar
 
 if TYPE_CHECKING:
     from typing import TypeAlias
 
 F = TypeVar("F")
-QueryValue: TypeAlias = Union[str, int]
+QueryValue: TypeAlias = str | int
 Query: TypeAlias = dict[F, Iterable[QueryValue]]
 
 # Types for distinct queries
@@ -30,7 +30,7 @@ DistinctField: TypeAlias = Literal[
 ]
 
 # Types for search queries
-SearchField: TypeAlias = Union[DistinctField, Literal["any"]]
+SearchField: TypeAlias = DistinctField | Literal["any"]
 SearchQuery: TypeAlias = dict[SearchField, Iterable[QueryValue]]
 
 # Types for tracklist filtering
@@ -44,7 +44,7 @@ TracklistField: TypeAlias = Literal[
 ]
 
 # Superset of all fields that can be used in a query
-QueryField: TypeAlias = Union[DistinctField, SearchField, TracklistField]
+QueryField: TypeAlias = DistinctField | SearchField | TracklistField
 
 # URI types
 Uri = NewType("Uri", str)

--- a/src/mopidy/zeroconf.py
+++ b/src/mopidy/zeroconf.py
@@ -1,6 +1,5 @@
 import logging
 import string
-from typing import Optional
 
 logger = logging.getLogger(__name__)
 
@@ -48,7 +47,7 @@ class Zeroconf:
         port: int,
         domain: str = "",
         host: str = "",
-        text: Optional[list[str]] = None,
+        text: list[str] | None = None,
     ) -> None:
         self.stype = stype
         self.port = port


### PR DESCRIPTION
This PR replaces `Union[X, Y]` with `X | Y` and `Optional[X]` with `X | None`, which is the new union type syntax introduced in Python 3.10. The work was done automatically using Ruff.