### PR TITLE
Dev tooling upgrades

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
             tox: docs
 
     name: ${{ matrix.name }}
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ghcr.io/mopidy/ci:latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,9 @@ jobs:
             python: "3.12"
             tox: py312
             coverage: true
+          - name: "Test: Python 3.13"
+            python: "3.13"
+            tox: py313
           - name: "Lint: pyright"
             python: "3.12"
             tox: pyright
@@ -45,6 +48,7 @@ jobs:
         with:
           python-version: ${{ matrix.python }}
           cache: pip
+          allow-prereleases: true
       - run: python -m pip install tox
       - run: python -m tox -e ${{ matrix.tox }}
         if: ${{ ! matrix.coverage }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ubuntu-devel.yml
+++ b/.github/workflows/ubuntu-devel.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   main:
     name: "Test: Python 3.12"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     # The container should be automatically updated from time to time.
     container: ubuntu:devel

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,7 +18,9 @@ old versions of our dependencies and a number of deprecated APIs.
 Dependencies
 ------------
 
-- Python >= 3.11 is now required. Python 3.7-3.10 are no longer supported.
+- Python >= 3.11 is now required.
+  Support for 3.7-3.10 have been dropped,
+  while Python 3.13 has been included in the testing matrix.
 
 - GStreamer >= 1.22.0 is now required.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ docs = [
     "sphinx-autodoc-typehints >= 1.12",
     "sphinx-rtd-theme >= 1.2",
 ]
-lint = ["ruff == 0.5.0"]
+lint = ["ruff == 0.6.5"]
 test = ["pytest >= 7.2", "pytest-cov >= 4.0", "responses >= 0.18"]
 typing = [
     "pygobject-stubs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ classifiers = [
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Topic :: Multimedia :: Sound/Audio :: Players",
 ]
 dynamic = ["version"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,44 +91,7 @@ filterwarnings = [
 target-version = "py311"
 
 [tool.ruff.lint]
-select = [
-    "A",   # flake8-builtins
-    "ANN", # flake8-annotations
-    "ARG", # flake8-unused-arguments
-    "B",   # flake8-bugbear
-    "C4",  # flake8-comprehensions
-    "C90", # mccabe
-    "D",   # pydocstyle
-    "DTZ", # flake8-datetimez
-    "E",   # pycodestyle
-    "ERA", # eradicate
-    "F",   # pyflakes
-    "FBT", # flake8-boolean-trap
-    "I",   # isort
-    "INP", # flake8-no-pep420
-    "ISC", # flake8-implicit-str-concat
-    "N",   # pep8-naming
-    "PGH", # pygrep-hooks
-    "PIE", # flake8-pie
-    "PLC", # pylint convention
-    "PLE", # pylint error
-    "PLR", # pylint refactor
-    "PLW", # pylint warning
-    "PT",  # flake8-pytest-style
-    "PTH", # flake8-use-pathlib
-    "Q",   # flake8-quotes
-    "RET", # flake8-return
-    "RSE", # flake8-raise
-    "RUF", # ruff
-    "SIM", # flake8-simplify
-    "SLF", # flake8-self
-    "T20", # flake8-print
-    "TCH", # flake8-type-checking
-    "TID", # flake8-tidy-imports
-    "TRY", # tryceratops
-    "UP",  # pyupgrade
-    "W",   # pycodestyle
-]
+select = ["ALL"]
 ignore = [
     "A002",    # builtin-argument-shadowing  # TODO
     "A003",    # builtin-attribute-shadowing
@@ -150,11 +113,19 @@ ignore = [
     "FBT001",  # boolean-positional-arg-in-function-definition  # TODO
     "FBT002",  # boolean-default-value-in-function-definition  # TODO
     "FBT003",  # boolean-positional-value-in-function-call  # TODO
+    "FIX002",  # line-contains-todo
+    "FIX003",  # line-contains-fixme
+    "FIX004",  # line-contains-hack
+    "G004",    # logging-f-string
     "ISC001",  # single-line-implicit-string-concatenation
     "PLR2004", # magic-value-comparison
     "PLW2901", # redefined-loop-name
     "RET504",  # unnecessary-assign
+    "S101",    # assert  # TODO
+    "S314",    # suspicious-xml-element-tree-usage -- ElementTree is safe given expat >= 2.6.1
     "SLF001",  # private-member-access  # TODO
+    "TD002",   # missing-todo-author
+    "TD003",   # missing-todo-link
     "TCH003",  # typing-only-standard-library-import
     "TRY003",  # raise-vanilla-args
     "TRY400",  # error-instead-of-exception
@@ -177,6 +148,8 @@ ignore = [
     "PT007",   # pytest-parametrize-values-wrong-type  # TODO
     "PT009",   # pytest-unittest-assertion  # TODO
     "PT011",   # pytest-raises-too-broad  # TODO
+    "S101",    # assert
+    "S108",    # hardcoded-temp-file
     "SLF001",  # private-member-access
     "TRY002",  # raise-vanilla-class
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,7 +42,7 @@ lint = ["ruff == 0.5.0"]
 test = ["pytest >= 7.2", "pytest-cov >= 4.0", "responses >= 0.18"]
 typing = [
     "pygobject-stubs",
-    "pyright == 1.1.350",
+    "pyright == 1.1.380",
     "types-requests",
     "types-setuptools",
 ]

--- a/src/mopidy/__init__.py
+++ b/src/mopidy/__init__.py
@@ -6,7 +6,7 @@ from importlib.metadata import version
 if not sys.version_info >= (3, 11):
     sys.exit(
         f"ERROR: Mopidy requires Python >= 3.11, "
-        f"but found {platform.python_version()}."
+        f"but found {platform.python_version()}.",
     )
 
 warnings.filterwarnings("ignore", "could not open display")

--- a/src/mopidy/__main__.py
+++ b/src/mopidy/__main__.py
@@ -100,13 +100,13 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
             if not ext.validate_extension_data(data):
                 config[extension.ext_name] = {"enabled": False}
                 config_errors[extension.ext_name] = {
-                    "enabled": "extension disabled by self check."
+                    "enabled": "extension disabled by self check.",
                 }
                 extensions_status["validate"].append(extension)
             elif not config[extension.ext_name]["enabled"]:
                 config[extension.ext_name] = {"enabled": False}
                 config_errors[extension.ext_name] = {
-                    "enabled": "extension disabled by user config."
+                    "enabled": "extension disabled by user config.",
                 }
                 extensions_status["disabled"].append(extension)
             elif config_errors.get(extension.ext_name):
@@ -119,7 +119,8 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
                 extensions_status["enabled"].append(extension)
 
         log_extension_info(
-            [d.extension for d in extensions_data], extensions_status["enabled"]
+            [d.extension for d in extensions_data],
+            extensions_status["enabled"],
         )
 
         # Config and deps commands are simply special cased for now.
@@ -162,7 +163,7 @@ def main() -> int:  # noqa: C901, PLR0912, PLR0915
                 # collections.Sequence to provide a RO view.
                 logger.exception(
                     f"Extension {extension.ext_name} failed during setup. "
-                    f"This might have left the registry in a bad state."
+                    f"This might have left the registry in a bad state.",
                 )
 
         # Anything that wants to exit after this point must use
@@ -207,7 +208,7 @@ def create_initial_config_file(config_files, extensions_data):
         logger.info(f"Initialized {config_file.as_uri()} with default config")
     except OSError as exc:
         logger.warning(
-            f"Unable to initialize {config_file.as_uri()} with default config: {exc}"
+            f"Unable to initialize {config_file.as_uri()} with default config: {exc}",
         )
 
 
@@ -242,7 +243,7 @@ def check_config_errors(
             del errors[section]["enabled"]
             logger.warning(
                 f"Found {section} configuration errors. "
-                f"The extension has been automatically disabled:"
+                f"The extension has been automatically disabled:",
             )
         else:
             continue
@@ -253,7 +254,7 @@ def check_config_errors(
     if extensions_status["config"]:
         logger.warning(
             "Please fix the extension configuration errors or "
-            "disable the extensions to silence these messages."
+            "disable the extensions to silence these messages.",
         )
 
     if fatal_errors:

--- a/src/mopidy/audio/actor.py
+++ b/src/mopidy/audio/actor.py
@@ -48,13 +48,15 @@ class _Outputs(Gst.Bin):
 
         tee = Gst.ElementFactory.make("tee")
         if tee is None:
-            raise exceptions.AudioException("Failed to create GStreamer tee.")
+            msg = "Failed to create GStreamer tee."
+            raise exceptions.AudioException(msg)
         self._tee = tee
         self.add(self._tee)
 
         tee_sink = self._tee.get_static_pad("sink")
         if tee_sink is None:
-            raise exceptions.AudioException("Failed to get sink from GStreamer tee.")
+            msg = "Failed to get sink from GStreamer tee."
+            raise exceptions.AudioException(msg)
         ghost_pad = Gst.GhostPad.new("sink", tee_sink)
         self.add_pad(ghost_pad)
 
@@ -67,9 +69,8 @@ class _Outputs(Gst.Bin):
             )
         except GLib.Error as exc:
             logger.error('Failed to create audio output "%s": %s', description, exc)
-            raise exceptions.AudioException(
-                f"Failed to create audio output {description!r}",
-            ) from exc
+            msg = f"Failed to create audio output {description!r}"
+            raise exceptions.AudioException(msg) from exc
 
         self._add(output)
         logger.info('Audio output set to "%s"', description)
@@ -79,7 +80,8 @@ class _Outputs(Gst.Bin):
 
         queue = Gst.ElementFactory.make("queue")
         if queue is None:
-            raise exceptions.AudioException("Failed to create GStreamer queue.")
+            msg = "Failed to create GStreamer queue."
+            raise exceptions.AudioException(msg)
         self.add(queue)
 
         queue.link(element)
@@ -436,7 +438,8 @@ class Audio(pykka.ThreadingActor):
     def _setup_playbin(self) -> None:
         playbin = Gst.ElementFactory.make("playbin")
         if playbin is None:
-            raise exceptions.AudioException("Failed to create GStreamer playbin.")
+            msg = "Failed to create GStreamer playbin."
+            raise exceptions.AudioException(msg)
         playbin.set_property("flags", _GST_PLAY_FLAGS_AUDIO)
 
         # TODO: turn into config values...
@@ -463,8 +466,9 @@ class Audio(pykka.ThreadingActor):
         if self._config["audio"]["output"] == "testoutput":
             fakesink = Gst.ElementFactory.make("fakesink")
             if fakesink is None:
+                msg = "Failed to create GStreamer fakesink element."
                 raise exceptions.AudioException(
-                    "Failed to create GStreamer fakesink element.",
+                    msg,
                 )
             self._outputs = fakesink
         else:
@@ -480,24 +484,24 @@ class Audio(pykka.ThreadingActor):
         assert self._playbin
 
         if self._outputs is None:
-            raise TypeError("Audio outputs must be set up before audio sinks.")
+            msg = "Audio outputs must be set up before audio sinks."
+            raise TypeError(msg)
 
         audio_sink = Gst.ElementFactory.make("bin", "audio-sink")
         if audio_sink is None:
-            raise exceptions.AudioException(
-                "Failed to create GStreamer bin 'audio-sink'.",
-            )
+            msg = "Failed to create GStreamer bin 'audio-sink'."
+            raise exceptions.AudioException(msg)
         audio_sink = cast(Gst.Bin, audio_sink)
 
         queue = Gst.ElementFactory.make("queue")
         if queue is None:
-            raise exceptions.AudioException("Failed to create GStreamer queue element.")
+            msg = "Failed to create GStreamer queue element."
+            raise exceptions.AudioException(msg)
 
         volume = Gst.ElementFactory.make("volume")
         if volume is None:
-            raise exceptions.AudioException(
-                "Failed to create GStreamer volume element.",
-            )
+            msg = "Failed to create GStreamer volume element."
+            raise exceptions.AudioException(msg)
 
         # Queue element to buy us time between the about-to-finish event and
         # the actual switch, i.e. about to switch can block for longer thanks
@@ -522,7 +526,8 @@ class Audio(pykka.ThreadingActor):
 
         queue_sink = queue.get_static_pad("sink")
         if queue_sink is None:
-            raise exceptions.AudioException("Failed to get sink from GStreamer queue.")
+            msg = "Failed to get sink from GStreamer queue."
+            raise exceptions.AudioException(msg)
         ghost_pad = Gst.GhostPad.new("sink", queue_sink)
         audio_sink.add_pad(ghost_pad)
 
@@ -555,9 +560,8 @@ class Audio(pykka.ThreadingActor):
 
         source_factory = source.get_factory()
         if source_factory is None:
-            raise exceptions.AudioException(
-                "Failed to get factory from GStreamer source.",
-            )
+            msg = "Failed to get factory from GStreamer source."
+            raise exceptions.AudioException(msg)
 
         if self._source_setup_callback:
             logger.debug("Running source-setup callback")
@@ -722,7 +726,8 @@ class Audio(pykka.ThreadingActor):
 
         bus = self._playbin.get_bus()
         if bus is None:
-            raise exceptions.AudioException("Failed to get bus from GStreamer playbin.")
+            msg = "Failed to get bus from GStreamer playbin."
+            raise exceptions.AudioException(msg)
 
         bus.set_sync_handler(sync_handler)
 

--- a/src/mopidy/audio/actor.py
+++ b/src/mopidy/audio/actor.py
@@ -44,7 +44,7 @@ _GST_STATE_MAPPING: dict[Gst.State, PlaybackState] = {
 class _Outputs(Gst.Bin):
     def __init__(self):
         Gst.Bin.__init__(self)
-        # TODO gst1: Set 'outputs' as the Bin name for easier debugging
+        # TODO(gst1): Set 'outputs' as the Bin name for easier debugging
 
         tee = Gst.ElementFactory.make("tee")
         if tee is None:
@@ -59,7 +59,7 @@ class _Outputs(Gst.Bin):
         self.add_pad(ghost_pad)
 
     def add_output(self, description) -> None:
-        # XXX This only works for pipelines not in use until #790 gets done.
+        # NOTE: This only works for pipelines not in use until #790 gets done.
         try:
             output = Gst.parse_bin_from_description(
                 description,
@@ -202,7 +202,7 @@ class _Handler:
         )
 
         if new_state == Gst.State.READY and pending_state == Gst.State.NULL:
-            # XXX: We're not called on the last state change when going down to
+            # HACK: We're not called on the last state change when going down to
             # NULL, so we rewrite the second to last call to get the expected
             # behavior.
             new_state = Gst.State.NULL
@@ -219,7 +219,7 @@ class _Handler:
 
         target_state = _GST_STATE_MAPPING.get(self._audio._target_state)
         if target_state is None:
-            # XXX: Workaround for #1430, to be fixed properly by #1222.
+            # HACK: Workaround for #1430, to be fixed properly by #1222.
             logger.warning("Race condition happened. See #1222 and #1430.")
             return
         if target_state == new_state:
@@ -588,7 +588,7 @@ class Audio(pykka.ThreadingActor):
         """
         assert self._playbin
 
-        # XXX: Hack to workaround issue on Mac OS X where volume level
+        # HACK: Hack to workaround issue on Mac OS X where volume level
         # does not persist between track changes. mopidy/mopidy#886
         current_volume = self.mixer.get_volume() if self.mixer is not None else None
 

--- a/src/mopidy/audio/actor.py
+++ b/src/mopidy/audio/actor.py
@@ -62,12 +62,13 @@ class _Outputs(Gst.Bin):
         # XXX This only works for pipelines not in use until #790 gets done.
         try:
             output = Gst.parse_bin_from_description(
-                description, ghost_unlinked_pads=True
+                description,
+                ghost_unlinked_pads=True,
             )
         except GLib.Error as exc:
             logger.error('Failed to create audio output "%s": %s', description, exc)
             raise exceptions.AudioException(
-                f"Failed to create audio output {description!r}"
+                f"Failed to create audio output {description!r}",
             ) from exc
 
         self._add(output)
@@ -143,7 +144,8 @@ class _Handler:
     def setup_event_handling(self, pad) -> None:
         self._pad = pad
         self._event_handler_id = pad.add_probe(
-            Gst.PadProbeType.EVENT_BOTH, self.on_pad_event
+            Gst.PadProbeType.EVENT_BOTH,
+            self.on_pad_event,
         )
 
     def teardown_message_handling(self) -> None:
@@ -462,7 +464,7 @@ class Audio(pykka.ThreadingActor):
             fakesink = Gst.ElementFactory.make("fakesink")
             if fakesink is None:
                 raise exceptions.AudioException(
-                    "Failed to create GStreamer fakesink element."
+                    "Failed to create GStreamer fakesink element.",
                 )
             self._outputs = fakesink
         else:
@@ -483,7 +485,7 @@ class Audio(pykka.ThreadingActor):
         audio_sink = Gst.ElementFactory.make("bin", "audio-sink")
         if audio_sink is None:
             raise exceptions.AudioException(
-                "Failed to create GStreamer bin 'audio-sink'."
+                "Failed to create GStreamer bin 'audio-sink'.",
             )
         audio_sink = cast(Gst.Bin, audio_sink)
 
@@ -494,7 +496,7 @@ class Audio(pykka.ThreadingActor):
         volume = Gst.ElementFactory.make("volume")
         if volume is None:
             raise exceptions.AudioException(
-                "Failed to create GStreamer volume element."
+                "Failed to create GStreamer volume element.",
             )
 
         # Queue element to buy us time between the about-to-finish event and
@@ -547,13 +549,14 @@ class Audio(pykka.ThreadingActor):
         source: Gst.Element,
     ) -> None:
         gst_logger.debug(
-            "Got source-setup signal: element=%s", source.__class__.__name__
+            "Got source-setup signal: element=%s",
+            source.__class__.__name__,
         )
 
         source_factory = source.get_factory()
         if source_factory is None:
             raise exceptions.AudioException(
-                "Failed to get factory from GStreamer source."
+                "Failed to get factory from GStreamer source.",
             )
 
         if self._source_setup_callback:
@@ -597,7 +600,7 @@ class Audio(pykka.ThreadingActor):
         if live_stream and download:
             logger.warning(
                 "Ambiguous buffering flags: "
-                "'live_stream' and 'download' should not both be set."
+                "'live_stream' and 'download' should not both be set.",
             )
 
         self._pending_uri = uri
@@ -661,7 +664,9 @@ class Audio(pykka.ThreadingActor):
         # Since elements are not allowed to act on the seek event, only modify
         # it, this should be safe to do.
         return self._queue.seek_simple(
-            Gst.Format.TIME, Gst.SeekFlags.FLUSH, gst_position
+            Gst.Format.TIME,
+            Gst.SeekFlags.FLUSH,
+            gst_position,
         )
 
     def start_playback(self) -> bool:

--- a/src/mopidy/audio/scan.py
+++ b/src/mopidy/audio/scan.py
@@ -87,7 +87,8 @@ class Scanner:
 def _setup_pipeline(uri: str, proxy_config=None) -> tuple[Gst.Pipeline, utils.Signals]:
     src = Gst.Element.make_from_uri(Gst.URIType.SRC, uri)
     if not src:
-        raise exceptions.ScannerError(f"GStreamer can not open: {uri}")
+        msg = f"GStreamer can not open: {uri}"
+        raise exceptions.ScannerError(msg)
 
     if proxy_config:
         utils.setup_proxy(src, proxy_config)
@@ -96,7 +97,8 @@ def _setup_pipeline(uri: str, proxy_config=None) -> tuple[Gst.Pipeline, utils.Si
 
     pipeline = Gst.ElementFactory.make("pipeline")
     if pipeline is None:
-        raise exceptions.AudioException("Failed to create GStreamer pipeline element.")
+        msg = "Failed to create GStreamer pipeline element."
+        raise exceptions.AudioException(msg)
     pipeline = cast(Gst.Pipeline, pipeline)
     pipeline.add(src)
 
@@ -105,7 +107,8 @@ def _setup_pipeline(uri: str, proxy_config=None) -> tuple[Gst.Pipeline, utils.Si
     elif _has_dynamic_src_pad(src):
         signals.connect(src, "pad-added", _setup_decodebin, pipeline, signals)
     else:
-        raise exceptions.ScannerError("No pads found in source element.")
+        msg = "No pads found in source element."
+        raise exceptions.ScannerError(msg)
 
     return pipeline, signals
 
@@ -129,11 +132,13 @@ def _has_dynamic_src_pad(element) -> bool:
 def _setup_decodebin(element, pad, pipeline, signals) -> None:  # noqa: ARG001
     typefind = Gst.ElementFactory.make("typefind")
     if typefind is None:
-        raise exceptions.AudioException("Failed to create GStreamer typefind element.")
+        msg = "Failed to create GStreamer typefind element."
+        raise exceptions.AudioException(msg)
 
     decodebin = Gst.ElementFactory.make("decodebin")
     if decodebin is None:
-        raise exceptions.AudioException("Failed to create GStreamer decodebin element.")
+        msg = "Failed to create GStreamer decodebin element."
+        raise exceptions.AudioException(msg)
 
     for el in (typefind, decodebin):
         pipeline.add(el)
@@ -159,11 +164,13 @@ def _have_type(
 
     element_bus = element.get_bus()
     if element_bus is None:
-        raise exceptions.AudioException("Failed to get bus of GStreamer element.")
+        msg = "Failed to get bus of GStreamer element."
+        raise exceptions.AudioException(msg)
 
     message = Gst.Message.new_application(element, struct)
     if message is None:
-        raise exceptions.AudioException("Failed to create GStreamer message.")
+        msg = "Failed to create GStreamer message."
+        raise exceptions.AudioException(msg)
 
     element_bus.post(message)
 
@@ -175,7 +182,8 @@ def _pad_added(
 ) -> None:
     fakesink = Gst.ElementFactory.make("fakesink")
     if fakesink is None:
-        raise exceptions.AudioException("Failed to create GStreamer fakesink element.")
+        msg = "Failed to create GStreamer fakesink element."
+        raise exceptions.AudioException(msg)
 
     fakesink.set_property("sync", False)
 
@@ -183,7 +191,8 @@ def _pad_added(
     fakesink.sync_state_with_parent()
     fakesink_sink = fakesink.get_static_pad("sink")
     if fakesink_sink is None:
-        raise exceptions.AudioException("Failed to get sink pad of GStreamer fakesink.")
+        msg = "Failed to get sink pad of GStreamer fakesink."
+        raise exceptions.AudioException(msg)
     pad.link(fakesink_sink)
 
     raw_caps = Gst.Caps.from_string("audio/x-raw")
@@ -196,11 +205,13 @@ def _pad_added(
 
         element_bus = element.get_bus()
         if element_bus is None:
-            raise exceptions.AudioException("Failed to get bus of GStreamer element.")
+            msg = "Failed to get bus of GStreamer element."
+            raise exceptions.AudioException(msg)
 
         message = Gst.Message.new_application(element, struct)
         if message is None:
-            raise exceptions.AudioException("Failed to create GStreamer message.")
+            msg = "Failed to create GStreamer message."
+            raise exceptions.AudioException(msg)
 
         element_bus.post(message)
 
@@ -218,11 +229,13 @@ def _autoplug_select(
 
         element_bus = element.get_bus()
         if element_bus is None:
-            raise exceptions.AudioException("Failed to get bus of GStreamer element.")
+            msg = "Failed to get bus of GStreamer element."
+            raise exceptions.AudioException(msg)
 
         message = Gst.Message.new_application(element, struct)
         if message is None:
-            raise exceptions.AudioException("Failed to create GStreamer message.")
+            msg = "Failed to create GStreamer message."
+            raise exceptions.AudioException(msg)
 
         element_bus.post(message)
 
@@ -356,7 +369,8 @@ def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
         timeout = timeout_ms - (int(time.time() * 1000) - start)
 
-    raise exceptions.ScannerError(f"Timeout after {timeout_ms:d}ms")
+    msg = f"Timeout after {timeout_ms:d}ms"
+    raise exceptions.ScannerError(msg)
 
 
 if __name__ == "__main__":

--- a/src/mopidy/audio/scan.py
+++ b/src/mopidy/audio/scan.py
@@ -1,9 +1,8 @@
-import collections
 import logging
 import time
 from enum import IntEnum
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, NamedTuple, cast
 
 from mopidy import exceptions
 from mopidy.audio import tags as tags_lib
@@ -26,10 +25,14 @@ class GstAutoplugSelectResult(IntEnum):
     SKIP = 2
 
 
-_Result = collections.namedtuple(
-    "_Result",
-    ("uri", "tags", "duration", "seekable", "mime", "playable"),
-)
+class _Result(NamedTuple):
+    uri: str
+    tags: dict[str, Any]
+    duration: int | None
+    seekable: bool
+    mime: str | None
+    playable: bool
+
 
 logger = logging.getLogger(__name__)
 
@@ -47,11 +50,19 @@ class Scanner:
     :type event: int
     """
 
-    def __init__(self, timeout=1000, proxy_config=None):
+    def __init__(
+        self,
+        timeout: int = 1000,
+        proxy_config: dict[str, Any] | None = None,
+    ) -> None:
         self._timeout_ms = int(timeout)
         self._proxy_config = proxy_config or {}
 
-    def scan(self, uri, timeout=None):
+    def scan(
+        self,
+        uri: str,
+        timeout: float | None = None,
+    ) -> _Result:
         """Scan the given uri collecting relevant metadata.
 
         :param uri: URI of the resource to scan.

--- a/src/mopidy/audio/scan.py
+++ b/src/mopidy/audio/scan.py
@@ -27,7 +27,8 @@ class GstAutoplugSelectResult(IntEnum):
 
 
 _Result = collections.namedtuple(
-    "_Result", ("uri", "tags", "duration", "seekable", "mime", "playable")
+    "_Result",
+    ("uri", "tags", "duration", "seekable", "mime", "playable"),
 )
 
 logger = logging.getLogger(__name__)
@@ -211,7 +212,7 @@ def _autoplug_select(
     factory: Gst.ElementFactory,
 ) -> GstAutoplugSelectResult:
     if factory.list_is_type(
-        GstElementFactoryListType.DECODER | GstElementFactoryListType.AUDIO
+        GstElementFactoryListType.DECODER | GstElementFactoryListType.AUDIO,
     ):
         struct = Gst.Structure.new_empty("have-audio")
 
@@ -228,7 +229,7 @@ def _autoplug_select(
     if not factory.list_is_type(
         GstElementFactoryListType.DEMUXER
         | GstElementFactoryListType.DEPAYLOADER
-        | GstElementFactoryListType.PARSER
+        | GstElementFactoryListType.PARSER,
     ):
         return GstAutoplugSelectResult.EXPOSE
     return GstAutoplugSelectResult.TRY

--- a/src/mopidy/audio/tags.py
+++ b/src/mopidy/audio/tags.py
@@ -62,7 +62,9 @@ gstreamer-GstTagList.html
             if isinstance(value, GLib.Date):
                 try:
                     date = datetime.date(
-                        value.get_year(), value.get_month(), value.get_day()
+                        value.get_year(),
+                        value.get_month(),
+                        value.get_day(),
                     )
                     result[tag].append(date.isoformat())
                 except ValueError:
@@ -138,10 +140,15 @@ def convert_tags_to_track(tags):
     track_kwargs["composers"] = _artists(tags, Gst.TAG_COMPOSER)
     track_kwargs["performers"] = _artists(tags, Gst.TAG_PERFORMER)
     track_kwargs["artists"] = _artists(
-        tags, Gst.TAG_ARTIST, "musicbrainz-artistid", "musicbrainz-sortname"
+        tags,
+        Gst.TAG_ARTIST,
+        "musicbrainz-artistid",
+        "musicbrainz-sortname",
     )
     album_kwargs["artists"] = _artists(
-        tags, Gst.TAG_ALBUM_ARTIST, "musicbrainz-albumartistid"
+        tags,
+        Gst.TAG_ALBUM_ARTIST,
+        "musicbrainz-albumartistid",
     )
 
     track_kwargs["genre"] = "; ".join(tags.get(Gst.TAG_GENRE, []))

--- a/src/mopidy/backend.py
+++ b/src/mopidy/backend.py
@@ -116,7 +116,9 @@ class LibraryProvider:
         return []
 
     def get_distinct(
-        self, field: DistinctField, query: Query[SearchField] | None = None
+        self,
+        field: DistinctField,
+        query: Query[SearchField] | None = None,
     ) -> set[str]:
         """See :meth:`mopidy.core.LibraryController.get_distinct`.
 

--- a/src/mopidy/commands.py
+++ b/src/mopidy/commands.py
@@ -42,9 +42,8 @@ def config_override_type(value: str) -> tuple[str, str, str]:
         key, value = remainder.split("=", 1)
         return (section.strip(), key.strip(), value.strip())
     except ValueError as exc:
-        raise argparse.ArgumentTypeError(
-            f"{value} must have the format section/key=value",
-        ) from exc
+        msg = f"{value} must have the format section/key=value"
+        raise argparse.ArgumentTypeError(msg) from exc
 
 
 class _ParserError(Exception):

--- a/src/mopidy/commands.py
+++ b/src/mopidy/commands.py
@@ -43,7 +43,7 @@ def config_override_type(value: str) -> tuple[str, str, str]:
         return (section.strip(), key.strip(), value.strip())
     except ValueError as exc:
         raise argparse.ArgumentTypeError(
-            f"{value} must have the format section/key=value"
+            f"{value} must have the format section/key=value",
         ) from exc
 
 
@@ -251,7 +251,10 @@ class Command:
             self.exit(1, f"unrecognized command: {child}", usage)
 
         return self._children[child]._parse(
-            result._args, result, overrides, " ".join([prog, child])
+            result._args,
+            result,
+            overrides,
+            " ".join([prog, child]),
         )
 
     def run(
@@ -289,7 +292,10 @@ class RootCommand(Command):
         super().__init__()
         self.set(base_verbosity_level=0)
         self.add_argument(
-            "-h", "--help", action="help", help="Show this message and exit"
+            "-h",
+            "--help",
+            action="help",
+            help="Show this message and exit",
         )
         self.add_argument(
             "--version",
@@ -491,7 +497,10 @@ class RootCommand(Command):
         core = cast(
             CoreProxy,
             Core.start(
-                config=config, mixer=mixer, backends=backends, audio=audio
+                config=config,
+                mixer=mixer,
+                backends=backends,
+                audio=audio,
             ).proxy(),
         )
         call = ProxyCall(attr_path=("_setup",), args=(), kwargs={})

--- a/src/mopidy/commands.py
+++ b/src/mopidy/commands.py
@@ -198,7 +198,7 @@ class Command:
             result.append(formatter.format_help())
 
         for childname, child in self._children.items():
-            child._subhelp(" ".join((name, childname)), result)
+            child._subhelp(f"{name} {childname}", result)
 
     def parse(self, args: list[str], prog: str | None = None) -> argparse.Namespace:
         """Parse command line arguments.
@@ -253,7 +253,7 @@ class Command:
             result._args,
             result,
             overrides,
-            " ".join([prog, child]),
+            f"{prog} {child}",
         )
 
     def run(

--- a/src/mopidy/config/__init__.py
+++ b/src/mopidy/config/__init__.py
@@ -197,8 +197,10 @@ def format_initial(extensions_data: list[ExtensionData]) -> str:
 
     versions = [f"Mopidy {mopidy.__version__}"]
     extensions_data = sorted(extensions_data, key=lambda d: d.extension.dist_name)
-    for data in extensions_data:
-        versions.append(f"{data.extension.dist_name} {data.extension.version}")
+    versions.extend(
+        f"{data.extension.dist_name} {data.extension.version}"
+        for data in extensions_data
+    )
 
     header = _INITIAL_HELP.strip().format(versions="\n#   ".join(versions))
     formatted_config = _format(

--- a/src/mopidy/config/__init__.py
+++ b/src/mopidy/config/__init__.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
 
 
 __all__ = [
-    # TODO List everything that is reexported, not just the unused parts.
+    # TODO: List everything that is reexported, not just the unused parts.
     "ConfigValue",
     "Float",
     "List",

--- a/src/mopidy/config/__init__.py
+++ b/src/mopidy/config/__init__.py
@@ -336,7 +336,7 @@ def _format(
             if comment:
                 output[-1] += "  ; " + comment.capitalize()
             if disable:
-                output[-1] = re.sub(r"^", "#", output[-1], flags=re.M)
+                output[-1] = re.sub(r"^", "#", output[-1], flags=re.MULTILINE)
         output.append("")
     return "\n".join(output).strip()
 

--- a/src/mopidy/config/__init__.py
+++ b/src/mopidy/config/__init__.py
@@ -202,7 +202,11 @@ def format_initial(extensions_data: list[ExtensionData]) -> str:
 
     header = _INITIAL_HELP.strip().format(versions="\n#   ".join(versions))
     formatted_config = _format(
-        config=config, comments={}, schemas=schemas, display=False, disable=True
+        config=config,
+        comments={},
+        schemas=schemas,
+        display=False,
+        disable=True,
     )
     return header + "\n\n" + formatted_config
 
@@ -249,13 +253,13 @@ def _load_file(
 ) -> None:
     if not file_path.exists():
         logger.debug(
-            f"Loading config from {file_path.as_uri()} failed; it does not exist"
+            f"Loading config from {file_path.as_uri()} failed; it does not exist",
         )
         return
     if not os.access(str(file_path), os.R_OK):
         logger.warning(
             f"Loading config from {file_path.as_uri()} failed; "
-            f"read permission missing"
+            f"read permission missing",
         )
         return
 
@@ -266,13 +270,13 @@ def _load_file(
     except configparser.MissingSectionHeaderError:
         logger.warning(
             f"Loading config from {file_path.as_uri()} failed; "
-            f"it does not have a config section"
+            f"it does not have a config section",
         )
     except configparser.ParsingError as e:
         linenos = ", ".join(str(lineno) for lineno, line in e.errors)
         logger.warning(
             f"Config file {file_path.as_uri()} has errors; "
-            f"line {linenos} has been ignored"
+            f"line {linenos} has been ignored",
         )
     except OSError:
         # TODO: if this is the initial load of logging config we might not
@@ -300,7 +304,7 @@ def _validate(
     for section in sections:
         logger.warning(
             f"Ignoring config section {section!r} "
-            f"because no matching extension was found"
+            f"because no matching extension was found",
         )
 
     return cast(Config, config), errors

--- a/src/mopidy/config/__init__.py
+++ b/src/mopidy/config/__init__.py
@@ -361,7 +361,8 @@ def _preprocess(config_string: str) -> str:
             case ";":
                 return f"__SEMICOLON{next(counter):d}__ ="
             case _:
-                raise AssertionError(f"Unexpected comment type: {match.group(1)!r}")
+                msg = f"Unexpected comment type: {match.group(1)!r}"
+                raise AssertionError(msg)
 
     def inlinecomments(_match) -> str:
         return f"\n__INLINE{next(counter):d}__ ="

--- a/src/mopidy/config/keyring.py
+++ b/src/mopidy/config/keyring.py
@@ -8,7 +8,7 @@ except ImportError:
     dbus = None
 
 
-# XXX: Hack to workaround introspection bug caused by gnome-keyring, should be
+# HACK: Hack to workaround introspection bug caused by gnome-keyring, should be
 # fixed by version 3.5 per:
 # https://git.gnome.org/browse/gnome-keyring/commit/?id=5dccbe88eb94eea9934e2b7
 EMPTY_STRING = dbus.String("", variant_level=1) if dbus else ""

--- a/src/mopidy/config/keyring.py
+++ b/src/mopidy/config/keyring.py
@@ -75,7 +75,9 @@ def set(  # noqa: A001, PLR0911
     """
     if not dbus:
         logger.debug(
-            "Saving %s/%s to keyring failed. (dbus not installed)", section, key
+            "Saving %s/%s to keyring failed. (dbus not installed)",
+            section,
+            key,
         )
         return False
 
@@ -104,7 +106,7 @@ def set(  # noqa: A001, PLR0911
 
     session = service.OpenSession("plain", EMPTY_STRING)[1]
     secret = dbus.Struct(
-        (session, "", dbus.ByteArray(value), "plain/text; charset=utf8")
+        (session, "", dbus.ByteArray(value), "plain/text; charset=utf8"),
     )
     label = f"mopidy: {section}/{key}"
     attributes = {"service": "mopidy", "section": section, "key": key}

--- a/src/mopidy/config/types.py
+++ b/src/mopidy/config/types.py
@@ -56,6 +56,8 @@ class DeprecatedValue:
 
 
 class _TransformedValue(str):
+    __slots__ = ("original",)
+
     def __new__(cls, _original, transformed):
         return super().__new__(cls, transformed)
 

--- a/src/mopidy/config/types.py
+++ b/src/mopidy/config/types.py
@@ -249,7 +249,8 @@ class Boolean(ConfigValue[bool]):
             return True
         if result.lower() in self.false_values:
             return False
-        raise ValueError(f"invalid value for boolean: {result!r}")
+        msg = f"invalid value for boolean: {result!r}"
+        raise ValueError(msg)
 
     def serialize(
         self,
@@ -260,7 +261,8 @@ class Boolean(ConfigValue[bool]):
             return "true"
         if value in (False, None):
             return "false"
-        raise ValueError(f"{value!r} is not a boolean")
+        msg = f"{value!r} is not a boolean"
+        raise ValueError(msg)
 
 
 class Pair(ConfigValue[tuple[K, V]]):
@@ -296,9 +298,10 @@ class Pair(ConfigValue[tuple[K, V]]):
         elif self._optional_pair:
             values = (raw_value, raw_value)
         else:
-            raise ValueError(
-                f"Config value must include {self._separator!r} separator: {raw_value}",
+            msg = (
+                f"Config value must include {self._separator!r} separator: {raw_value}"
             )
+            raise ValueError(msg)
 
         return cast(
             tuple[K, V],
@@ -454,7 +457,8 @@ class Hostname(ConfigValue[str]):
         try:
             socket.getaddrinfo(raw_value, None)
         except OSError as exc:
-            raise ValueError("must be a resolveable hostname or valid IP") from exc
+            msg = "must be a resolveable hostname or valid IP"
+            raise ValueError(msg) from exc
 
         return raw_value
 

--- a/src/mopidy/config/types.py
+++ b/src/mopidy/config/types.py
@@ -297,7 +297,7 @@ class Pair(ConfigValue[tuple[K, V]]):
             values = (raw_value, raw_value)
         else:
             raise ValueError(
-                f"Config value must include {self._separator!r} separator: {raw_value}"
+                f"Config value must include {self._separator!r} separator: {raw_value}",
             )
 
         return cast(
@@ -309,13 +309,16 @@ class Pair(ConfigValue[tuple[K, V]]):
         )
 
     def serialize(
-        self, value: tuple[K, V], display: bool = False
+        self,
+        value: tuple[K, V],
+        display: bool = False,
     ) -> str | DeprecatedValue:
         serialized_first_value = self._subtypes[0].serialize(value[0], display=display)
         serialized_second_value = self._subtypes[1].serialize(value[1], display=display)
 
         if isinstance(serialized_first_value, DeprecatedValue) or isinstance(
-            serialized_second_value, DeprecatedValue
+            serialized_second_value,
+            DeprecatedValue,
         ):
             return DeprecatedValue()
 
@@ -370,7 +373,9 @@ class List(ConfigValue[tuple[V, ...] | frozenset[V]]):
         return cast(tuple[V, ...] | frozenset[V], values)
 
     def serialize(
-        self, value: tuple[V, ...] | frozenset[V], display: bool = False
+        self,
+        value: tuple[V, ...] | frozenset[V],
+        display: bool = False,
     ) -> str:
         if not value:
             return ""
@@ -463,7 +468,10 @@ class Port(Integer):
 
     def __init__(self, choices=None, optional=False):
         super().__init__(
-            minimum=0, maximum=2**16 - 1, choices=choices, optional=optional
+            minimum=0,
+            maximum=2**16 - 1,
+            choices=choices,
+            optional=optional,
         )
 
 

--- a/src/mopidy/config/validators.py
+++ b/src/mopidy/config/validators.py
@@ -24,7 +24,8 @@ def validate_required(value: Any, required: bool) -> None:
     the raw string, _not_ the converted value.
     """
     if required and not value:
-        raise ValueError("must be set.")
+        msg = "must be set."
+        raise ValueError(msg)
 
 
 def validate_choice(value: T, choices: Iterable[T] | None) -> None:
@@ -34,7 +35,8 @@ def validate_choice(value: T, choices: Iterable[T] | None) -> None:
     """
     if choices is not None and value not in choices:
         names = ", ".join(repr(c) for c in choices)
-        raise ValueError(f"must be one of {names}, not {value}.")
+        msg = f"must be one of {names}, not {value}."
+        raise ValueError(msg)
 
 
 def validate_minimum(value: CT, minimum: CT | None) -> None:
@@ -43,7 +45,8 @@ def validate_minimum(value: CT, minimum: CT | None) -> None:
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
     """
     if minimum is not None and value < minimum:
-        raise ValueError(f"{value!r} must be larger than {minimum!r}.")
+        msg = f"{value!r} must be larger than {minimum!r}."
+        raise ValueError(msg)
 
 
 def validate_maximum(value: CT, maximum: CT | None) -> None:
@@ -52,4 +55,5 @@ def validate_maximum(value: CT, maximum: CT | None) -> None:
     Normally called in :meth:`~mopidy.config.types.ConfigValue.deserialize`.
     """
     if maximum is not None and value > maximum:
-        raise ValueError(f"{value!r} must be smaller than {maximum!r}.")
+        msg = f"{value!r} must be smaller than {maximum!r}."
+        raise ValueError(msg)

--- a/src/mopidy/core/actor.py
+++ b/src/mopidy/core/actor.py
@@ -76,15 +76,15 @@ class Core(
         self.backends = Backends(backends or [])
 
         self.library = pykka.traversable(
-            LibraryController(backends=self.backends, core=self)
+            LibraryController(backends=self.backends, core=self),
         )
         self.history = pykka.traversable(HistoryController())
         self.mixer = pykka.traversable(MixerController(mixer=mixer))
         self.playback = pykka.traversable(
-            PlaybackController(audio=audio, backends=self.backends, core=self)
+            PlaybackController(audio=audio, backends=self.backends, core=self),
         )
         self.playlists = pykka.traversable(
-            PlaylistsController(backends=self.backends, core=self)
+            PlaylistsController(backends=self.backends, core=self),
         )
         self.tracklist = pykka.traversable(TracklistController(core=self))
 
@@ -288,7 +288,7 @@ class Backends(list):
                 if scheme in backends_by_scheme:
                     raise AssertionError(
                         f"Cannot add URI scheme {scheme!r} for {name(b)}, "
-                        f"it is already handled by {name(backends_by_scheme[scheme])}"
+                        f"it is already handled by {name(backends_by_scheme[scheme])}",
                     )
                 backends_by_scheme[scheme] = b
 

--- a/src/mopidy/core/actor.py
+++ b/src/mopidy/core/actor.py
@@ -286,10 +286,11 @@ class Backends(list):
 
             for scheme in b.uri_schemes.get():
                 if scheme in backends_by_scheme:
-                    raise AssertionError(
+                    msg = (
                         f"Cannot add URI scheme {scheme!r} for {name(b)}, "
-                        f"it is already handled by {name(backends_by_scheme[scheme])}",
+                        f"it is already handled by {name(backends_by_scheme[scheme])}"
                     )
+                    raise AssertionError(msg)
                 backends_by_scheme[scheme] = b
 
                 if has_library:

--- a/src/mopidy/core/actor.py
+++ b/src/mopidy/core/actor.py
@@ -181,7 +181,7 @@ class Core(
                 ]
             if len(coverage):
                 self._load_state(coverage)
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("Restore state: Unexpected error: %s", str(e))
 
     def _teardown(self) -> None:
@@ -193,7 +193,7 @@ class Core(
                 and self._config["core"]["restore_state"]
             ):
                 self._save_state()
-        except Exception as e:
+        except Exception as e:  # noqa: BLE001
             logger.warning("Unexpected error while saving state: %s", str(e))
 
     def _get_data_dir(self) -> Path:

--- a/src/mopidy/core/actor.py
+++ b/src/mopidy/core/actor.py
@@ -116,7 +116,7 @@ class Core(
         new_state: PlaybackState,
         target_state: PlaybackState | None,
     ) -> None:
-        # XXX: This is a temporary fix for issue #232 while we wait for a more
+        # NOTE: This is a temporary fix for issue #232 while we wait for a more
         # permanent solution with the implementation of issue #234. When the
         # Spotify play token is lost, the Spotify backend pauses audio
         # playback, but mopidy.core doesn't know this, so we need to update

--- a/src/mopidy/core/history.py
+++ b/src/mopidy/core/history.py
@@ -31,7 +31,8 @@ class HistoryController:
         :param track: track to add
         """
         if not isinstance(track, Track):
-            raise TypeError("Only Track objects can be added to the history")
+            msg = "Only Track objects can be added to the history"
+            raise TypeError(msg)
 
         timestamp = int(time.time() * 1000)
 

--- a/src/mopidy/core/library.py
+++ b/src/mopidy/core/library.py
@@ -243,7 +243,7 @@ class LibraryController:
                 if result is not None:
                     validation.check_instance(result, Mapping)
                     for uri, tracks in result.items():
-                        # TODO Consider making Track.uri field mandatory, and
+                        # TODO: Consider making Track.uri field mandatory, and
                         # then remove this filtering of tracks without URIs.
                         validation.check_instances(tracks, Track)
                         results[uri] = [track for track in tracks if track.uri]

--- a/src/mopidy/core/library.py
+++ b/src/mopidy/core/library.py
@@ -213,9 +213,8 @@ class LibraryController:
                 validation.check_instance(future.get(), Mapping)
                 for uri, images in future.get().items():
                     if uri not in uris:
-                        raise exceptions.ValidationError(
-                            f"Got unknown image URI: {uri}",
-                        )
+                        msg = f"Got unknown image URI: {uri}"
+                        raise exceptions.ValidationError(msg)
                     validation.check_instances(images, Image)
                     results[uri] += tuple(images)
         return results

--- a/src/mopidy/core/library.py
+++ b/src/mopidy/core/library.py
@@ -214,7 +214,7 @@ class LibraryController:
                 for uri, images in future.get().items():
                     if uri not in uris:
                         raise exceptions.ValidationError(
-                            f"Got unknown image URI: {uri}"
+                            f"Got unknown image URI: {uri}",
                         )
                     validation.check_instances(images, Image)
                     results[uri] += tuple(images)
@@ -324,7 +324,9 @@ class LibraryController:
         futures = {}
         for backend, backend_uris in self._get_backends_to_uris(uris).items():
             futures[backend] = backend.library.search(
-                query=query, uris=backend_uris, exact=exact
+                query=query,
+                uris=backend_uris,
+                exact=exact,
             )
 
         # Some of our tests check for LookupError to catch bad queries. This is
@@ -369,7 +371,7 @@ def _normalize_query(query: Query[SearchField]) -> Query[SearchField]:
         logger.warning(
             "A client or frontend made a library search with an empty query. "
             "This is strongly discouraged. Please check what sent this query "
-            "and file a bug."
+            "and file a bug.",
         )
     return query
 

--- a/src/mopidy/core/playback.py
+++ b/src/mopidy/core/playback.py
@@ -384,7 +384,8 @@ class PlaybackController:
             self._pending_tl_track = None
             return True
 
-        raise CoreError(f"Unknown playback state: {state}")
+        msg = f"Unknown playback state: {state}"
+        raise CoreError(msg)
 
     def previous(self) -> None:
         """Change to the previous track.

--- a/src/mopidy/core/playback.py
+++ b/src/mopidy/core/playback.py
@@ -270,7 +270,7 @@ class PlaybackController:
                 logger.info("No playable track in the list.")
                 break
 
-        # TODO return result?
+        # TODO: return result?
 
     def pause(self) -> None:
         """Pause playback."""

--- a/src/mopidy/core/playback.py
+++ b/src/mopidy/core/playback.py
@@ -191,7 +191,7 @@ class PlaybackController:
                 attr_path=("playback", "_on_about_to_finish"),
                 args=(),
                 kwargs={},
-            )
+            ),
         )
 
     def _on_about_to_finish(self) -> None:
@@ -540,7 +540,9 @@ class PlaybackController:
     ) -> None:
         logger.debug("Triggering playback state change event")
         listener.CoreListener.send(
-            "playback_state_changed", old_state=old_state, new_state=new_state
+            "playback_state_changed",
+            old_state=old_state,
+            new_state=new_state,
         )
 
     def _trigger_seeked(self, time_position: int) -> None:

--- a/src/mopidy/core/tracklist.py
+++ b/src/mopidy/core/tracklist.py
@@ -370,7 +370,8 @@ class TracklistController:
             The ``tracks`` argument. Use ``uris``.
         """
         if sum(o is not None for o in [tracks, uris]) != 1:
-            raise ValueError('Exactly one of "tracks" or "uris" must be set')
+            msg = 'Exactly one of "tracks" or "uris" must be set'
+            raise ValueError(msg)
 
         if tracks is not None:
             validation.check_instances(tracks, Track)
@@ -393,9 +394,8 @@ class TracklistController:
 
         for track in tracks:
             if self.get_length() >= max_length:
-                raise exceptions.TracklistFull(
-                    f"Tracklist may contain at most {max_length:d} tracks.",
-                )
+                msg = f"Tracklist may contain at most {max_length:d} tracks."
+                raise exceptions.TracklistFull(msg)
 
             tl_track = TlTrack(self._next_tlid, track)
             self._next_tlid += 1
@@ -469,15 +469,20 @@ class TracklistController:
 
         # TODO: use validation helpers?
         if start >= end:
-            raise AssertionError("start must be smaller than end")
+            msg = "start must be smaller than end"
+            raise AssertionError(msg)
         if start < 0:
-            raise AssertionError("start must be at least zero")
+            msg = "start must be at least zero"
+            raise AssertionError(msg)
         if end > len(tl_tracks):
-            raise AssertionError("end can not be larger than tracklist length")
+            msg = "end can not be larger than tracklist length"
+            raise AssertionError(msg)
         if to_position < 0:
-            raise AssertionError("to_position must be at least zero")
+            msg = "to_position must be at least zero"
+            raise AssertionError(msg)
         if to_position > len(tl_tracks):
-            raise AssertionError("to_position can not be larger than tracklist length")
+            msg = "to_position can not be larger than tracklist length"
+            raise AssertionError(msg)
 
         new_tl_tracks = tl_tracks[:start] + tl_tracks[end:]
         for tl_track in tl_tracks[start:end]:
@@ -517,13 +522,16 @@ class TracklistController:
 
         # TOOD: use validation helpers?
         if start is not None and end is not None and start >= end:
-            raise AssertionError("start must be smaller than end")
+            msg = "start must be smaller than end"
+            raise AssertionError(msg)
 
         if start is not None and start < 0:
-            raise AssertionError("start must be at least zero")
+            msg = "start must be at least zero"
+            raise AssertionError(msg)
 
         if end is not None and end > len(tl_tracks):
-            raise AssertionError("end can not be larger than tracklist length")
+            msg = "end can not be larger than tracklist length"
+            raise AssertionError(msg)
 
         before = tl_tracks[: start or 0]
         shuffled = tl_tracks[start:end]

--- a/src/mopidy/core/tracklist.py
+++ b/src/mopidy/core/tracklist.py
@@ -394,7 +394,7 @@ class TracklistController:
         for track in tracks:
             if self.get_length() >= max_length:
                 raise exceptions.TracklistFull(
-                    f"Tracklist may contain at most {max_length:d} tracks."
+                    f"Tracklist may contain at most {max_length:d} tracks.",
                 )
 
             tl_track = TlTrack(self._next_tlid, track)

--- a/src/mopidy/ext.py
+++ b/src/mopidy/ext.py
@@ -59,7 +59,8 @@ class Extension:
 
         :returns: str
         """
-        raise NotImplementedError('Add at least a config section with "enabled = true"')
+        msg = 'Add at least a config section with "enabled = true"'
+        raise NotImplementedError(msg)
 
     def get_config_schema(self) -> ConfigSchema:
         """The extension's config validation schema.
@@ -74,7 +75,8 @@ class Extension:
     def check_attr(cls) -> None:
         """Check if ext_name exist."""
         if not hasattr(cls, "ext_name") or cls.ext_name is None:
-            raise AttributeError(f"{cls} not an extension or ext_name missing!")
+            msg = f"{cls} not an extension or ext_name missing!"
+            raise AttributeError(msg)
 
     @classmethod
     def get_cache_dir(cls, config: Config) -> Path:

--- a/src/mopidy/file/library.py
+++ b/src/mopidy/file/library.py
@@ -102,7 +102,8 @@ class FileLibraryProvider(backend.LibraryProvider):
         try:
             result = self._scanner.scan(uri)
             track = tags.convert_tags_to_track(result.tags).replace(
-                uri=uri, length=result.duration
+                uri=uri,
+                length=result.duration,
             )
         except exceptions.ScannerError as e:
             logger.warning("Failed looking up %s: %s", uri, e)
@@ -152,7 +153,8 @@ class FileLibraryProvider(backend.LibraryProvider):
     def _get_media_dirs_refs(self) -> Generator[Ref, Any, None]:
         for media_dir in self._media_dirs:
             yield Ref.directory(
-                name=media_dir["name"], uri=path.path_to_uri(media_dir["path"])
+                name=media_dir["name"],
+                uri=path.path_to_uri(media_dir["path"]),
             )
 
     def _is_in_basedir(self, local_path) -> bool:

--- a/src/mopidy/file/library.py
+++ b/src/mopidy/file/library.py
@@ -145,7 +145,7 @@ class FileLibraryProvider(backend.LibraryProvider):
             if len(media_dir_split) == 2:
                 name = media_dir_split[1]
             else:
-                # TODO Mpd client should accept / in dir name
+                # TODO: MPD client should accept `/` in dir name
                 name = media_dir_split[0].replace(os.sep, "+")
 
             yield MediaDir(path=local_path, name=name)

--- a/src/mopidy/http/__init__.py
+++ b/src/mopidy/http/__init__.py
@@ -36,7 +36,8 @@ class Extension(ext.Extension):
         try:
             import tornado.web  # noqa: F401 (Imported to test if available)
         except ImportError as exc:
-            raise exceptions.ExtensionError("tornado library not found") from exc
+            msg = "tornado library not found"
+            raise exceptions.ExtensionError(msg) from exc
 
     def setup(self, registry: ext.Registry) -> None:
         from .actor import HttpFrontend

--- a/src/mopidy/http/actor.py
+++ b/src/mopidy/http/actor.py
@@ -98,7 +98,7 @@ def on_event(name: str, io_loop: tornado.ioloop.IOLoop, **data: Any) -> None:
 class HttpServer(threading.Thread):
     name = "HttpServer"
 
-    def __init__(  # noqa: PLR0913
+    def __init__(
         self,
         config: Config,
         core: CoreProxy,

--- a/src/mopidy/http/actor.py
+++ b/src/mopidy/http/actor.py
@@ -65,7 +65,9 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
 
         if self.zeroconf_name:
             self.zeroconf_http = zeroconf.Zeroconf(
-                name=self.zeroconf_name, stype="_http._tcp", port=self.port
+                name=self.zeroconf_name,
+                stype="_http._tcp",
+                port=self.port,
             )
             self.zeroconf_mopidy_http = zeroconf.Zeroconf(
                 name=self.zeroconf_name,
@@ -151,7 +153,7 @@ class HttpServer(threading.Thread):
             formatting.indent(
                 "\n".join(
                     f"{path!r}: {handler!r}" for (path, handler, *_) in request_handlers
-                )
+                ),
             ),
         )
 
@@ -183,7 +185,7 @@ class HttpServer(threading.Thread):
                     f"/{static['name']}/(.*)",
                     handlers.StaticFileHandler,
                     {"path": static["path"], "default_filename": "index.html"},
-                )
+                ),
             )
             logger.debug("Loaded static HTTP extension: %s", static["name"])
         return result
@@ -202,7 +204,7 @@ class HttpServer(threading.Thread):
                 r"/",
                 tornado.web.RedirectHandler,
                 {"url": f"/{default_app}/", "permanent": False},
-            )
+            ),
         ]
 
     def _get_cookie_secret(self) -> str:
@@ -214,6 +216,6 @@ class HttpServer(threading.Thread):
             cookie_secret = file_path.read_text().strip()
             if not cookie_secret:
                 logging.error(
-                    f"HTTP server could not find cookie secret in {file_path}"
+                    f"HTTP server could not find cookie secret in {file_path}",
                 )
         return cookie_secret

--- a/src/mopidy/http/actor.py
+++ b/src/mopidy/http/actor.py
@@ -53,7 +53,8 @@ class HttpFrontend(pykka.ThreadingActor, CoreListener):
                 statics=self.statics,
             )
         except OSError as exc:
-            raise exceptions.FrontendError("HTTP server startup failed.") from exc
+            msg = "HTTP server startup failed."
+            raise exceptions.FrontendError(msg) from exc
 
         self.zeroconf_name = config["http"]["zeroconf"]
         self.zeroconf_http = None

--- a/src/mopidy/http/handlers.py
+++ b/src/mopidy/http/handlers.py
@@ -126,7 +126,7 @@ def _send_broadcast(
 
 
 class WebSocketHandler(tornado.websocket.WebSocketHandler):
-    # XXX This set is shared by all WebSocketHandler objects. This isn't
+    # NOTE: This set is shared by all WebSocketHandler objects. This isn't
     # optimal, but there's currently no use case for having more than one of
     # these anyway.
     clients: ClassVar[set[WebSocketHandler]] = set()

--- a/src/mopidy/http/handlers.py
+++ b/src/mopidy/http/handlers.py
@@ -89,7 +89,7 @@ def make_jsonrpc_wrapper(core_actor: CoreProxy) -> jsonrpc.JsonRpcWrapper:
             "core.playback": core.PlaybackController,
             "core.playlists": core.PlaylistsController,
             "core.tracklist": core.TracklistController,
-        }
+        },
     )
     return jsonrpc.JsonRpcWrapper(
         objects={
@@ -120,7 +120,7 @@ def _send_broadcast(
     except Exception as exc:
         logger.debug(
             f"Broadcast of WebSocket message to "
-            f"{client.request.remote_ip} failed: {exc}"
+            f"{client.request.remote_ip} failed: {exc}",
         )
         # TODO: should this do the same cleanup as the on_message code?
 

--- a/src/mopidy/http/handlers.py
+++ b/src/mopidy/http/handlers.py
@@ -117,7 +117,7 @@ def _send_broadcast(
     # to succeed, so catch everything.
     try:
         client.write_message(msg)
-    except Exception as exc:
+    except Exception as exc:  # noqa: BLE001
         logger.debug(
             f"Broadcast of WebSocket message to "
             f"{client.request.remote_ip} failed: {exc}",
@@ -180,7 +180,7 @@ class WebSocketHandler(tornado.websocket.WebSocketHandler):
                     self.request.remote_ip,
                     response,
                 )
-        except Exception as exc:
+        except Exception as exc:  # noqa: BLE001
             logger.error(f"WebSocket request error: {exc}")
             self.close()
 
@@ -265,8 +265,8 @@ class JsonRpcHandler(tornado.web.RequestHandler):
                     self.request.remote_ip,
                     response,
                 )
-        except Exception as e:
-            logger.error("HTTP JSON-RPC request error: %s", e)
+        except Exception as exc:  # noqa: BLE001
+            logger.error("HTTP JSON-RPC request error: %s", exc)
             self.write_error(500)
 
     def set_extra_headers(self) -> None:

--- a/src/mopidy/internal/deps.py
+++ b/src/mopidy/internal/deps.py
@@ -116,7 +116,7 @@ def pkg_info(
                             pkg_name=name,
                             depth=depth + 1,
                             seen_pkgs=seen_pkgs,
-                        )
+                        ),
                     )
         return DepInfo(
             name=pkg_name,

--- a/src/mopidy/internal/deps.py
+++ b/src/mopidy/internal/deps.py
@@ -144,13 +144,11 @@ def gstreamer_info() -> DepInfo:
 
     other.append("Relevant elements:")
     other.append("  Found:")
-    for element in found_elements:
-        other.append(f"    {element}")
+    other.extend(f"    {element}" for element in found_elements)
     if not found_elements:
         other.append("    none")
     other.append("  Not found:")
-    for element in missing_elements:
-        other.append(f"    {element}")
+    other.extend(f"    {element}" for element in missing_elements)
     if not missing_elements:
         other.append("    none")
 

--- a/src/mopidy/internal/deps.py
+++ b/src/mopidy/internal/deps.py
@@ -121,7 +121,7 @@ def pkg_info(
         return DepInfo(
             name=pkg_name,
             version=distribution.version,
-            path=distribution.locate_file("."),
+            path=distribution.locate_file("."),  # pyright: ignore[reportArgumentType]
             dependencies=dependencies,
         )
     except metadata.PackageNotFoundError:

--- a/src/mopidy/internal/gi.py
+++ b/src/mopidy/internal/gi.py
@@ -20,8 +20,8 @@ except ValueError:
 
         Please see https://docs.mopidy.com/en/latest/installation/ for
         instructions on how to install the required dependencies.
-    """
-        )
+    """,
+        ),
     )
     raise
 
@@ -37,7 +37,7 @@ REQUIRED_GST_VERSION_DISPLAY = ".".join(map(str, REQUIRED_GST_VERSION))
 if Gst.version() < REQUIRED_GST_VERSION:
     sys.exit(
         f"ERROR: Mopidy requires GStreamer >= {REQUIRED_GST_VERSION_DISPLAY}, "
-        f"but found {Gst.version_string()}."
+        f"but found {Gst.version_string()}.",
     )
 
 

--- a/src/mopidy/internal/jsonrpc.py
+++ b/src/mopidy/internal/jsonrpc.py
@@ -108,7 +108,8 @@ class JsonRpcWrapper:
         encoders: list[type[json.JSONEncoder]] | None = None,
     ):
         if "" in objects:
-            raise AttributeError("The empty string is not allowed as an object mount")
+            msg = "The empty string is not allowed as an object mount"
+            raise AttributeError(msg)
         self.objects = objects
         self.decoder = get_combined_json_decoder(decoders or [])
         self.encoder = get_combined_json_encoder(encoders or [])
@@ -371,7 +372,8 @@ class JsonRpcInspector:
 
     def __init__(self, objects: dict[str, Callable[..., Any]]) -> None:
         if "" in objects:
-            raise AttributeError("The empty string is not allowed as an object mount")
+            msg = "The empty string is not allowed as an object mount"
+            raise AttributeError(msg)
         self.objects = objects
 
     def describe(self) -> dict[str, Any]:

--- a/src/mopidy/internal/jsonrpc.py
+++ b/src/mopidy/internal/jsonrpc.py
@@ -158,7 +158,7 @@ class JsonRpcWrapper:
     ) -> JsonRpcErrorResponse | list[JsonRpcResponse] | None:
         if not requests:
             return JsonRpcInvalidRequestError(
-                data="Batch list cannot be empty"
+                data="Batch list cannot be empty",
             ).get_response()
 
         responses: list[JsonRpcResponse] = []
@@ -198,7 +198,7 @@ class JsonRpcWrapper:
                         "type": exc.__class__.__name__,
                         "message": str(exc),
                         "traceback": traceback.format_exc(),
-                    }
+                    },
                 ) from exc
             except Exception as exc:
                 raise JsonRpcApplicationError(
@@ -206,7 +206,7 @@ class JsonRpcWrapper:
                         "type": exc.__class__.__name__,
                         "message": str(exc),
                         "traceback": traceback.format_exc(),
-                    }
+                    },
                 ) from exc
         except JsonRpcError as exc:
             if "id" not in request or request["id"] is None:
@@ -235,7 +235,7 @@ class JsonRpcWrapper:
         if isinstance(params, dict):  # pyright: ignore[reportUnnecessaryIsInstance]
             return [], params
         raise JsonRpcInvalidRequestError(
-            data="'params', if given, must be an array or an object"
+            data="'params', if given, must be an array or an object",
         )
 
     def _get_method(self, method_path: str) -> Callable[..., Any]:
@@ -247,7 +247,7 @@ class JsonRpcWrapper:
 
         if "." not in method_path:
             raise JsonRpcMethodNotFoundError(
-                data=f"Could not find object mount in method name {method_path!r}"
+                data=f"Could not find object mount in method name {method_path!r}",
             )
 
         mount, method_name = method_path.rsplit(".", 1)
@@ -259,14 +259,14 @@ class JsonRpcWrapper:
             obj = self.objects[mount]
         except KeyError as exc:
             raise JsonRpcMethodNotFoundError(
-                data=f"No object found at {mount!r}"
+                data=f"No object found at {mount!r}",
             ) from exc
 
         try:
             return getattr(obj, method_name)
         except AttributeError as exc:
             raise JsonRpcMethodNotFoundError(
-                data=f"Object mounted at {mount!r} has no member {method_name!r}"
+                data=f"Object mounted at {mount!r} has no member {method_name!r}",
             ) from exc
 
     def _unwrap_result(self, result: pykka.Future[T] | T) -> T:

--- a/src/mopidy/internal/log.py
+++ b/src/mopidy/internal/log.py
@@ -87,9 +87,9 @@ def setup_logging(
         path = config["logging"]["config_file"]
         try:
             logging.config.fileConfig(path, disable_existing_loggers=False)
-        except Exception as e:
+        except Exception as exc:  # noqa: BLE001
             # Catch everything as logging does not specify what can go wrong.
-            logger.error("Loading logging config %r failed. %s", path, e)
+            logger.error("Loading logging config %r failed. %s", path, exc)
 
     loglevels = config.get("loglevels", {})
 
@@ -206,7 +206,7 @@ class ColorizingStreamHandler(logging.StreamHandler):
             self.stream.write(message)
             self.stream.write(getattr(self, "terminator", "\n"))
             self.flush()
-        except Exception:
+        except Exception:  # noqa: BLE001
             self.handleError(record)
 
     def format(self, record: LogRecord) -> str:

--- a/src/mopidy/internal/log.py
+++ b/src/mopidy/internal/log.py
@@ -123,10 +123,8 @@ def get_verbosity_level(
     else:
         result = base_verbosity_level + (logging_config["verbosity"] or 0)
 
-    if result < min(LOG_LEVELS.keys()):
-        result = min(LOG_LEVELS.keys())
-    if result > max(LOG_LEVELS.keys()):
-        result = max(LOG_LEVELS.keys())
+    result = max(result, min(LOG_LEVELS.keys()))
+    result = min(result, max(LOG_LEVELS.keys()))
 
     return result
 

--- a/src/mopidy/internal/log.py
+++ b/src/mopidy/internal/log.py
@@ -94,7 +94,9 @@ def setup_logging(
     loglevels = config.get("loglevels", {})
 
     verbosity_level = get_verbosity_level(
-        config["logging"], base_verbosity_level, args_verbosity_level
+        config["logging"],
+        base_verbosity_level,
+        args_verbosity_level,
     )
     verbosity_filter = VerbosityFilter(verbosity_level, loglevels)
 

--- a/src/mopidy/internal/network.py
+++ b/src/mopidy/internal/network.py
@@ -13,7 +13,7 @@ def try_ipv6_socket() -> bool:
         socket.socket(socket.AF_INET6).close()
     except OSError as exc:
         logger.debug(
-            f"Platform supports IPv6, but socket creation failed, disabling: {exc}"
+            f"Platform supports IPv6, but socket creation failed, disabling: {exc}",
         )
         return False
     else:

--- a/src/mopidy/internal/path.py
+++ b/src/mopidy/internal/path.py
@@ -19,7 +19,7 @@ def get_or_create_dir(dir_path: str | PathLike[str]) -> pathlib.Path:
     if dir_path.is_file():
         raise OSError(
             f"A file with the same name as the desired dir, "
-            f"{dir_path!r}, already exists."
+            f"{dir_path!r}, already exists.",
         )
     if not dir_path.is_dir():
         logger.info(f"Creating dir {dir_path.as_uri()}")

--- a/src/mopidy/internal/path.py
+++ b/src/mopidy/internal/path.py
@@ -17,10 +17,11 @@ XDG_DIRS = xdg.get_dirs()
 def get_or_create_dir(dir_path: str | PathLike[str]) -> pathlib.Path:
     dir_path = expand_path(dir_path)
     if dir_path.is_file():
-        raise OSError(
+        msg = (
             f"A file with the same name as the desired dir, "
-            f"{dir_path!r}, already exists.",
+            f"{dir_path!r}, already exists."
         )
+        raise OSError(msg)
     if not dir_path.is_dir():
         logger.info(f"Creating dir {dir_path.as_uri()}")
         dir_path.mkdir(mode=0o755, parents=True)
@@ -86,7 +87,8 @@ def expand_path(path: bytes | str | PathLike[str]) -> pathlib.Path:
     for xdg_var, xdg_dir in XDG_DIRS.items():
         path = path.replace("$" + xdg_var, str(xdg_dir))
     if "$" in path:
-        raise ValueError(f"Unexpanded '$...' in path {path!r}")
+        msg = f"Unexpanded '$...' in path {path!r}"
+        raise ValueError(msg)
 
     return pathlib.Path(path).expanduser().resolve()
 

--- a/src/mopidy/internal/playlists.py
+++ b/src/mopidy/internal/playlists.py
@@ -1,6 +1,6 @@
 import configparser
 import io
-from xml.etree import ElementTree
+from xml.etree import ElementTree as ET
 
 from mopidy.internal import validation
 
@@ -33,9 +33,9 @@ def detect_xspf_header(data):
 
     try:
         data = io.BytesIO(data)
-        for _event, element in ElementTree.iterparse(data, events=["start"]):
+        for _event, element in ET.iterparse(data, events=["start"]):
             return element.tag.lower() == "{http://xspf.org/ns/0/}playlist"
-    except ElementTree.ParseError:
+    except ET.ParseError:
         pass
     return False
 
@@ -47,9 +47,9 @@ def detect_asx_header(data):
 
     try:
         data = io.BytesIO(data)
-        for _event, element in ElementTree.iterparse(data, events=["start"]):
+        for _event, element in ET.iterparse(data, events=["start"]):
             return element.tag.lower() == "asx"
-    except ElementTree.ParseError:
+    except ET.ParseError:
         pass
     return False
 
@@ -93,9 +93,9 @@ def parse_xspf(data):
     element = None
     try:
         # Last element will be root.
-        for _event, element in ElementTree.iterparse(io.BytesIO(data)):
+        for _event, element in ET.iterparse(io.BytesIO(data)):
             element.tag = element.tag.lower()  # normalize
-    except ElementTree.ParseError:
+    except ET.ParseError:
         return
     if element is None:
         return
@@ -110,9 +110,9 @@ def parse_asx(data):
     element = None
     try:
         # Last element will be root.
-        for _event, element in ElementTree.iterparse(io.BytesIO(data)):
+        for _event, element in ET.iterparse(io.BytesIO(data)):
             element.tag = element.tag.lower()  # normalize
-    except ElementTree.ParseError:
+    except ET.ParseError:
         return
     if element is None:
         return

--- a/src/mopidy/internal/storage.py
+++ b/src/mopidy/internal/storage.py
@@ -43,13 +43,18 @@ def dump(path, data):
 
     # TODO: cleanup directory/basename.* files.
     tmp = tempfile.NamedTemporaryFile(
-        prefix=path.name + ".", dir=str(path.parent), delete=False
+        prefix=path.name + ".",
+        dir=str(path.parent),
+        delete=False,
     )
     tmp_path = pathlib.Path(tmp.name)
 
     try:
         data_string = json.dumps(
-            data, cls=models.ModelJSONEncoder, indent=2, separators=(",", ": ")
+            data,
+            cls=models.ModelJSONEncoder,
+            indent=2,
+            separators=(",", ": "),
         )
         with gzip.GzipFile(fileobj=tmp, mode="wb") as fp:
             fp.write(data_string.encode())

--- a/src/mopidy/internal/validation.py
+++ b/src/mopidy/internal/validation.py
@@ -37,7 +37,7 @@ PLAYBACK_STATES: set[str] = {ps.value for ps in PlaybackState}
 FIELD_TYPES: dict[str, type] = {
     "album": str,
     "albumartist": str,
-    "any": int | str,
+    "any": int | str,  # pyright: ignore[reportAssignmentType]
     "artist": str,
     "comment": str,
     "composer": str,

--- a/src/mopidy/internal/validation.py
+++ b/src/mopidy/internal/validation.py
@@ -27,7 +27,8 @@ def get_literals(literal_type: Any) -> set[str]:
     if hasattr(literal_type, "__origin__") and literal_type.__origin__ is Literal:
         return set(get_args(literal_type))
 
-    raise ValueError("Provided type is neither a Union nor a Literal type.")
+    msg = "Provided type is neither a Union nor a Literal type."
+    raise ValueError(msg)
 
 
 T = TypeVar("T")
@@ -120,15 +121,14 @@ def check_integer(
     max: int | None = None,
 ) -> None:
     if not isinstance(arg, int):
-        raise exceptions.ValidationError(f"Expected an integer, not {arg!r}")
+        msg = f"Expected an integer, not {arg!r}"
+        raise exceptions.ValidationError(msg)
     if min is not None and arg < min:
-        raise exceptions.ValidationError(
-            f"Expected number larger or equal to {min}, not {arg!r}",
-        )
+        msg = f"Expected number larger or equal to {min}, not {arg!r}"
+        raise exceptions.ValidationError(msg)
     if max is not None and arg > max:
-        raise exceptions.ValidationError(
-            f"Expected number smaller or equal to {max}, not {arg!r}",
-        )
+        msg = f"Expected number smaller or equal to {max}, not {arg!r}"
+        raise exceptions.ValidationError(msg)
 
 
 def check_query(
@@ -142,7 +142,8 @@ def check_query(
     # TODO: normalize blank -> [] or just remove field?
 
     if not isinstance(arg, Mapping):
-        raise exceptions.ValidationError(f"Expected a query dictionary, not {arg!r}")
+        msg = f"Expected a query dictionary, not {arg!r}"
+        raise exceptions.ValidationError(msg)
 
     for key, value in arg.items():
         check_choice(

--- a/src/mopidy/internal/validation.py
+++ b/src/mopidy/internal/validation.py
@@ -123,11 +123,11 @@ def check_integer(
         raise exceptions.ValidationError(f"Expected an integer, not {arg!r}")
     if min is not None and arg < min:
         raise exceptions.ValidationError(
-            f"Expected number larger or equal to {min}, not {arg!r}"
+            f"Expected number larger or equal to {min}, not {arg!r}",
         )
     if max is not None and arg > max:
         raise exceptions.ValidationError(
-            f"Expected number smaller or equal to {max}, not {arg!r}"
+            f"Expected number smaller or equal to {max}, not {arg!r}",
         )
 
 

--- a/src/mopidy/internal/xdg.py
+++ b/src/mopidy/internal/xdg.py
@@ -18,13 +18,13 @@ def get_dirs() -> dict[str, pathlib.Path]:
 
     dirs = {
         "XDG_CACHE_DIR": pathlib.Path(
-            os.getenv("XDG_CACHE_HOME", "~/.cache")
+            os.getenv("XDG_CACHE_HOME", "~/.cache"),
         ).expanduser(),
         "XDG_CONFIG_DIR": pathlib.Path(
-            os.getenv("XDG_CONFIG_HOME", "~/.config")
+            os.getenv("XDG_CONFIG_HOME", "~/.config"),
         ).expanduser(),
         "XDG_DATA_DIR": pathlib.Path(
-            os.getenv("XDG_DATA_HOME", "~/.local/share")
+            os.getenv("XDG_DATA_HOME", "~/.local/share"),
         ).expanduser(),
     }
 

--- a/src/mopidy/listener.py
+++ b/src/mopidy/listener.py
@@ -24,7 +24,7 @@ def send(cls, event, **kwargs):
                 attr_path=("on_event",),
                 args=(event,),
                 kwargs=kwargs,
-            )
+            ),
         )
 
 
@@ -44,5 +44,7 @@ class Listener:
         except Exception:
             # Ensure we don't crash the actor due to "bad" events.
             logger.exception(
-                "Triggering event failed: %s(%s)", event, ", ".join(kwargs)
+                "Triggering event failed: %s(%s)",
+                event,
+                ", ".join(kwargs),
             )

--- a/src/mopidy/m3u/playlists.py
+++ b/src/mopidy/m3u/playlists.py
@@ -184,9 +184,8 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         if not path.is_absolute():
             path = self._abspath(path)
         if not self._is_in_basedir(path):
-            raise BackendError(
-                f"Path {path!r} is not inside playlist dir {self._playlists_dir!r}",
-            )
+            msg = f"Path {path!r} is not inside playlist dir {self._playlists_dir!r}"
+            raise BackendError(msg)
         if "w" in mode:
             return replace(path, mode, encoding=encoding, errors="replace")
         return path.open(mode, encoding=encoding, errors="replace")

--- a/src/mopidy/m3u/playlists.py
+++ b/src/mopidy/m3u/playlists.py
@@ -176,14 +176,16 @@ class M3UPlaylistsProvider(backend.PlaylistsProvider):
         return path.is_path_inside_base_dir(local_path, self._playlists_dir)
 
     def _open(
-        self, path: Path, mode: str = "r"
+        self,
+        path: Path,
+        mode: str = "r",
     ) -> contextlib._GeneratorContextManager[IO[Any]] | IO[Any]:
         encoding = "utf-8" if path.suffix == ".m3u8" else self._default_encoding
         if not path.is_absolute():
             path = self._abspath(path)
         if not self._is_in_basedir(path):
             raise BackendError(
-                f"Path {path!r} is not inside playlist dir {self._playlists_dir!r}"
+                f"Path {path!r} is not inside playlist dir {self._playlists_dir!r}",
             )
         if "w" in mode:
             return replace(path, mode, encoding=encoding, errors="replace")

--- a/src/mopidy/models/fields.py
+++ b/src/mopidy/models/fields.py
@@ -55,11 +55,11 @@ class Field(Generic[T]):
         """Validate and possibly modify the field value before assignment."""
         if self._type and not isinstance(value, self._type):
             raise TypeError(
-                f"Expected {self._name} to be a {self._type}, not {value!r}"
+                f"Expected {self._name} to be a {self._type}, not {value!r}",
             )
         if self._choices and value not in self._choices:
             raise TypeError(
-                f"Expected {self._name} to be a one of {self._choices}, not {value!r}"
+                f"Expected {self._name} to be a one of {self._choices}, not {value!r}",
             )
         return value
 
@@ -165,11 +165,11 @@ class Integer(Field[int]):
         value = super().validate(value)
         if self._min is not None and value < self._min:
             raise ValueError(
-                f"Expected {self._name} to be at least {self._min}, not {value:d}"
+                f"Expected {self._name} to be at least {self._min}, not {value:d}",
             )
         if self._max is not None and value > self._max:
             raise ValueError(
-                f"Expected {self._name} to be at most {self._max}, not {value:d}"
+                f"Expected {self._name} to be at most {self._max}, not {value:d}",
             )
         return value
 
@@ -204,12 +204,12 @@ class Collection(Field[tuple[V, ...] | frozenset[V]]):
         if isinstance(value, str):
             raise TypeError(
                 f"Expected {self._name} to be a collection of "
-                f"{self._type.__name__}, not {value!r}"
+                f"{self._type.__name__}, not {value!r}",
             )
         for v in value:
             if not isinstance(v, self._type):
                 raise TypeError(
                     f"Expected {self._name} to be a collection of "
-                    f"{self._type.__name__}, not {value!r}"
+                    f"{self._type.__name__}, not {value!r}",
                 )
         return self._default.__class__(value)

--- a/src/mopidy/models/fields.py
+++ b/src/mopidy/models/fields.py
@@ -54,13 +54,11 @@ class Field(Generic[T]):
     def validate(self, value: T) -> T:
         """Validate and possibly modify the field value before assignment."""
         if self._type and not isinstance(value, self._type):
-            raise TypeError(
-                f"Expected {self._name} to be a {self._type}, not {value!r}",
-            )
+            msg = f"Expected {self._name} to be a {self._type}, not {value!r}"
+            raise TypeError(msg)
         if self._choices and value not in self._choices:
-            raise TypeError(
-                f"Expected {self._name} to be a one of {self._choices}, not {value!r}",
-            )
+            msg = f"Expected {self._name} to be a one of {self._choices}, not {value!r}"
+            raise TypeError(msg)
         return value
 
     @overload
@@ -164,13 +162,11 @@ class Integer(Field[int]):
     def validate(self, value: int) -> int:
         value = super().validate(value)
         if self._min is not None and value < self._min:
-            raise ValueError(
-                f"Expected {self._name} to be at least {self._min}, not {value:d}",
-            )
+            msg = f"Expected {self._name} to be at least {self._min}, not {value:d}"
+            raise ValueError(msg)
         if self._max is not None and value > self._max:
-            raise ValueError(
-                f"Expected {self._name} to be at most {self._max}, not {value:d}",
-            )
+            msg = f"Expected {self._name} to be at most {self._max}, not {value:d}"
+            raise ValueError(msg)
         return value
 
 
@@ -202,14 +198,16 @@ class Collection(Field[tuple[V, ...] | frozenset[V]]):
         assert self._default is not None
         assert self._type is not None
         if isinstance(value, str):
-            raise TypeError(
+            msg = (
                 f"Expected {self._name} to be a collection of "
-                f"{self._type.__name__}, not {value!r}",
+                f"{self._type.__name__}, not {value!r}"
             )
+            raise TypeError(msg)
         for v in value:
             if not isinstance(v, self._type):
-                raise TypeError(
+                msg = (
                     f"Expected {self._name} to be a collection of "
-                    f"{self._type.__name__}, not {value!r}",
+                    f"{self._type.__name__}, not {value!r}"
                 )
+                raise TypeError(msg)
         return self._default.__class__(value)

--- a/src/mopidy/models/immutable.py
+++ b/src/mopidy/models/immutable.py
@@ -34,22 +34,23 @@ class ImmutableObject:
     def __init__(self, *_args, **kwargs):
         for key, value in kwargs.items():
             if not self._is_valid_field(key):
-                raise TypeError(
-                    f"__init__() got an unexpected keyword argument {key!r}",
-                )
+                msg = f"__init__() got an unexpected keyword argument {key!r}"
+                raise TypeError(msg)
             self._set_field(key, value)
 
     def __setattr__(self, name, value):
         if name.startswith("_"):
             object.__setattr__(self, name, value)
         else:
-            raise AttributeError("Object is immutable.")
+            msg = "Object is immutable."
+            raise AttributeError(msg)
 
     def __delattr__(self, name):
         if name.startswith("_"):
             object.__delattr__(self, name)
         else:
-            raise AttributeError("Object is immutable.")
+            msg = "Object is immutable."
+            raise AttributeError(msg)
 
     def _is_valid_field(self, name):
         return hasattr(self, name) and not callable(getattr(self, name))
@@ -111,7 +112,8 @@ class ImmutableObject:
         other = copy.copy(self)
         for key, value in kwargs.items():
             if not self._is_valid_field(key):
-                raise TypeError(f"replace() got an unexpected keyword argument {key!r}")
+                msg = f"replace() got an unexpected keyword argument {key!r}"
+                raise TypeError(msg)
             other._set_field(key, value)
         return other
 

--- a/src/mopidy/models/immutable.py
+++ b/src/mopidy/models/immutable.py
@@ -35,7 +35,7 @@ class ImmutableObject:
         for key, value in kwargs.items():
             if not self._is_valid_field(key):
                 raise TypeError(
-                    f"__init__() got an unexpected keyword argument {key!r}"
+                    f"__init__() got an unexpected keyword argument {key!r}",
                 )
             self._set_field(key, value)
 
@@ -85,7 +85,9 @@ class ImmutableObject:
         return all(
             a == b
             for a, b in itertools.zip_longest(
-                self._items(), other._items(), fillvalue=object()
+                self._items(),
+                other._items(),
+                fillvalue=object(),
             )
         )
 
@@ -171,7 +173,8 @@ class _ValidatedImmutableObjectMeta(type, Generic[T]):
 
 
 class ValidatedImmutableObject(
-    ImmutableObject, metaclass=_ValidatedImmutableObjectMeta
+    ImmutableObject,
+    metaclass=_ValidatedImmutableObjectMeta,
 ):
     """Superclass for immutable objects whose fields can only be modified via the
     constructor. Fields should be :class:`Field` instances to ensure type

--- a/src/mopidy/models/immutable.py
+++ b/src/mopidy/models/immutable.py
@@ -143,7 +143,7 @@ class _ValidatedImmutableObjectMeta(type, Generic[T]):
         name: str,
         bases: tuple[type, ...],
         attrs: dict[str, Any],
-    ) -> _ValidatedImmutableObjectMeta:
+    ) -> _ValidatedImmutableObjectMeta:  # noqa: PYI019
         fields = {}
 
         for base in bases:  # Copy parent fields over to our state

--- a/src/mopidy/models/immutable.py
+++ b/src/mopidy/models/immutable.py
@@ -226,4 +226,7 @@ class ValidatedImmutableObject(
         other = super().replace(**kwargs)
         if hasattr(self, "_hash"):
             object.__delattr__(other, "_hash")
-        return self._instances.setdefault(weakref.ref(other), other)
+        return self._instances.setdefault(  # pyright: ignore[reportCallIssue]
+            weakref.ref(other),  # pyright: ignore[reportArgumentType]
+            other,
+        )

--- a/src/mopidy/stream/actor.py
+++ b/src/mopidy/stream/actor.py
@@ -21,7 +21,8 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
         super().__init__()
 
         self._scanner = scan.Scanner(
-            timeout=config["stream"]["timeout"], proxy_config=config["proxy"]
+            timeout=config["stream"]["timeout"],
+            proxy_config=config["proxy"],
         )
 
         self._session = http.get_requests_session(
@@ -31,7 +32,7 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
 
         blacklist = config["stream"]["metadata_blacklist"]
         self._blacklist_re = re.compile(
-            rf"^({'|'.join(fnmatch.translate(u) for u in blacklist)})$"
+            rf"^({'|'.join(fnmatch.translate(u) for u in blacklist)})$",
         )
 
         self._timeout = config["stream"]["timeout"]
@@ -45,7 +46,7 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
             logger.warning(
                 'The stream/protocols config value includes the "file" '
                 'protocol. "file" playback is now handled by Mopidy-File. '
-                "Please remove it from the stream/protocols config."
+                "Please remove it from the stream/protocols config.",
             )
             uri_schemes -= {UriScheme("file")}
         StreamBackend.uri_schemes = sorted(uri_schemes)
@@ -71,7 +72,8 @@ class StreamLibraryProvider(backend.LibraryProvider):
 
         if scan_result:
             track = tags.convert_tags_to_track(scan_result.tags).replace(
-                uri=uri, length=scan_result.duration
+                uri=uri,
+                length=scan_result.duration,
             )
         else:
             logger.warning("Problem looking up %s", uri)

--- a/src/mopidy/stream/actor.py
+++ b/src/mopidy/stream/actor.py
@@ -179,7 +179,7 @@ def _unwrap_stream(  # noqa: PLR0911  # TODO: cleanup the return value of this.
             )
             return uri, None
 
-        # TODO Test streams and return first that seems to be playable
+        # TODO: Test streams and return first that seems to be playable
         new_uri = uris[0]
         logger.debug("Parsed playlist (%s) and found new URI: %s", uri, new_uri)
         uri = Uri(urllib.parse.urljoin(uri, new_uri))

--- a/src/mopidy/zeroconf.py
+++ b/src/mopidy/zeroconf.py
@@ -70,7 +70,8 @@ class Zeroconf:
                 )
                 self.display_hostname = f"{self.server.GetHostName()}"
                 self.name = string.Template(name).safe_substitute(
-                    hostname=self.display_hostname, port=port
+                    hostname=self.display_hostname,
+                    port=port,
                 )
             except dbus.exceptions.DBusException as e:
                 logger.debug("%s: Server failed: %s", self, e)
@@ -109,7 +110,8 @@ class Zeroconf:
 
             self.group = dbus.Interface(
                 self.bus.get_object(
-                    "org.freedesktop.Avahi", self.server.EntryGroupNew()
+                    "org.freedesktop.Avahi",
+                    self.server.EntryGroupNew(),
                 ),
                 "org.freedesktop.Avahi.EntryGroup",
             )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -25,4 +25,3 @@ class IsA:
 
 any_int = IsA(int)
 any_str = IsA(str)
-any_unicode = any_str  # TODO remove

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -542,20 +542,28 @@ class AudioStateTest(unittest.TestCase):
 
     def test_state_does_not_change_when_in_gst_ready_state(self):
         self.audio._handler.on_playbin_state_changed(
-            Gst.State.NULL, Gst.State.READY, Gst.State.VOID_PENDING
+            Gst.State.NULL,
+            Gst.State.READY,
+            Gst.State.VOID_PENDING,
         )
 
         assert self.audio.state == audio.PlaybackState.STOPPED
 
     def test_state_changes_from_stopped_to_playing_on_play(self):
         self.audio._handler.on_playbin_state_changed(
-            Gst.State.NULL, Gst.State.READY, Gst.State.PLAYING
+            Gst.State.NULL,
+            Gst.State.READY,
+            Gst.State.PLAYING,
         )
         self.audio._handler.on_playbin_state_changed(
-            Gst.State.READY, Gst.State.PAUSED, Gst.State.PLAYING
+            Gst.State.READY,
+            Gst.State.PAUSED,
+            Gst.State.PLAYING,
         )
         self.audio._handler.on_playbin_state_changed(
-            Gst.State.PAUSED, Gst.State.PLAYING, Gst.State.VOID_PENDING
+            Gst.State.PAUSED,
+            Gst.State.PLAYING,
+            Gst.State.VOID_PENDING,
         )
 
         assert self.audio.state == audio.PlaybackState.PLAYING
@@ -564,7 +572,9 @@ class AudioStateTest(unittest.TestCase):
         self.audio.state = audio.PlaybackState.PLAYING
 
         self.audio._handler.on_playbin_state_changed(
-            Gst.State.PLAYING, Gst.State.PAUSED, Gst.State.VOID_PENDING
+            Gst.State.PLAYING,
+            Gst.State.PAUSED,
+            Gst.State.VOID_PENDING,
         )
 
         assert self.audio.state == audio.PlaybackState.PAUSED
@@ -573,10 +583,14 @@ class AudioStateTest(unittest.TestCase):
         self.audio.state = audio.PlaybackState.PLAYING
 
         self.audio._handler.on_playbin_state_changed(
-            Gst.State.PLAYING, Gst.State.PAUSED, Gst.State.NULL
+            Gst.State.PLAYING,
+            Gst.State.PAUSED,
+            Gst.State.NULL,
         )
         self.audio._handler.on_playbin_state_changed(
-            Gst.State.PAUSED, Gst.State.READY, Gst.State.NULL
+            Gst.State.PAUSED,
+            Gst.State.READY,
+            Gst.State.NULL,
         )
         # We never get the following call, so the logic must work without it
         # self.audio._handler.on_playbin_state_changed(

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -95,27 +95,27 @@ class AudioTest(BaseTest):
 
     @unittest.SkipTest
     def test_deliver_data(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
     @unittest.SkipTest
     def test_end_of_data_stream(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
     @unittest.SkipTest
     def test_set_mute(self):
-        pass  # TODO Probably needs a fakemixer with a mixer track
+        pass  # TODO: Implement test
 
     @unittest.SkipTest
     def test_set_state_encapsulation(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
     @unittest.SkipTest
     def test_set_position(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
     @unittest.SkipTest
     def test_invalid_output_raises_error(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
 
 class AudioDummyTest(DummyMixin, AudioTest):
@@ -522,15 +522,15 @@ class MixerTest(BaseTest):
 
     @unittest.SkipTest
     def test_set_state_encapsulation(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
     @unittest.SkipTest
     def test_set_position(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
     @unittest.SkipTest
     def test_invalid_output_raises_error(self):
-        pass  # TODO
+        pass  # TODO: Implement test
 
 
 class AudioStateTest(unittest.TestCase):

--- a/tests/audio/test_actor.py
+++ b/tests/audio/test_actor.py
@@ -4,11 +4,11 @@ from typing import ClassVar
 from unittest import mock
 
 import pykka
+
 from mopidy import audio
 from mopidy.audio.constants import PlaybackState
 from mopidy.internal import path
 from mopidy.internal.gi import Gst
-
 from tests import dummy_audio, path_to_data_dir
 
 # We want to make sure both our real audio class and the fake one behave

--- a/tests/audio/test_listener.py
+++ b/tests/audio/test_listener.py
@@ -19,7 +19,9 @@ class AudioListenerTest(unittest.TestCase):
         )
 
         self.listener.state_changed.assert_called_with(
-            old_state="stopped", new_state="playing", target_state=None
+            old_state="stopped",
+            new_state="playing",
+            target_state=None,
         )
 
     def test_listener_has_default_impl_for_reached_end_of_stream(self):

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -36,7 +36,8 @@ class ScannerTest(unittest.TestCase):
             if path.suffix != ".mp3":
                 continue
             if not result.playable and result.mime == "audio/mpeg":
-                raise unittest.SkipTest("Missing MP3 support?")
+                msg = "Missing MP3 support?"
+                raise unittest.SkipTest(msg)
 
     def test_tags_is_set(self):
         self.scan(self.find("scanner/simple"))

--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -3,7 +3,6 @@ import unittest
 from mopidy import exceptions
 from mopidy.audio import scan
 from mopidy.internal.path import path_to_uri
-
 from tests import path_to_data_dir
 
 

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -207,7 +207,7 @@ class TagsToTrackTest(unittest.TestCase):
     def test_missing_track_date(self):
         del self.tags["date"]
         self.check(
-            self.track.replace(album=self.track.album.replace(date=None), date=None)
+            self.track.replace(album=self.track.album.replace(date=None), date=None),
         )
 
     def test_multiple_track_date(self):

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -2,8 +2,8 @@ import unittest
 from unittest import mock
 
 import pytest
-from mopidy import backend
 
+from mopidy import backend
 from tests import dummy_backend
 
 

--- a/tests/backend/test_backend.py
+++ b/tests/backend/test_backend.py
@@ -23,7 +23,7 @@ class LibraryTest(unittest.TestCase):
             [
                 mock.call("dummy1:a"),
                 mock.call("dummy1:b"),
-            ]
+            ],
         )
 
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -2,7 +2,6 @@ import unittest
 from unittest import mock
 
 from mopidy import config, ext
-
 from tests import path_to_data_dir
 
 

--- a/tests/config/test_config.py
+++ b/tests/config/test_config.py
@@ -233,7 +233,7 @@ class PostProcessorTest(unittest.TestCase):
         assert result == "# foobar"
 
         result = config._postprocess(
-            "[__COMMENTS__]\n__SEMICOLON0__ = foo\n__HASH1__ = bar"
+            "[__COMMENTS__]\n__SEMICOLON0__ = foo\n__HASH1__ = bar",
         )
         assert result == "; foo\n# bar"
 
@@ -242,13 +242,13 @@ class PostProcessorTest(unittest.TestCase):
             "[__COMMENTS__]\n"
             "__SEMICOLON0__ = foo\n"
             "__INLINE1__ = bar\n"
-            "__INLINE2__ = baz"
+            "__INLINE2__ = baz",
         )
         assert result == "; foo ; bar ; baz"
 
     def test_inline_semicolon_comment(self):
         result = config._postprocess(
-            "[__COMMENTS__]\n[section]\nfoo = bar\n__INLINE0__ = baz"
+            "[__COMMENTS__]\n[section]\nfoo = bar\n__INLINE0__ = baz",
         )
         assert result == "[section]\nfoo = bar ; baz"
 
@@ -265,7 +265,7 @@ class PostProcessorTest(unittest.TestCase):
             "[__COMMENTS__]\n"
             "[section]\n"
             "__SECTION0__ = foobar\n"
-            "__INLINE1__ = baz"
+            "__INLINE1__ = baz",
         )
         assert result == "[section] foobar ; baz"
 

--- a/tests/config/test_schemas.py
+++ b/tests/config/test_schemas.py
@@ -3,7 +3,6 @@ import unittest
 from unittest import mock
 
 from mopidy.config import schemas, types
-
 from tests import any_unicode
 
 

--- a/tests/config/test_schemas.py
+++ b/tests/config/test_schemas.py
@@ -3,7 +3,7 @@ import unittest
 from unittest import mock
 
 from mopidy.config import schemas, types
-from tests import any_unicode
+from tests import any_str
 
 
 class ConfigSchemaTest(unittest.TestCase):
@@ -21,7 +21,7 @@ class ConfigSchemaTest(unittest.TestCase):
         del self.values["foo"]
 
         result, errors = self.schema.deserialize(self.values)
-        assert errors == {"foo": any_unicode}
+        assert errors == {"foo": any_str}
         assert result.pop("foo") is None
         assert result.pop("bar") is not None
         assert result.pop("baz") is not None
@@ -31,7 +31,7 @@ class ConfigSchemaTest(unittest.TestCase):
         self.values["extra"] = "123"
 
         result, errors = self.schema.deserialize(self.values)
-        assert errors == {"extra": any_unicode}
+        assert errors == {"extra": any_str}
         assert result.pop("foo") is not None
         assert result.pop("bar") is not None
         assert result.pop("baz") is not None

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -442,7 +442,7 @@ class TestBoolean:
         assert result == "false"
 
     def test_serialize_none_as_false(self):
-        # TODO We should consider making `None` an invalid value, but we have
+        # TODO: We should consider making `None` an invalid value, but we have
         # existing code that assumes it to work like False.
 
         cv = types.Boolean()

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -234,7 +234,7 @@ class TestSecret:
 
     def test_deserialize_utilises_transformer(self):
         cv = types.Secret(
-            transformer=lambda value: codecs.decode(value, encoding="rot13")
+            transformer=lambda value: codecs.decode(value, encoding="rot13"),
         )
 
         result = cv.deserialize("zbcvql")
@@ -571,7 +571,9 @@ class TestPair:
     @pytest.mark.parametrize("optional", (True, False))
     @pytest.mark.parametrize("optional_pair", (True, False))
     def test_deserialize_enforces_required_pair_values(
-        self, optional: bool, optional_pair: bool
+        self,
+        optional: bool,
+        optional_pair: bool,
     ):
         cv = types.Pair(optional=optional, optional_pair=optional_pair)
 
@@ -587,7 +589,10 @@ class TestPair:
     @pytest.mark.parametrize("optional_pair", (True, False))
     @pytest.mark.parametrize("sep", ("!", "@", "#", "$", "%", "^", "&", "*", "/", "\\"))
     def test_deserialize_enforces_required_pair_values_with_custom_separator(
-        self, optional: bool, optional_pair: bool, sep: str
+        self,
+        optional: bool,
+        optional_pair: bool,
+        sep: str,
     ):
         cv = types.Pair(optional=optional, optional_pair=optional_pair, separator=sep)
 
@@ -680,7 +685,7 @@ class TestPair:
         assert result == (None, "def")
 
         cv = types.Pair(
-            subtypes=(types.String(optional=True), types.String(optional=True))
+            subtypes=(types.String(optional=True), types.String(optional=True)),
         )
         result = cv.deserialize("|")
         assert result == (None, None)
@@ -836,7 +841,7 @@ class TestPair:
             subtypes=(
                 types.Pair(optional=True),
                 types.Pair(),
-            )
+            ),
         )
         result = cv.deserialize("|abc|def")
         assert result == (None, ("abc", "def"))
@@ -893,7 +898,7 @@ class TestPair:
             subtypes=(
                 types.String(),
                 types.Pair(optional_pair=True),
-            )
+            ),
         )
         result = cv.deserialize("abc|def")
         assert result == ("abc", ("def", "def"))

--- a/tests/config/test_types.py
+++ b/tests/config/test_types.py
@@ -6,6 +6,7 @@ from typing import ClassVar
 from unittest import mock
 
 import pytest
+
 from mopidy.config import types
 from mopidy.internal import log
 

--- a/tests/config/test_validator.py
+++ b/tests/config/test_validator.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mopidy.config import validators
 
 

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -4,14 +4,14 @@ import tempfile
 import unittest
 from unittest import mock
 
-import mopidy
 import pykka
 import pytest
+
+import mopidy
 from mopidy.audio import PlaybackState
 from mopidy.core import Core, CoreListener
 from mopidy.internal import models, storage
 from mopidy.models import Track
-
 from tests import dummy_mixer
 
 

--- a/tests/core/test_actor.py
+++ b/tests/core/test_actor.py
@@ -179,7 +179,7 @@ class CoreActorSaveLoadStateTest(unittest.TestCase):
                 "max_tracklist_length": 10000,
                 "restore_state": True,
                 "data_dir": self.temp_dir,
-            }
+            },
         }
 
         self.mixer = dummy_mixer.create_proxy()
@@ -251,7 +251,7 @@ class CoreActorSaveLoadStateTest(unittest.TestCase):
                         timestamp=13,
                         track=models.Ref.track(uri="a:b", name="b"),
                     ),
-                ]
+                ],
             ),
             playback=models.PlaybackState(tlid=12, state="paused", time_position=432),
             mixer=models.MixerState(mute=True, volume=12),

--- a/tests/core/test_events.py
+++ b/tests/core/test_events.py
@@ -2,10 +2,10 @@ import unittest
 from unittest import mock
 
 import pykka
+
 from mopidy import core
 from mopidy.internal import deprecation
 from mopidy.models import Track
-
 from tests import dummy_backend
 
 

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pytest
+
 from mopidy.core import HistoryController
 from mopidy.internal.models import HistoryState, HistoryTrack
 from mopidy.models import Artist, Ref, Track

--- a/tests/core/test_history.py
+++ b/tests/core/test_history.py
@@ -86,7 +86,7 @@ class CoreHistorySaveLoadStateTest(unittest.TestCase):
                 HistoryTrack(timestamp=34, track=self.refs[0]),
                 HistoryTrack(timestamp=45, track=self.refs[2]),
                 HistoryTrack(timestamp=56, track=self.refs[1]),
-            ]
+            ],
         )
         coverage = ["history"]
         self.history._load_state(state, coverage)

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 import pytest
+
 from mopidy import backend, core
 from mopidy.internal import validation
 from mopidy.models import Image, Ref, SearchResult, Track

