### PR TITLE
Modify Backend.lookup to accept list of URIs 

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -82,7 +82,7 @@ Backend API
 
 Changes to the Backend API may affect Mopidy backend extensions.
 
-- No changes so far.
+- Added :meth:`mopidy.backend.LibraryProvider.lookup_many` to take a list of URIs and return a mapping of URIs to tracks. If this method is not implemented then repeated calls to :meth:`mopidy.backend.LibraryProvider.lookup` will be used as a fallback.
 
 Models
 ------

--- a/src/mopidy/backend.py
+++ b/src/mopidy/backend.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Iterable
 from typing import TYPE_CHECKING, Any, ClassVar
 
 import pykka
@@ -137,12 +138,24 @@ class LibraryProvider:
         """
         return {}
 
-    def lookup(self, uri: Uri) -> list[Track]:
+    def lookup_many(self, uris: Iterable[Uri]) -> dict[Uri, list[Track]]:
         """See :meth:`mopidy.core.LibraryController.lookup`.
 
         *MUST be implemented by subclass.*
         """
+        results = {}
+        for uri in uris:
+            results[uri] = self.lookup(uri)
+
+        return results
+
+    def lookup(self, uri: Uri) -> list[Track]:
+        """See :meth:`mopidy.core.LibraryController.lookup`.
+
+        *MUST be implemented by subclass if :meth:`lookup_many` is not implemented.*
+        """
         raise NotImplementedError
+
 
     def refresh(self, uri: Uri | None = None) -> None:
         """See :meth:`mopidy.core.LibraryController.refresh`.
@@ -467,7 +480,7 @@ class LibraryProviderProxy:
     browse = proxy_method(LibraryProvider.browse)
     get_distinct = proxy_method(LibraryProvider.get_distinct)
     get_images = proxy_method(LibraryProvider.get_images)
-    lookup = proxy_method(LibraryProvider.lookup)
+    lookup_many = proxy_method(LibraryProvider.lookup_many)
     refresh = proxy_method(LibraryProvider.refresh)
     search = proxy_method(LibraryProvider.search)
 

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -1,4 +1,5 @@
 import unittest
+from unittest import mock
 
 import pytest
 from mopidy import backend
@@ -11,6 +12,19 @@ class LibraryTest(unittest.TestCase):
         library = dummy_backend.DummyLibraryProvider(backend=None)
 
         assert library.get_images(["trackuri"]) == {}
+
+    def test_lookup_many_falls_back(self):
+        library = backend.LibraryProvider(backend=None)
+        library.lookup = mock.Mock()
+
+        library.lookup_many(uris=["dummy1:a", "dummy1:b"])
+
+        library.lookup.assert_has_calls(
+            [
+                mock.call("dummy1:a"),
+                mock.call("dummy1:b"),
+            ]
+        )
 
 
 class PlaylistsTest(unittest.TestCase):

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -1169,9 +1169,9 @@ class TestCorePlaybackWithOldBackend:
         b.uri_schemes.get.return_value = ["dummy1"]
         b.playback = mock.Mock(spec=backend.PlaybackProvider)
         b.playback.play.side_effect = TypeError
-        b.library.lookup.return_value.get.return_value = [
-            Track(uri="dummy1:a", length=40000)
-        ]
+        b.library.lookup_many.return_value.get.return_value = {
+            "dummy1:a": [Track(uri="dummy1:a", length=40000)]
+        }
 
         c = core.Core(config, mixer=None, backends=[b])
         c.tracklist.add(uris=["dummy1:a"])

--- a/tests/dummy_backend.py
+++ b/tests/dummy_backend.py
@@ -44,9 +44,8 @@ class DummyLibraryProvider(backend.LibraryProvider):
     def get_distinct(self, field, query=None):
         return self.dummy_get_distinct_result.get(field, set())
 
-    def lookup(self, uri):
-        uri = Ref.track(uri=uri).uri
-        return [t for t in self.dummy_library if uri == t.uri]
+    def lookup_many(self, uris):
+        return {uri: [t for t in self.dummy_library if uri == t.uri] for uri in uris}
 
     def refresh(self, uri=None):
         pass


### PR DESCRIPTION
Resolves #2116.

Adds `Backend.lookup_many()` as a replacement method to `Backend.lookup` which accepts a of URIs instead a single URI so that calls can be batched instead of done sequentially. Also reflects these in changes `core.LibraryController.lookup` to pass in the list of URIs it receives instead of calling `Backend.lookup` individually for each URI. Provides a default implementation for `Backend.lookup_many` to call `Backend.lookup` individually to preserve backwards compatibility with existing backends. 