### PR TITLE
Switch to main as the integration branch

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -83,19 +83,19 @@ We welcome all kinds of help with bug fixing, testing, documentation, and suppor
 - `Source code <https://github.com/mopidy/mopidy>`_
 - `Issue tracker <https://github.com/mopidy/mopidy/issues>`_
 
-.. image:: https://img.shields.io/pypi/v/Mopidy.svg?style=flat
-    :target: https://pypi.python.org/pypi/Mopidy/
+.. image:: https://img.shields.io/pypi/v/mopidy
+    :target: https://pypi.org/project/mopidy/
     :alt: Latest PyPI version
 
-.. image:: https://img.shields.io/github/actions/workflow/status/mopidy/mopidy/ci.yml?branch=develop
+.. image:: https://img.shields.io/github/actions/workflow/status/mopidy/mopidy/ci.yml
     :target: https://github.com/mopidy/mopidy/actions/workflows/ci.yml
     :alt: CI build status
 
-.. image:: https://img.shields.io/readthedocs/mopidy.svg
+.. image:: https://img.shields.io/readthedocs/mopidy
     :target: https://docs.mopidy.com/
     :alt: Read the Docs build status
 
-.. image:: https://img.shields.io/codecov/c/github/mopidy/mopidy/develop.svg
+.. image:: https://img.shields.io/codecov/c/github/mopidy/mopidy
     :target: https://codecov.io/gh/mopidy/mopidy
     :alt: Test coverage
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -117,6 +117,9 @@ Extension support
 Internals
 ---------
 
+- Dropped split between the ``main`` and ``develop`` branches. We now use
+  ``main`` for all development, and have removed the ``develop`` branch.
+
 - Added type hints to most of the source code.
 
 - Switched from mypy to pyright for type checking.

--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -73,7 +73,7 @@ Pull request guidelines
      Making sure your ideas and solutions are aligned with other contributors
      greatly increases the odds of your pull request being quickly accepted.
 
-#. Create a new branch, based on the ``develop`` branch, for every feature or
+#. Create a new branch, based on the ``main`` branch, for every feature or
    bug fix. Keep branches small and on topic, as that makes them far easier to
    review.
 
@@ -112,13 +112,5 @@ Pull request guidelines
    - `On commit messages
      <https://who-t.blogspot.com/2009/12/on-commit-messages.html>`_
 
-#. Send a pull request to the ``develop`` branch. See the `GitHub pull request
+#. Send a pull request to the ``main`` branch. See the `GitHub pull request
    docs <https://help.github.com/en/articles/about-pull-requests>`_ for help.
-
-.. note::
-
-    If you are contributing a bug fix for a specific minor version of Mopidy
-    you should create the branch based on ``release-x.y`` instead of
-    ``develop``. When the release is done the changes will be merged back into
-    ``develop`` automatically as part of the normal release process. See
-    :ref:`creating-releases`.

--- a/docs/devenv.rst
+++ b/docs/devenv.rst
@@ -82,7 +82,7 @@ When you've cloned the ``mopidy`` Git repo, ``cd`` into it::
 
     cd ~/mopidy-dev/mopidy/
 
-With a fresh clone of the Git repo, you should start out on the ``develop``
+With a fresh clone of the Git repo, you should start out on the ``main``
 branch. This is where all features for the next feature release land. To
 confirm that you're on the right branch, run::
 
@@ -501,12 +501,12 @@ Creating a branch
 Fetch the latest data from all remotes without affecting your working
 directory::
 
-    git remote update
+    git remote update --prune
 
 Now, we are ready to create and checkout a new branch off of the upstream
-``develop`` branch for our work::
+``main`` branch for our work::
 
-    git checkout -b fix/666-crash-on-foo upstream/develop
+    git checkout -b fix-crash-on-foo upstream/main
 
 Do the work, while remembering to adhere to code style, test the changes, make
 necessary updates to the documentation, and making small commits with good
@@ -519,7 +519,7 @@ Creating a pull request
 
 When everything is done and committed, push the branch to your fork on GitHub::
 
-    git push myuser fix/666-crash-on-foo
+    git push myuser fix-crash-on-foo
 
 Go to the repository on GitHub where you want the change merged, in this case
 https://github.com/mopidy/mopidy, and `create a pull request
@@ -539,7 +539,7 @@ our CI setup runs on your pull request.
 When you've fixed the issues, you can update the pull request simply by pushing
 more commits to the same branch in your fork::
 
-    git push myuser fix/666-crash-on-foo
+    git push myuser fix-crash-on-foo
 
 Likewise, when you get review comments from other developers on your pull
 request, you're expected to create additional commits which addresses the

--- a/docs/extensiondev.rst
+++ b/docs/extensiondev.rst
@@ -779,5 +779,5 @@ the events fire::
 
 
 For further details and examples, refer to the
-`/tests <https://github.com/mopidy/mopidy/tree/develop/tests>`_
-directory on the Mopidy development branch.
+`/tests <https://github.com/mopidy/mopidy/tree/main/tests>`_
+directory in the Mopidy repo.

--- a/docs/releasing.rst
+++ b/docs/releasing.rst
@@ -27,9 +27,9 @@ stream-lined release procedure.
 
     git commit -m "Release v2.0.2"
 
-#. Tag the commit::
+#. Tag the commit with an annotated tag::
 