--- a/tests/core/test_library.py
+++ b/tests/core/test_library.py
@@ -69,7 +69,7 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
     def test_get_images_returns_images(self):
         self.library1.get_images.return_value.get.return_value = {
-            "dummy1:track": [Image(uri="uri")]
+            "dummy1:track": [Image(uri="uri")],
         }
 
         result = self.core.library.get_images(["dummy1:track"])
@@ -77,14 +77,14 @@ class CoreLibraryTest(BaseCoreLibraryTest):
 
     def test_get_images_merges_results(self):
         self.library1.get_images.return_value.get.return_value = {
-            "dummy1:track": [Image(uri="uri1")]
+            "dummy1:track": [Image(uri="uri1")],
         }
         self.library2.get_images.return_value.get.return_value = {
-            "dummy2:track": [Image(uri="uri2")]
+            "dummy2:track": [Image(uri="uri2")],
         }
 
         result = self.core.library.get_images(
-            ["dummy1:track", "dummy2:track", "dummy3:track", "dummy4:track"]
+            ["dummy1:track", "dummy2:track", "dummy3:track", "dummy4:track"],
         )
         expected = {
             "dummy1:track": (Image(uri="uri1"),),
@@ -212,7 +212,7 @@ class CoreLibraryTest(BaseCoreLibraryTest):
                 "dummy1:b",
                 "dummy2:a",
                 "dummy2:b",
-            ]
+            ],
         )
 
         self.library1.lookup_many.assert_called_once_with(["dummy1:a", "dummy1:b"])
