### PR TITLE
Stricter types

### DIFF
--- a/src/mopidy/config/types.py
+++ b/src/mopidy/config/types.py
@@ -443,7 +443,7 @@ class Hostname(ConfigValue[str]):
 
         socket_path = path.get_unix_socket_path(raw_value)
         if socket_path is not None:
-            path_str = Path(not self._required).deserialize(socket_path)
+            path_str = Path(not self._required).deserialize(str(socket_path))
             return f"unix:{path_str}"
 
         try:

--- a/src/mopidy/internal/xdg.py
+++ b/src/mopidy/internal/xdg.py
@@ -3,7 +3,7 @@ import os
 import pathlib
 
 
-def get_dirs():
+def get_dirs() -> dict[str, pathlib.Path]:
     """Returns a dict of all the known XDG Base Directories for the current user.
 
     The keys ``XDG_CACHE_DIR``, ``XDG_CONFIG_DIR``, and ``XDG_DATA_DIR`` is
@@ -33,7 +33,7 @@ def get_dirs():
     return dirs
 
 
-def _get_user_dirs(xdg_config_dir):
+def _get_user_dirs(xdg_config_dir: pathlib.Path) -> dict[str, pathlib.Path]:
     """Returns a dict of XDG dirs read from
     ``$XDG_CONFIG_HOME/user-dirs.dirs``.
 
@@ -57,9 +57,9 @@ def _get_user_dirs(xdg_config_dir):
     config = configparser.RawConfigParser()
     config.read_string(data.decode())
 
-    result = {}
+    result: dict[str, pathlib.Path] = {}
     for k, v in config.items("XDG_USER_DIRS"):
-        if v is None:
+        if v is None:  # pyright: ignore[reportUnnecessaryComparison]
             continue
         if isinstance(k, bytes):
             k = k.decode()

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -53,7 +53,7 @@ class GetOrCreateDirTest(unittest.TestCase):
 
     def test_create_dir_with_none(self):
         with pytest.raises(TypeError):
-            path.get_or_create_dir(None)
+            path.get_or_create_dir(None)  # pyright: ignore[reportArgumentType]
 
 
 class GetOrCreateFileTest(unittest.TestCase):
@@ -100,7 +100,7 @@ class GetOrCreateFileTest(unittest.TestCase):
 
     def test_create_file_with_none_filename_throws_type_error(self):
         with pytest.raises(TypeError):
-            path.get_or_create_file(None)
+            path.get_or_create_file(None)  # pyright: ignore[reportArgumentType]
 
     def test_create_dir_without_mkdir(self):
         file_path = self.parent / "foo" / "bar"
@@ -124,8 +124,8 @@ class GetOrCreateFileTest(unittest.TestCase):
 
 class GetUnixSocketPathTest(unittest.TestCase):
     def test_correctly_matched_socket_path(self):
-        assert (
-            path.get_unix_socket_path("unix:/tmp/mopidy.socket") == "/tmp/mopidy.socket"
+        assert path.get_unix_socket_path("unix:/tmp/mopidy.socket") == pathlib.Path(
+            "/tmp/mopidy.socket"
         )
 
     def test_correctly_no_match_socket_path(self):


### PR DESCRIPTION
This makes the types of the following modules pass pyright in strict mode:

- `mopidy.internal.path`
- `mopidy.internal.xdg`
- `mopidy.internal.jsonrpc`
