### PR TITLE
Fix backend.library.search() return type and default impl

### DIFF
--- a/src/mopidy/backend.py
+++ b/src/mopidy/backend.py
@@ -157,7 +157,7 @@ class LibraryProvider:
         query: Query[SearchField],
         uris: list[Uri] | None = None,
         exact: bool = False,
-    ) -> list[SearchResult]:
+    ) -> SearchResult | None:
         """See :meth:`mopidy.core.LibraryController.search`.
 
         *MAY be implemented by subclass.*
@@ -165,7 +165,7 @@ class LibraryProvider:
         .. versionadded:: 1.0
             The ``exact`` param which replaces the old ``find_exact``.
         """
-        return []
+        return None
 
 
 @pykka.traversable


### PR DESCRIPTION
Ref discussion at https://github.com/mopidy/mopidy/commit/06fea20b96acd1bcdbef01d7eb2a85900ae9294f#r134689375 it looks like we've had a wrong type and default implementation in this method for a long time.