@@ -263,32 +263,44 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         assert result1 in result
         assert result2 in result
         self.library1.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=False
+            query={"any": ["a"]},
+            uris=None,
+            exact=False,
         )
         self.library2.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=False
+            query={"any": ["a"]},
+            uris=None,
+            exact=False,
         )
 
     def test_search_with_uris_selects_dummy1_backend(self):
         self.core.library.search(
-            query={"any": ["a"]}, uris=["dummy1:", "dummy1:foo", "dummy3:"]
+            query={"any": ["a"]},
+            uris=["dummy1:", "dummy1:foo", "dummy3:"],
         )
 
         self.library1.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=["dummy1:", "dummy1:foo"], exact=False
+            query={"any": ["a"]},
+            uris=["dummy1:", "dummy1:foo"],
+            exact=False,
         )
         assert not self.library2.search.called
 
     def test_search_with_uris_selects_both_backends(self):
         self.core.library.search(
-            query={"any": ["a"]}, uris=["dummy1:", "dummy1:foo", "dummy2:"]
+            query={"any": ["a"]},
+            uris=["dummy1:", "dummy1:foo", "dummy2:"],
         )
 
         self.library1.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=["dummy1:", "dummy1:foo"], exact=False
+            query={"any": ["a"]},
+            uris=["dummy1:", "dummy1:foo"],
+            exact=False,
         )
         self.library2.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=["dummy2:"], exact=False
