### PR TITLE
Refactor deps command

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -98,6 +98,13 @@ Changes to the Audio API may affect a few Mopidy backend extensions.
   - :func:`mopidy.audio.create_buffer`
   - :func:`mopidy.audio.millisecond_to_clocktime`
 
+Extension support
+-----------------
+
+- The command :command:`mopidy deps` no longer repeats transitive dependencies
+  that have already been listed. This reduces the length of the command's output
+  drastically. (PR: :issue:`2152`)
+
 Internals
 ---------
 

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -4,7 +4,6 @@ from importlib import metadata
 from pathlib import Path
 from unittest import mock
 
-import pytest
 from mopidy.internal import deps
 from mopidy.internal.gi import Gst, gi
 
@@ -12,84 +11,94 @@ from mopidy.internal.gi import Gst, gi
 class TestDeps:
     def test_format_dependency_list(self):
         adapters = [
-            lambda: {
-                "name": "Python",
-                "version": "FooPython 2.7.3",
-            },
-            lambda: {
-                "name": "Platform",
-                "version": "Loonix 4.0.1",
-            },
-            lambda: {
-                "name": "Pykka",
-                "version": "1.1",
-                "path": "/foo/bar",
-                "other": "Quux",
-            },
-            lambda: {
-                "name": "Foo",
-            },
-            lambda: {
-                "name": "Mopidy",
-                "version": "0.13",
-                "dependencies": [
-                    {
-                        "name": "pylast",
-                        "version": "0.5",
-                        "dependencies": [{"name": "setuptools", "version": "0.6"}],
-                    }
+            deps.DepInfo(
+                name="Python",
+                version="FooPython 3.12.3",
+            ),
+            deps.DepInfo(
+                name="Platform",
+                version="Loonix 7.0.1",
+            ),
+            deps.DepInfo(
+                name="pykka",
+                version="5.1",
+                path=Path("/foo/bar"),
+                other="Quux",
+            ),
+            deps.DepInfo(
+                name="foo",
+            ),
+            deps.DepInfo(
+                name="mopidy",
+                version="4.13",
+                dependencies=[
+                    deps.DepInfo(
+                        name="pylast",
+                        version="0.5",
+                        dependencies=[
+                            deps.DepInfo(
+                                name="setuptools",
+                                version="0.6",
+                            ),
+                        ],
+                    )
                 ],
-            },
+            ),
         ]
 
         result = deps.format_dependency_list(adapters)
-        assert "Python: FooPython 2.7.3" in result
-        assert "Platform: Loonix 4.0.1" in result
-        assert "Pykka: 1.1 from /foo/bar" in result
+        assert "Python: FooPython 3.12.3" in result
+        assert "Platform: Loonix 7.0.1" in result
+        assert "pykka: 5.1 from /foo/bar" in result
         assert "/baz.py" not in result
         assert "Detailed information: Quux" in result
-        assert "Foo: not found" in result
-        assert "Mopidy: 0.13" in result
+        assert "foo: not found" in result
+        assert "mopidy: 4.13" in result
         assert "  pylast: 0.5" in result
         assert "    setuptools: 0.6" in result
 
     def test_format_dependency_list_real(self):
         result = deps.format_dependency_list()
         assert "Python 3." in result
-        assert "Mopidy: 4." in result
+        assert "mopidy: 4." in result
         assert "setuptools: 6" in result
 
     def test_executable_info(self):
         result = deps.executable_info()
 
-        assert result["name"] == "Executable"
-        assert sys.argv[0] in result["version"]
+        assert result.name == "Executable"
+        assert result.version
+        assert sys.argv[0] in result.version
 
     def test_platform_info(self):
         result = deps.platform_info()
 
-        assert result["name"] == "Platform"
-        assert platform.platform() in result["version"]
+        assert result.name == "Platform"
+        assert result.version
+        assert platform.platform() in result.version
 
     def test_python_info(self):
         result = deps.python_info()
 
-        assert result["name"] == "Python"
-        assert platform.python_implementation() in result["version"]
-        assert platform.python_version() in result["version"]
-        assert "python" in str(result["path"])
-        assert "platform.py" not in str(result["path"])
+        assert result.name == "Python"
+        assert result.version
+        assert platform.python_implementation() in result.version
+        assert platform.python_version() in result.version
+        assert "python" in str(result.path)
+        assert "platform.py" not in str(result.path)
 
     def test_gstreamer_info(self):
         result = deps.gstreamer_info()
 
-        assert result["name"] == "GStreamer"
-        assert ".".join(map(str, Gst.version())) == result["version"]
-        assert "gi" in str(result["path"])
-        assert "__init__.py" not in str(result["path"])
-        assert "Python wrapper: python-gi" in result["other"]
-        assert gi.__version__ in result["other"]
-        assert "Relevant elements:" in result["other"]
+        assert result.name == "GStreamer"
+        assert result.version
+        assert ".".join(map(str, Gst.version())) == result.version
+        assert "gi" in str(result.path)
+        assert "__init__.py" not in str(result.path)
+        assert result.other
+        assert "Python wrapper: python-gi" in result.other
+        assert gi.__version__ in result.other
+        assert "Relevant elements:" in result.other
 
     def test_gstreamer_check_elements(self):
         with mock.patch(
@@ -97,7 +106,8 @@ class TestDeps:
             return_val=("test1", True),
         ):
             result = deps.gstreamer_info()
-            assert "    none" in result["other"]
+            assert result.other
+            assert "    none" in result.other
 
     @mock.patch.object(metadata, "distribution")
     def test_pkg_info(self, get_distribution_mock):
@@ -131,36 +141,33 @@ class TestDeps:
             dist_setuptools,
         ]
 
