### PR TITLE
Add LibraryController.identify method

### DIFF
--- a/src/mopidy/backend.py
+++ b/src/mopidy/backend.py
@@ -14,7 +14,7 @@ from mopidy import listener
 if TYPE_CHECKING:
     from mopidy.audio.actor import AudioProxy
     from mopidy.internal.gi import Gst
-    from mopidy.models import Image, Playlist, Ref, SearchResult, Track
+    from mopidy.models import Image, Playlist, Ref, RefType, SearchResult, Track
     from mopidy.types import (
         DistinctField,
         DurationMs,
@@ -174,6 +174,13 @@ class LibraryProvider:
 
         .. versionadded:: 1.0
             The ``exact`` param which replaces the old ``find_exact``.
+        """
+        return None
+
+    def identify(self, uri: Uri) -> RefType | None:
+        """See :meth:`mopidy.core.LibraryController.lookup`.
+
+        *MAY be implemented by subclass.*
         """
         return None
 
@@ -482,6 +489,7 @@ class LibraryProviderProxy:
     lookup_many = proxy_method(LibraryProvider.lookup_many)
     refresh = proxy_method(LibraryProvider.refresh)
     search = proxy_method(LibraryProvider.search)
+    identify = proxy_method(LibraryProvider.identify)
 
 
 class PlaybackProviderProxy:

--- a/src/mopidy/core/library.py
+++ b/src/mopidy/core/library.py
@@ -12,7 +12,7 @@ from pykka.typing import proxy_method
 
 from mopidy import exceptions
 from mopidy.internal import deprecation, validation
-from mopidy.models import Image, Ref, SearchResult, Track
+from mopidy.models import Image, Ref, RefType, SearchResult, Track
 from mopidy.types import DistinctField, Query, SearchField, Uri, UriScheme
 
 if TYPE_CHECKING:
@@ -349,6 +349,18 @@ class LibraryController:
                 )
 
         return results
+
+    def identify(self, uri: Uri) -> RefType | None:
+        """Identify the type of resource the given URI points to.
+
+        :param uri: The URI to identify
+        """
+        backend = self._get_backend(uri)
+        if not backend:
+            return None
+
+        with _backend_error_handling(backend):
+            return backend.library.identify(uri).get()
 
 
 def _normalize_query(query: Query[SearchField]) -> Query[SearchField]:

--- a/src/mopidy/models/__init__.py
+++ b/src/mopidy/models/__init__.py
@@ -1,3 +1,5 @@
+import enum
+
 from mopidy.models import fields
 from mopidy.models.immutable import ImmutableObject, ValidatedImmutableObject
 from mopidy.models.serialize import ModelJSONEncoder, model_json_decoder
@@ -11,11 +13,20 @@ __all__ = [
     "ModelJSONEncoder",
     "Playlist",
     "Ref",
+    "RefType",
     "SearchResult",
     "TlTrack",
     "Track",
     "ValidatedImmutableObject",
 ]
+
+
+class RefType(enum.StrEnum):
+    ALBUM = "album"
+    ARTIST = "artist"
+    DIRECTORY = "directory"
+    PLAYLIST = "playlist"
+    TRACK = "track"
 
 
 class Ref(ValidatedImmutableObject):


### PR DESCRIPTION
Implements the interface as discussed in #2156 and nothing else. Brought over `RefType` from #2157 