+            query={"any": ["a"]},
+            uris=["dummy2:"],
+            exact=False,
         )
 
     def test_search_filters_out_none(self):
@@ -303,10 +315,14 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         assert result1 in result
         assert None not in result
         self.library1.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=False
+            query={"any": ["a"]},
+            uris=None,
+            exact=False,
         )
         self.library2.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=False
+            query={"any": ["a"]},
+            uris=None,
+            exact=False,
         )
 
     def test_search_accepts_query_dict_instead_of_kwargs(self):
@@ -323,16 +339,22 @@ class CoreLibraryTest(BaseCoreLibraryTest):
         assert result1 in result
         assert result2 in result
         self.library1.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=False
+            query={"any": ["a"]},
+            uris=None,
+            exact=False,
         )
         self.library2.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=False
+            query={"any": ["a"]},
+            uris=None,
+            exact=False,
         )
 
     def test_search_normalises_bad_queries(self):
         self.core.library.search({"any": "foobar"})
         self.library1.search.assert_called_once_with(
-            query={"any": ["foobar"]}, uris=None, exact=False
+            query={"any": ["foobar"]},
+            uris=None,
+            exact=False,
         )
 
 
@@ -373,7 +395,8 @@ class GetDistinctTest(BaseCoreLibraryTest):
     def test_checks_field_is_valid(self, check_choice_mock):
         self.core.library.get_distinct("artist")
         check_choice_mock.assert_called_with(
-            "artist", validation.DISTINCT_FIELDS.keys()
+            "artist",
+            validation.DISTINCT_FIELDS.keys(),
         )
 
     def test_any_field_raises_valueerror(self):