-        result = deps.pkg_info()
+        mopidy_dep = deps.pkg_info(pkg_name="mopidy", seen_pkgs=set())
 
-        assert result["name"] == "Mopidy"
-        assert result["version"] == "0.13"
-        assert "mopidy" in str(result["path"])
+        assert mopidy_dep.name == "mopidy"
+        assert mopidy_dep.version == "0.13"
+        assert "mopidy" in str(mopidy_dep.path)
 
-        dep_info_pykka = result["dependencies"][0]
-        assert dep_info_pykka["name"] == "Pykka"
-        assert dep_info_pykka["version"] == "1.1"
+        pykka_dep = mopidy_dep.dependencies[0]
+        assert pykka_dep.name == "pykka"
+        assert pykka_dep.version == "1.1"
 
-        dep_info_setuptools = dep_info_pykka["dependencies"][0]
-        assert dep_info_setuptools["name"] == "setuptools"
-        assert dep_info_setuptools["version"] == "0.6"
+        setuptools_dep = pykka_dep.dependencies[0]
+        assert setuptools_dep.name == "setuptools"
+        assert setuptools_dep.version == "0.6"
 
     @mock.patch.object(metadata, "distribution")
     def test_pkg_info_for_missing_dist(self, get_distribution_mock):
         get_distribution_mock.side_effect = metadata.PackageNotFoundError("test")
 
-        result = deps.pkg_info()
+        result = deps.pkg_info(pkg_name="mopidy", seen_pkgs=set())
 
-        assert result["name"] == "Mopidy"
-        assert "version" not in result
-        assert "path" not in result
+        assert result.name == "mopidy"
+        assert result.version is None
+        assert result.path is None
 
-    @pytest.mark.parametrize("include_transitive_deps", [True, False])
-    @pytest.mark.parametrize("include_extras", [True, False])
-    def test_pkg_info_real(self, include_transitive_deps, include_extras):
+    def test_pkg_info_real(self):
         result = deps.pkg_info(
-            "Mopidy",
-            include_transitive_deps=include_transitive_deps,
-            include_extras=include_extras,
+            pkg_name="mopidy",
+            seen_pkgs=set(),
         )
         assert result


### PR DESCRIPTION
- Do not repeat transitive dependencies.
- Refactor to use dataclass instead of dicts.

```diff
--- before.txt  2024-02-23 19:58:31.779994186 +0100
+++ after.txt   2024-02-23 19:58:37.528000081 +0100
@@ -1,7 +1,7 @@
 Executable: /home/jodal/mopidy-dev/.venv/bin/mopidy
 Platform: Linux-6.6.15-amd64-x86_64-with-glibc2.37
 Python: CPython 3.11.8 from /usr/lib/python3.11
-Mopidy: 4.0.0a1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
+mopidy: 4.0.0a1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   pygobject: 3.46.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
     pycairo: 1.26.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   pykka: 4.0.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
@@ -13,31 +13,14 @@
     certifi: 2024.2.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   setuptools: 69.1.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   tornado: 6.4 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-Mopidy-MPD: 4.0.0a1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
+mopidy-mpd: 4.0.0a1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   mopidy: 4.0.0a1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    pygobject: 3.46.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-      pycairo: 1.26.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    pykka: 4.0.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-      typing-extensions: 4.9.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    requests: 2.31.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-      charset-normalizer: 3.3.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-      idna: 3.6 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-      urllib3: 2.2.1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-      certifi: 2024.2.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    setuptools: 69.1.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    tornado: 6.4 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   pykka: 4.0.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    typing-extensions: 4.9.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   setuptools: 69.1.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-Mopidy-Spotify: 4.1.1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-  Mopidy: 4.0.0a1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-  Pykka: 4.0.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    typing-extensions: 4.9.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
+mopidy-spotify: 4.1.1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
+  mopidy: 4.0.0a1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
+  pykka: 4.0.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   requests: 2.31.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    charset-normalizer: 3.3.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    idna: 3.6 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    urllib3: 2.2.1 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
-    certifi: 2024.2.2 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
   setuptools: 69.1.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages
 GStreamer: 1.22.10.0 from /home/jodal/mopidy-dev/.venv/lib/python3.11/site-packages/gi
   Detailed information: 
```