-    git tag -m "Release v2.0.2" v2.0.2
+    git tag -a -m "Release v2.0.2" v2.0.2
 
    It is encouraged to use ``-s`` to sign the tag if you have a GnuPG setup.
 
@@ -86,18 +86,17 @@ Releasing Mopidy itself
 =======================
 
 Mopidy itself is a bit more complicated than extensions because the changelog
-is maintained in the Git repo, and because we maintain multiple branches to be
-able to work towards the next bugfix release and the next feature release at
-the same time.
+is maintained in the Git repo.
 
 
 Preparations
 ------------
 
-#. Update the changelog. Commit and push it.
-
-#. Make sure that everything has been merged into the ``develop`` branch on
+#. Make sure that everything has been merged into the ``main`` branch on
    GitHub, and that all CI checks are green.
+
+#. Make sure the changelog in the ``docs/changelog.rst`` file includes all
+   significant changes since the last release. Commit and push it.
 
 #. Perform any manual tests you feel are required.
 
@@ -105,32 +104,35 @@ Preparations
 Release
 -------
 
-#. Bump the version in ``setup.cfg`` in line with :ref:`our strategy <versioning>`.
-   For example, to ``3.3.0``, and set the release date in the changelog.
+#. Select a version number in line with :ref:`our strategy <versioning>`,
+   e.g. ``v3.3.0`` in the following examples.
 
-#. Commit the bumped version and release date::
+#. Update the release in ``docs/changelog.rst`` with the right version number
+   and release date.
 
-    git commit -m "Prepare release of v3.3.0"
+#. Commit the final touches to the changelog::
 
-#. Merge the release branch (``develop`` in the example) into ``main``::
+    git commit -m "Release v3.3.0"
 
-    git checkout main
-    git pull
-    git merge --no-ff -m "Release v3.3.0" develop
+#. Tag the commit with an annotated tag::
 
-#. Tag the commit::
-
-    git tag -m "Release v3.3.0" v3.3.0
+    git tag -a -m "Release v3.3.0" v3.3.0
 
    It is encouraged to use ``-s`` to sign the tag if you have a GnuPG setup.
+
+#. Verify that Mopidy reports the new version number::
+
+     mopidy --version
+
+    If it doesn't, check that you've properly tagged the release.
 
 #. Push to GitHub::
 
     git push origin main --follow-tags
 
-#. Go to the GitHub repository's tags page at
-   ``https://github.com/mopidy/mopidy/tags``. Find the tag and select
-   "Create release" in the tag's dropdown menu.
+#. Go to the GitHub repository's
+   `tags page <https://github.com/mopidy/mopidy/tags>`_.
+   Find the tag and select "Create release" in the tag's dropdown menu.
 
 #. Copy the tag, e.g. ``v3.3.0`` into the "title" field. Write a changelog
    entry in the description field, and hit "Publish release".
@@ -141,16 +143,9 @@ Release
 Post-release
 ------------
 
-#. To prepare for further development, merge the ``main`` branch back into
-   the ``develop`` branch and push it to GitHub::
-
-    git checkout develop
-    git merge main
-    git push origin develop
-
 #. Make sure the new tag is built by
    `Read the Docs <https://readthedocs.org/projects/mopidy/builds/>`_,
-   and that the `"latest" version <https://docs.mopidy.com/en/latest/>`_
+   and that the `"stable" version <https://docs.mopidy.com/stable/>`_
    shows the newly released version.
 
 #. Spread the word through an announcement post on the `Discourse forum
@@ -158,6 +153,6 @@ Post-release
 
 #. Notify distribution packagers, including but not limited to:
 
-   - `Arch Linux <https://www.archlinux.org/packages/community/any/mopidy/>`_
+   - `Arch Linux <https://archlinux.org/packages/extra/any/mopidy/>`_
    - `Debian <https://salsa.debian.org/mopidy-team>`_
    - `Homebrew <https://github.com/mopidy/homebrew-mopidy>`_


### PR DESCRIPTION
This PR does the necessary documentation updates to drop `develop` branch and
just use `main` for development.

### Background

- The change rate to core naturally decreased with all the extensions we moved
  out during the Python 3 porting.
- The change rate to core is in general quite low these days.
- The `git flow` workflow have a lot less mindshare than what it had when we
  started using this branch layout.

### Benefits

- Mopidy core will have an identical branch setup to all of Mopidy's extensions.
- Less education of potential contributors.

### Drawbacks?

The main drawback is that if we spend a long while on a big release, we have to
create explicit bugfix release branches and cherry-pick fixes that might be
released earlier than the big release.

I don't really see this as a drawback, as this moves the responsibility for
choosing where something should ship from the contributor to "us" aka release
managers. As we're confident with Git, we can very quickly create short-lived
bugfix release branches, cherry-pick what we think belongs there, tag a
release, and merge it back into main.

This will also change the workflow for getting documentation fixes out a bit.
The last few years, we've hosted the docs for the `main` branch at
`/en/latest/`, and the docs for the `develop` branch at `/en/develop/`.

After this change, and with Read The Docs's new support for shorter URLs, we'll
host the docs for the latest tag at `/stable/` and the `main` branch (where all
changes land) on `/latest/`.

To get important documentation fixes out to the stable version of the docs, we
would need to make a tagged release. Luckily, this is quite rarely needed, and
making a release is becoming easier and easier with the changes we have been
doing and are doing.