@@ -403,7 +426,8 @@ class GetDistinctTest(BaseCoreLibraryTest):
 
         assert self.core.library.get_distinct("track") == {result1}
         deprecate_warn_mock.assert_called_once_with(
-            "core.library.get_distinct:field_arg:track", pending=mock.ANY
+            "core.library.get_distinct:field_arg:track",
+            pending=mock.ANY,
         )
 
     @mock.patch("mopidy.core.library.logger")
@@ -450,13 +474,17 @@ class LegacyFindExactToSearchLibraryTest(unittest.TestCase):
     def test_core_search_call_backend_search_with_exact(self):
         self.core.library.search(query={"any": ["a"]})
         self.backend.library.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=False
+            query={"any": ["a"]},
+            uris=None,
+            exact=False,
         )
 
     def test_core_search_with_exact_call_backend_search_with_exact(self):
         self.core.library.search(query={"any": ["a"]}, exact=True)
         self.backend.library.search.assert_called_once_with(
-            query={"any": ["a"]}, uris=None, exact=True
+            query={"any": ["a"]},
+            uris=None,
+            exact=True,
         )
 
     def test_core_search_with_handles_legacy_backend(self):
@@ -588,7 +616,7 @@ class LookupByUrisBadBackendTest(MockBackendCoreLibraryBase):
     def test_backend_returns_wrong_type(self, logger):
         uri = "dummy:/1"
         self.library.lookup_many.return_value.get.return_value = [
-            Track(uri=uri, name="abc")
+            Track(uri=uri, name="abc"),
         ]
         assert self.core.library.lookup(uris=[uri]) == {uri: []}
         logger.error.assert_called_with(mock.ANY, "DummyBackend", mock.ANY)

