### PR TITLE
Add M3U library provider

### DIFF
--- a/src/mopidy/m3u/backend.py
+++ b/src/mopidy/m3u/backend.py
@@ -7,7 +7,7 @@ import pykka
 from mopidy import backend
 from mopidy.types import UriScheme
 
-from . import playlists
+from . import library, playlists
 
 if TYPE_CHECKING:
     from mopidy.audio import AudioProxy
@@ -24,3 +24,4 @@ class M3UBackend(pykka.ThreadingActor, backend.Backend):
     ) -> None:
         super().__init__()
         self.playlists = playlists.M3UPlaylistsProvider(self, config)
+        self.library = library.M3ULibraryProvider(self, self.playlists)

--- a/src/mopidy/m3u/library.py
+++ b/src/mopidy/m3u/library.py
@@ -1,0 +1,12 @@
+from mopidy import backend
+
+from . import playlists, translator
+
+
+class M3ULibraryProvider(backend.LibraryProvider):
+    def __init__(self, backend, playlist_provider: playlists.M3UPlaylistsProvider):
+        super().__init__(backend)
+        self.playlist_provider = playlist_provider
+
+    def lookup(self, uri):
+        return translator.refs_to_tracks(self.playlist_provider.get_items(uri))

--- a/src/mopidy/m3u/translator.py
+++ b/src/mopidy/m3u/translator.py
@@ -51,6 +51,12 @@ def path_to_ref(path: Path) -> Ref:
     return Ref.playlist(uri=path_to_uri(path), name=name_from_path(path))
 
 
+def refs_to_tracks(refs: Iterable[Ref | Track] | None)-> list[Track]:
+    if refs is None:
+        refs = []
+    return [Track(uri=item.uri, name=item.name) for item in refs]
+
+
 def load_items(
     fp: IO[str],
     basedir: Path,
@@ -96,11 +102,9 @@ def playlist(
     items: Iterable[Ref | Track] | None = None,
     mtime: float | None = None,
 ) -> Playlist:
-    if items is None:
-        items = []
     return Playlist(
         uri=path_to_uri(path),
         name=name_from_path(path),
-        tracks=[Track(uri=item.uri, name=item.name) for item in items],
+        tracks=refs_to_tracks(items),
         last_modified=(int(mtime * 1000) if mtime else None),
     )


### PR DESCRIPTION
Library provider is used by the core.tracklist.add method. Adding the provider allows m3u uris to be used with core.tracklist.add. Without it one cannot add a m3u playlist in one action and would instead have to list all the items then add them one at a time.

Resolves #2155 