--- a/tests/core/test_listener.py
+++ b/tests/core/test_listener.py
@@ -15,7 +15,8 @@ class CoreListenerTest(unittest.TestCase):
         self.listener.on_event("track_playback_paused", track=TlTrack(), position=0)
 
         self.listener.track_playback_paused.assert_called_with(
-            track=TlTrack(), position=0
+            track=TlTrack(),
+            position=0,
         )
 
     def test_listener_has_default_impl_for_track_playback_paused(self):
@@ -32,7 +33,8 @@ class CoreListenerTest(unittest.TestCase):
 
     def test_listener_has_default_impl_for_playback_state_changed(self):
         self.listener.playback_state_changed(
-            PlaybackState.STOPPED, PlaybackState.PLAYING
+            PlaybackState.STOPPED,
+            PlaybackState.PLAYING,
         )
 
     def test_listener_has_default_impl_for_tracklist_changed(self):

--- a/tests/core/test_mixer.py
+++ b/tests/core/test_mixer.py
@@ -3,9 +3,9 @@ from unittest import mock
 
 import pykka
 import pytest
+
 from mopidy import core, mixer
 from mopidy.internal.models import MixerState
-
 from tests import dummy_mixer
 
 

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -58,7 +58,7 @@ class MyTestBackend(dummy_backend.DummyBackend):
 
 class BaseTest:
     config: ClassVar[dict[str, dict[str, int]]] = {
-        "core": {"max_tracklist_length": 10000}
+        "core": {"max_tracklist_length": 10000},
     }
     tracks: ClassVar[list[Track]] = [
         Track(uri="dummy:a", length=1234, name="foo"),
@@ -70,7 +70,9 @@ class BaseTest:
         self.audio = dummy_audio.create_proxy(config=self.config, mixer=None)
         self.backend = MyTestBackend.start(audio=self.audio, config=self.config).proxy()
         self.core = core.Core(
-            audio=self.audio, backends=[self.backend], config=self.config
+            audio=self.audio,
+            backends=[self.backend],
+            config=self.config,
         )
         self.playback = self.core.playback
 
@@ -799,7 +801,7 @@ class TestEventEmission(BaseTest):
         # triggered as we have to switch back to the previous track.
         # The correct behavior would be to only emit seeked.
         assert listener_mock.send.mock_calls == [
-            mock.call("seeked", time_position=1000)
+            mock.call("seeked", time_position=1000),
         ]
 
     def test_previous_emits_events(self, listener_mock):
@@ -1034,7 +1036,9 @@ class TestBackendSelection:
         ]
 
         self.core = core.Core(
-            config, mixer=None, backends=[self.backend1, self.backend2]
+            config,
+            mixer=None,
+            backends=[self.backend1, self.backend2],
         )
 
         with deprecation.ignore():
@@ -1170,7 +1174,7 @@ class TestCorePlaybackWithOldBackend:
         b.playback = mock.Mock(spec=backend.PlaybackProvider)
         b.playback.play.side_effect = TypeError
         b.library.lookup_many.return_value.get.return_value = {
-            "dummy1:a": [Track(uri="dummy1:a", length=40000)]
+            "dummy1:a": [Track(uri="dummy1:a", length=40000)],
         }
 
         c = core.Core(config, mixer=None, backends=[b])

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -3,11 +3,11 @@ from unittest import mock
 
 import pykka
 import pytest
+
 from mopidy import backend, core
 from mopidy.internal import deprecation
 from mopidy.internal.models import PlaybackState
 from mopidy.models import Track
-
 from tests import dummy_audio, dummy_backend
 
 

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -307,8 +307,8 @@ class TestPreviousHandling(BaseTest):
         [
             (False, False, False, False, 0, None),
             (False, False, False, False, 1, 0),
-            (True, False, False, False, 0, 0),  # FIXME: #1694
-            (True, False, False, False, 1, 1),  # FIXME: #1694
+            (True, False, False, False, 0, 0),  # TODO: #1694
+            (True, False, False, False, 1, 1),  # TODO: #1694
         ],
     )
     def test_previous_all_modes(self, repeat, random, single, consume, index, result):

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -2,6 +2,7 @@ import unittest
 from unittest import mock
 
 import pytest
+
 from mopidy import backend, core
 from mopidy.internal.models import TracklistState
 from mopidy.models import TlTrack, Track

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -56,7 +56,7 @@ class TracklistTest(unittest.TestCase):
                 "dummy1:a",
                 "dummy1:b",
                 "dummy1:c",
-            ]
+            ],
         )
 
         assert len(tl_tracks) == 3

--- a/tests/core/test_tracklist.py
+++ b/tests/core/test_tracklist.py
@@ -103,7 +103,7 @@ class TracklistTest(unittest.TestCase):
         with pytest.raises(ValueError):
             self.core.tracklist.filter({"uri": "a"})
 
-    # TODO Extract tracklist tests from the local backend tests
+    # TODO: Extract tracklist tests from the local backend tests
 
 
 class TracklistIndexTest(unittest.TestCase):

--- a/tests/dummy_audio.py
+++ b/tests/dummy_audio.py
@@ -5,6 +5,7 @@ tests of the core and backends.
 """
 
 import pykka
+
 from mopidy import audio
 
 

--- a/tests/dummy_backend.py
+++ b/tests/dummy_backend.py
@@ -5,6 +5,7 @@ used in tests of the frontends.
 """
 
 import pykka
+
 from mopidy import backend
 from mopidy.models import Playlist, Ref, SearchResult
 

--- a/tests/dummy_mixer.py
+++ b/tests/dummy_mixer.py
@@ -1,4 +1,5 @@
 import pykka
+
 from mopidy import mixer
 
 

--- a/tests/file/conftest.py
+++ b/tests/file/conftest.py
@@ -1,8 +1,8 @@
 from unittest import mock
 
 import pytest
-from mopidy.file import backend
 
+from mopidy.file import backend
 from tests import path_to_data_dir
 
 

--- a/tests/file/conftest.py
+++ b/tests/file/conftest.py
@@ -6,17 +6,17 @@ from mopidy.file import backend
 from tests import path_to_data_dir
 
 
-@pytest.fixture()
+@pytest.fixture
 def media_dirs():
     return [str(path_to_data_dir(""))]
 
 
-@pytest.fixture()
+@pytest.fixture
 def follow_symlinks():
     return False
 
 
-@pytest.fixture()
+@pytest.fixture
 def config(media_dirs, follow_symlinks):
     return {
         "proxy": {},
@@ -30,6 +30,6 @@ def config(media_dirs, follow_symlinks):
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def provider(config):
     return backend.FileBackend(audio=mock.Mock(), config=config).library

--- a/tests/file/test_browse.py
+++ b/tests/file/test_browse.py
@@ -1,6 +1,6 @@
 import pytest
-from mopidy.internal import path
 
+from mopidy.internal import path
 from tests import path_to_data_dir
 
 

--- a/tests/file/test_file.py
+++ b/tests/file/test_file.py
@@ -15,4 +15,5 @@ def test_file_init():
             extension.setup(registry)
             assert registry["backend"][0] == FileBackend
             return
-    raise AssertionError("Mopidy-File not loaded!")
+    msg = "Mopidy-File not loaded!"
+    raise AssertionError(msg)

--- a/tests/file/test_lookup.py
+++ b/tests/file/test_lookup.py
@@ -1,9 +1,9 @@
 from unittest import mock
 
 import pytest
+
 from mopidy import exceptions
 from mopidy.internal import path
-
 from tests import path_to_data_dir
 
 

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -23,8 +23,8 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                         "path": Path(__file__).parent,
                         "default_filename": "test_handlers.py",
                     },
-                )
-            ]
+                ),
+            ],
         )
 
     def test_static_handler(self):
@@ -55,8 +55,8 @@ class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):
                         "allowed_origins": frozenset(),
                         "csrf_protection": True,
                     },
-                )
-            ]
+                ),
+            ],
         )
 
     def connection(self, **kwargs):
@@ -132,8 +132,8 @@ class JsonRpcHandlerTestBase(tornado.testing.AsyncHTTPTestCase):
                         "allowed_origins": set(),
                         "csrf_protection": self.csrf_protection,
                     },
-                )
-            ]
+                ),
+            ],
         )
 
     def assert_extra_response_headers(self, headers):
@@ -211,7 +211,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
 
     def test_post_with_origin_ok_sets_cors_headers(self):
         self.headers.update(
-            {"Content-Type": "application/json", "Origin": "http://foobar:6680"}
+            {"Content-Type": "application/json", "Origin": "http://foobar:6680"},
         )
         response = self.fetch("/rpc", method="POST", body="hi", headers=self.headers)
 
@@ -256,17 +256,23 @@ class CheckOriginTests(unittest.TestCase):
 
     def test_same_host_origin_allowed(self):
         assert handlers.check_origin(
-            "http://localhost:6680", self.headers, self.allowed
+            "http://localhost:6680",
+            self.headers,
+            self.allowed,
         )
 
     def test_different_host_origin_blocked(self):
         assert not handlers.check_origin(
-            "http://other:6680", self.headers, self.allowed
+            "http://other:6680",
+            self.headers,
+            self.allowed,
         )
 
     def test_different_port_blocked(self):
         assert not handlers.check_origin(
-            "http://localhost:80", self.headers, self.allowed
+            "http://localhost:80",
+            self.headers,
+            self.allowed,
         )
 
     def test_extra_origin_allowed(self):

--- a/tests/http/test_handlers.py
+++ b/tests/http/test_handlers.py
@@ -2,12 +2,13 @@ import unittest
 from pathlib import Path
 from unittest import mock
 
-import mopidy
 import pytest
 import tornado.httpclient
 import tornado.testing
 import tornado.web
 import tornado.websocket
+
+import mopidy
 from mopidy.http import handlers
 
 

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -21,7 +21,7 @@ class HttpServerTest(tornado.testing.AsyncHTTPTestCase):
                 "allowed_origins": frozenset(),
                 "csrf_protection": True,
                 "default_app": "mopidy",
-            }
+            },
         }
 
     def get_app(self):
@@ -39,7 +39,7 @@ class HttpServerTest(tornado.testing.AsyncHTTPTestCase):
                     apps=testapps,
                     statics=teststatics,
                 ),
-            }
+            },
         ]
 
         http_server = actor.HttpServer(
@@ -142,7 +142,7 @@ class MopidyRPCHandlerTest(HttpServerTest):
                 "params": [],
                 "jsonrpc": "2.0",
                 "id": 1,
-            }
+            },
         )
 
         response = self.fetch(
@@ -172,7 +172,7 @@ class MopidyRPCHandlerNoCSRFProtectionTest(HttpServerTest):
                 "params": [],
                 "jsonrpc": "2.0",
                 "id": 1,
-            }
+            },
         )
 
     def test_should_ignore_incorrect_content_type(self):
@@ -187,7 +187,10 @@ class MopidyRPCHandlerNoCSRFProtectionTest(HttpServerTest):
 
     def test_should_ignore_missing_content_type(self):
         response = self.fetch(
-            "/mopidy/rpc", method="POST", body=self.get_cmd(), headers={}
+            "/mopidy/rpc",
+            method="POST",
+            body=self.get_cmd(),
+            headers={},
         )
 
         assert response.code == 200
@@ -220,7 +223,7 @@ class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
                 "port": 6680,
                 "zeroconf": "",
                 "default_app": "static",
-            }
+            },
         }
         core = mock.Mock()
 
@@ -228,7 +231,7 @@ class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
             {
                 "name": "static",
                 "path": Path(__file__).parent,
-            }
+            },
         ]
 
         http_server = actor.HttpServer(
@@ -279,14 +282,18 @@ class HttpServerWithWsgiAppTest(tornado.testing.AsyncHTTPTestCase):
                 "port": 6680,
                 "zeroconf": "",
                 "default_app": "wsgi",
-            }
+            },
         }
         core = mock.Mock()
 
         apps = [{"name": "wsgi", "factory": wsgi_app_factory}]
 
         http_server = actor.HttpServer(
-            config=config, core=core, sockets=[], apps=apps, statics=[]
+            config=config,
+            core=core,
+            sockets=[],
+            apps=apps,
+            statics=[],
         )
 
         return tornado.web.Application(http_server._get_request_handlers())
@@ -320,14 +327,18 @@ class HttpServerWithAppDefaultApp(tornado.testing.AsyncHTTPTestCase):
                 "port": 6680,
                 "zeroconf": "",
                 "default_app": "default_app",
-            }
+            },
         }
         core = mock.Mock()
 
         apps = [{"name": "default_app", "factory": default_webapp_factory}]
 
         http_server = actor.HttpServer(
-            config=config, core=core, sockets=[], apps=apps, statics=[]
+            config=config,
+            core=core,
+            sockets=[],
+            apps=apps,
+            statics=[],
         )
 
         return tornado.web.Application(http_server._get_request_handlers())
@@ -352,7 +363,7 @@ class HttpServerWithStaticDefaultApp(tornado.testing.AsyncHTTPTestCase):
                 "port": 6680,
                 "zeroconf": "",
                 "default_app": "default_app",
-            }
+            },
         }
         core = mock.Mock()
 
@@ -360,7 +371,7 @@ class HttpServerWithStaticDefaultApp(tornado.testing.AsyncHTTPTestCase):
             {
                 "name": "default_app",
                 "path": Path(__file__).parent,
-            }
+            },
         ]
 
         http_server = actor.HttpServer(
@@ -447,11 +458,15 @@ class HttpServerTestLoginWithSecureCookie(tornado.testing.AsyncHTTPTestCase):
             {
                 "name": "cookie_secret",
                 "factory": cookie_secret_app_factory,
-            }
+            },
         ]
 
         http_server = actor.HttpServer(
-            config=config, core=core, sockets=[], apps=apps, statics=[]
+            config=config,
+            core=core,
+            sockets=[],
+            apps=apps,
+            statics=[],
         )
 
         return tornado.web.Application(

--- a/tests/http/test_server.py
+++ b/tests/http/test_server.py
@@ -4,9 +4,10 @@ import urllib
 from pathlib import Path
 from unittest import mock
 
-import mopidy
 import tornado.testing
 import tornado.wsgi
+
+import mopidy
 from mopidy.http import actor, handlers
 
 

--- a/tests/internal/test_deps.py
+++ b/tests/internal/test_deps.py
@@ -41,7 +41,7 @@ class TestDeps:
                                 version="0.6",
                             ),
                         ],
-                    )
+                    ),
                 ],
             ),
         ]
@@ -115,7 +115,7 @@ class TestDeps:
         dist_setuptools.name = "setuptools"
         dist_setuptools.version = "0.6"
         dist_setuptools.locate_file = mock.MagicMock(
-            return_value=Path("/tmp/example/setuptools/main.py")
+            return_value=Path("/tmp/example/setuptools/main.py"),
         )
         dist_setuptools.requires = []
 
@@ -123,7 +123,7 @@ class TestDeps:
         dist_pykka.name = "Pykka"
         dist_pykka.version = "1.1"
         dist_pykka.locate_file = mock.MagicMock(
-            return_value=Path("/tmp/example/pykka/main.py")
+            return_value=Path("/tmp/example/pykka/main.py"),
         )
         dist_pykka.requires = [f"{dist_setuptools.name}==0.6"]
 
@@ -131,7 +131,7 @@ class TestDeps:
         dist_mopidy.name = "Mopidy"
         dist_mopidy.version = "0.13"
         dist_mopidy.locate_file = mock.MagicMock(
-            return_value=Path("/tmp/example/mopidy/no_name.py")
+            return_value=Path("/tmp/example/mopidy/no_name.py"),
         )
         dist_mopidy.requires = [f"{dist_pykka.name}==1.1"]
 

--- a/tests/internal/test_http.py
+++ b/tests/internal/test_http.py
@@ -3,6 +3,7 @@ from unittest import mock
 import pytest
 import requests
 import responses
+
 from mopidy.internal import http
 
 TIMEOUT = 1000

--- a/tests/internal/test_http.py
+++ b/tests/internal/test_http.py
@@ -11,12 +11,12 @@ URI = "http://example.com/foo.txt"
 BODY = "This is the contents of foo.txt."
 
 
-@pytest.fixture()
+@pytest.fixture
 def session():
     return requests.Session()
 
 
-@pytest.fixture()
+@pytest.fixture
 def session_mock():
     return mock.Mock(spec=requests.Session)
 

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -637,7 +637,7 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
                 "core.playback": core.PlaybackController,
                 "core.playlists": core.PlaylistsController,
                 "core.tracklist": core.TracklistController,
-            }
+            },
         )
 
         methods = inspector.describe()

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -4,9 +4,9 @@ from unittest import mock
 
 import pykka
 import pytest
+
 from mopidy import core, models
 from mopidy.internal import deprecation, jsonrpc
-
 from tests import dummy_backend
 
 

--- a/tests/internal/test_jsonrpc.py
+++ b/tests/internal/test_jsonrpc.py
@@ -43,7 +43,8 @@ class Calculator:
         return "Grand Unified Theory"
 
     def fail(self):
-        raise ValueError("What did you expect?")
+        msg = "What did you expect?"
+        raise ValueError(msg)
 
 
 class JsonRpcTestBase(unittest.TestCase):

--- a/tests/internal/test_log.py
+++ b/tests/internal/test_log.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mopidy.internal import log
 
 

--- a/tests/internal/test_log.py
+++ b/tests/internal/test_log.py
@@ -3,7 +3,7 @@ import pytest
 from mopidy.internal import log
 
 
-@pytest.fixture()
+@pytest.fixture
 def config():
     return {
         "verbosity": 2,

--- a/tests/internal/test_models.py
+++ b/tests/internal/test_models.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 import pytest
+
 from mopidy.internal.models import (
     HistoryState,
     HistoryTrack,

--- a/tests/internal/test_network.py
+++ b/tests/internal/test_network.py
@@ -26,10 +26,10 @@ class FormatHostnameTest(unittest.TestCase):
     @patch("mopidy.internal.network.has_ipv6", True)
     def test_format_hostname_prefixes_ipv4_addresses_when_ipv6_available(self):
         network.has_ipv6 = True
-        assert network.format_hostname("0.0.0.0") == "::ffff:0.0.0.0"
+        assert network.format_hostname("0.0.0.0") == "::ffff:0.0.0.0"  # noqa: S104
         assert network.format_hostname("1.0.0.1") == "::ffff:1.0.0.1"
 
     @patch("mopidy.internal.network.has_ipv6", False)
     def test_format_hostname_does_nothing_when_only_ipv4_available(self):
         network.has_ipv6 = False
-        assert network.format_hostname("0.0.0.0") == "0.0.0.0"
+        assert network.format_hostname("0.0.0.0") == "0.0.0.0"  # noqa: S104

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -176,7 +176,7 @@ class ExpandPathTest(unittest.TestCase):
     def test_empty_path(self):
         result = path.expand_path("")
 
-        assert result == pathlib.Path().resolve()
+        assert result == pathlib.Path.cwd()
 
     def test_absolute_path(self):
         result = path.expand_path("/tmp/foo")

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -4,6 +4,7 @@ import tempfile
 import unittest
 
 import pytest
+
 from mopidy.internal import path
 from mopidy.internal.gi import GLib
 

--- a/tests/internal/test_path.py
+++ b/tests/internal/test_path.py
@@ -126,7 +126,7 @@ class GetOrCreateFileTest(unittest.TestCase):
 class GetUnixSocketPathTest(unittest.TestCase):
     def test_correctly_matched_socket_path(self):
         assert path.get_unix_socket_path("unix:/tmp/mopidy.socket") == pathlib.Path(
-            "/tmp/mopidy.socket"
+            "/tmp/mopidy.socket",
         )
 
     def test_correctly_no_match_socket_path(self):

--- a/tests/internal/test_playlists.py
+++ b/tests/internal/test_playlists.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mopidy.internal import playlists
 
 BAD = b"foobarbaz"

--- a/tests/internal/test_validation.py
+++ b/tests/internal/test_validation.py
@@ -1,4 +1,5 @@
 import pytest
+
 from mopidy import exceptions
 from mopidy.internal import validation
 

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -7,7 +7,7 @@ import pytest
 from mopidy.internal import xdg
 
 
-@pytest.fixture()
+@pytest.fixture
 def environ():
     patcher = mock.patch.dict(os.environ, clear=True)
     yield patcher.start()

--- a/tests/internal/test_xdg.py
+++ b/tests/internal/test_xdg.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from unittest import mock
 
 import pytest
+
 from mopidy.internal import xdg
 
 

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -6,10 +6,10 @@ import unittest
 from typing import Any, ClassVar
 
 import pykka
+
 from mopidy import core
 from mopidy.m3u.backend import M3UBackend
 from mopidy.models import Playlist, Track
-
 from tests import dummy_audio, path_to_data_dir
 from tests.m3u import generate_song
 

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -23,7 +23,7 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
             "default_encoding": "latin-1",
             "default_extension": ".m3u",
             "playlists_dir": path_to_data_dir(""),
-        }
+        },
     }
 
     def setUp(self):

--- a/tests/m3u/test_translator.py
+++ b/tests/m3u/test_translator.py
@@ -26,7 +26,7 @@ def dumps(items):
         ("./test.m3u", None, "m3u:test.m3u"),
         ("foo/../test.m3u", None, "m3u:test.m3u"),
         ("Test Playlist.m3u", None, "m3u:Test%20Playlist.m3u"),
-        ("test.mp3", "file", "file:///test.mp3"),
+        ("/test.mp3", "file", "file:///test.mp3"),
     ],
 )
 def test_path_to_uri(path, scheme, expected):

--- a/tests/m3u/test_translator.py
+++ b/tests/m3u/test_translator.py
@@ -2,6 +2,7 @@ import io
 import pathlib
 
 import pytest
+
 from mopidy.m3u import translator
 from mopidy.m3u.translator import path_to_uri
 from mopidy.models import Playlist, Ref, Track

--- a/tests/models/test_fields.py
+++ b/tests/models/test_fields.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pytest
+
 from mopidy.models.fields import Boolean, Collection, Field, Identifier, Integer, String
 
 

--- a/tests/models/test_legacy.py
+++ b/tests/models/test_legacy.py
@@ -1,6 +1,7 @@
 import unittest
 
 import pytest
+
 from mopidy.models import ImmutableObject
 
 

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -2,6 +2,7 @@ import json
 import unittest
 
 import pytest
+
 from mopidy.models import (
     Album,
     Artist,

--- a/tests/models/test_models.py
+++ b/tests/models/test_models.py
@@ -144,7 +144,8 @@ class RefTest(unittest.TestCase):
 
     def test_serialize_without_results(self):
         self.assertDictEqual(
-            {"__model__": "Ref", "uri": "uri"}, Ref(uri="uri").serialize()
+            {"__model__": "Ref", "uri": "uri"},
+            Ref(uri="uri").serialize(),
         )
 
     def test_to_json_and_back(self):

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -8,7 +8,7 @@ from mopidy.stream import actor
 from tests import path_to_data_dir
 
 
-@pytest.fixture()
+@pytest.fixture
 def config():
     return {
         "proxy": {},
@@ -21,12 +21,12 @@ def config():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def audio():
     return mock.Mock()
 
 
-@pytest.fixture()
+@pytest.fixture
 def track_uri():
     return path.path_to_uri(path_to_data_dir("song1.wav"))
 

--- a/tests/stream/test_library.py
+++ b/tests/stream/test_library.py
@@ -1,10 +1,10 @@
 from unittest import mock
 
 import pytest
+
 from mopidy.internal import path
 from mopidy.models import Track
 from mopidy.stream import actor
-
 from tests import path_to_data_dir
 
 

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -5,6 +5,7 @@ from unittest import mock
 import pytest
 import requests.exceptions
 import responses
+
 from mopidy import exceptions
 from mopidy.audio import scan
 from mopidy.stream import actor

--- a/tests/stream/test_playback.py
+++ b/tests/stream/test_playback.py
@@ -20,7 +20,7 @@ http://foo.bar/baz
 """.strip()
 
 
-@pytest.fixture()
+@pytest.fixture
 def config():
     return {
         "proxy": {},
@@ -33,24 +33,24 @@ def config():
     }
 
 
-@pytest.fixture()
+@pytest.fixture
 def audio():
     return mock.Mock()
 
 
-@pytest.fixture()
+@pytest.fixture
 def scanner():
     patcher = mock.patch.object(scan, "Scanner")
     yield patcher.start()()
     patcher.stop()
 
 
-@pytest.fixture()
+@pytest.fixture
 def backend(audio, config, scanner):
     return actor.StreamBackend(audio=audio, config=config)
 
 
-@pytest.fixture()
+@pytest.fixture
 def provider(backend):
     return backend.playback
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -3,6 +3,7 @@ import unittest
 from unittest import mock
 
 import pytest
+
 from mopidy import commands
 
 

--- a/tests/test_commands.py
+++ b/tests/test_commands.py
@@ -143,7 +143,9 @@ class CommandParsingTest(unittest.TestCase):
         with pytest.raises(SystemExit):
             cmd.parse([])
         self.exit_mock.assert_called_once_with(
-            mock.ANY, mock.ANY, "usage: foo --bar BAR"
+            mock.ANY,
+            mock.ANY,
+            "usage: foo --bar BAR",
         )
 
         self.exit_mock.reset_mock()
@@ -151,7 +153,9 @@ class CommandParsingTest(unittest.TestCase):
             cmd.parse([], prog="baz")
 
         self.exit_mock.assert_called_once_with(
-            mock.ANY, mock.ANY, "usage: baz --bar BAR"
+            mock.ANY,
+            mock.ANY,
+            "usage: baz --bar BAR",
         )
 
     def test_missing_required(self):
@@ -203,7 +207,9 @@ class CommandParsingTest(unittest.TestCase):
             cmd.parse(["--help"], prog="foo")
 
         self.exit_mock.assert_called_once_with(
-            1, "unrecognized arguments: --help", "usage: foo"
+            1,
+            "unrecognized arguments: --help",
+            "usage: foo",
         )
 
     def test_invalid_subcommand(self):
@@ -214,7 +220,9 @@ class CommandParsingTest(unittest.TestCase):
             cmd.parse(["bar"], prog="foo")
 
         self.exit_mock.assert_called_once_with(
-            1, "unrecognized command: bar", "usage: foo"
+            1,
+            "unrecognized command: bar",
+            "usage: foo",
         )
 
     def test_set(self):
@@ -367,7 +375,10 @@ class HelpTest(unittest.TestCase):
     def test_subcommand_with_options_shown(self):
         child = commands.Command()
         child.add_argument(
-            "-h", "--help", action="store_true", help="show this message"
+            "-h",
+            "--help",
+            action="store_true",
+            help="show this message",
         )
 
         cmd = commands.Command()
@@ -400,7 +411,10 @@ class HelpTest(unittest.TestCase):
         child = commands.Command()
         child.help = "  some text about everything this command does."
         child.add_argument(
-            "-h", "--help", action="store_true", help="show this message"
+            "-h",
+            "--help",
+            action="store_true",
+            help="show this message",
         )
 
         cmd = commands.Command()
@@ -422,7 +436,10 @@ class HelpTest(unittest.TestCase):
         child = commands.Command()
         child.add_child("baz", subchild)
         child.add_argument(
-            "-h", "--help", action="store_true", help="show this message"
+            "-h",
+            "--help",
+            action="store_true",
+            help="show this message",
         )
 
         cmd = commands.Command()

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -5,7 +5,7 @@ from unittest import mock
 import pytest
 
 from mopidy import config, exceptions, ext
-from tests import IsA, any_unicode
+from tests import IsA, any_str
 
 
 class DummyExtension(ext.Extension):
@@ -95,7 +95,7 @@ class TestLoadExtensions:
             any_testextension,
             mock_entry_point,
             IsA(config.ConfigSchema),
-            any_unicode,
+            any_str,
             None,
         )
         assert ext.load_extensions() == [expected]

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -22,7 +22,7 @@ any_testextension = IsA(DummyExtension)
 
 
 class TestExtension:
-    @pytest.fixture()
+    @pytest.fixture
     def extension(self):
         class MyExtension(ext.Extension):
             dist_name = "Mopidy-Foo"
@@ -72,7 +72,7 @@ class TestExtension:
 
 
 class TestLoadExtensions:
-    @pytest.fixture()
+    @pytest.fixture
     def iter_entry_points_mock(self, request):
         patcher = mock.patch.object(metadata, "entry_points")
         iter_entry_points = patcher.start()
@@ -80,7 +80,7 @@ class TestLoadExtensions:
         yield iter_entry_points
         patcher.stop()
 
-    @pytest.fixture()
+    @pytest.fixture
     def mock_entry_point(self, iter_entry_points_mock):
         entry_point = mock.Mock()
         entry_point.load = mock.Mock(return_value=DummyExtension)
@@ -147,7 +147,7 @@ class TestLoadExtensions:
 
 
 class TestValidateExtensionData:
-    @pytest.fixture()
+    @pytest.fixture
     def ext_data(self):
         extension = DummyExtension()
         entry_point = mock.Mock()

--- a/tests/test_ext.py
+++ b/tests/test_ext.py
@@ -3,8 +3,8 @@ from importlib import metadata
 from unittest import mock
 
 import pytest
-from mopidy import config, exceptions, ext
 
+from mopidy import config, exceptions, ext
 from tests import IsA, any_unicode
 
 

--- a/tests/test_help.py
+++ b/tests/test_help.py
@@ -9,9 +9,8 @@ import mopidy
 class HelpTest(unittest.TestCase):
     def test_help_has_mopidy_options(self):
         mopidy_dir = Path(mopidy.__file__).parent
-        args = [sys.executable, "-m", "mopidy", "--help"]
-        process = subprocess.Popen(
-            args,
+        process = subprocess.Popen(  # noqa: S603
+            [sys.executable, "-m", "mopidy", "--help"],
             stdout=subprocess.PIPE,
             cwd=mopidy_dir.parent,
         )

--- a/tests/test_httpclient.py
+++ b/tests/test_httpclient.py
@@ -1,6 +1,7 @@
 import re
 
 import pytest
+
 from mopidy import httpclient
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py311, py312, docs, pyright, ruff-lint, ruff-format
+envlist = py311, py312, py313, docs, pyright, ruff-lint, ruff-format
 
 [testenv]
 deps = .[test]


### PR DESCRIPTION
- Bump pyright to 1.1.380
- Bump ruff to 0.6.5 and select the new `ALL` rule. Following from this, a bunch of new lint rules have either been fixed or ignored.
- Test on Python 3.13
