### PR TITLE
Document use as service with PipeWire

### DIFF
--- a/docs/running/service.rst
+++ b/docs/running/service.rst
@@ -212,3 +212,43 @@ instead of adding any config to Mopidy add this to
 :file:`~mopidy/.pulse/client.conf`::
 
     default-server=127.0.0.1
+
+System service and PipeWire
+=============================
+
+When using PipeWire, you'll encounter a situation analogous to the one
+described for PulseAudio: You must configure PipeWire and Mopidy so
+that Mopidy sends the audio to the PipeWire server already running as
+your main user.
+
+First make sure that `pipewire-pulse` is installed; It's the PipeWire
+PulseAudio replacement.
+
+Check whether a configuration file for `pipewire-pulse` is available
+(may depends on the Linux distribution but
+:file:`/etc/pipewire/pipewire-pulse.conf` is standard); If not, copy
+from :file:`usr/share/pipewire/pipewire-pulse.conf`. Then modify that
+file for `pipewire-pulse` to accept sound over TCP from localhost
+(note the uncommented line with ``"tcp:4713"``)::
+
+    pulse.properties = {
+        # the addresses this server listens on
+        server.address = [
+            "unix:native"
+            #"unix:/tmp/something"
+            "tcp:4713"
+            #"tcp:[::]:9999"
+            #"tcp:127.0.0.1:8888"
+        ]
+
+Next, configure Mopidy to use this `pipewire-pulse` server:
+
+.. code-block:: ini
+
+    [audio]
+    output = pulsesink server=127.0.0.1
+
+After this, restart both PipeWire and Mopidy::
+
+    systemctl --user restart pipewire pipewire-pulse
+    sudo systemctl restart mopidy

--- a/docs/running/service.rst
+++ b/docs/running/service.rst
@@ -217,7 +217,7 @@ System service and PipeWire
 =============================
 
 When using PipeWire, you'll encounter a situation analogous to the one
-described for PulseAudio: You must configure PipeWire and Mopidy so
+described for PulseAudio. You must configure PipeWire and Mopidy so
 that Mopidy sends the audio to the PipeWire server already running as
 your main user.
 

--- a/docs/running/service.rst
+++ b/docs/running/service.rst
@@ -213,6 +213,7 @@ instead of adding any config to Mopidy add this to
 
     default-server=127.0.0.1
 
+
 System service and PipeWire
 =============================
 
@@ -225,7 +226,7 @@ First make sure that `pipewire-pulse` is installed; It's the PipeWire
 PulseAudio replacement.
 
 Check whether a configuration file for `pipewire-pulse` is available
-(may depends on the Linux distribution but
+(may depend on the Linux distribution but
 :file:`/etc/pipewire/pipewire-pulse.conf` is standard); If not, copy
 from :file:`/usr/share/pipewire/pipewire-pulse.conf`. Then modify that
 file for `pipewire-pulse` to accept sound over TCP from localhost

--- a/docs/running/service.rst
+++ b/docs/running/service.rst
@@ -227,7 +227,7 @@ PulseAudio replacement.
 Check whether a configuration file for `pipewire-pulse` is available
 (may depends on the Linux distribution but
 :file:`/etc/pipewire/pipewire-pulse.conf` is standard); If not, copy
-from :file:`usr/share/pipewire/pipewire-pulse.conf`. Then modify that
+from :file:`/usr/share/pipewire/pipewire-pulse.conf`. Then modify that
 file for `pipewire-pulse` to accept sound over TCP from localhost
 (note the uncommented line with ``"tcp:4713"``)::
 


### PR DESCRIPTION
Refs: #1974

After I upgraded my Mopidy host to a Raspberry Pi 5, I installed Debian Bookworm and had to reconfigure Mopidy as a service. I suggest to document how to configure PipeWire and Mopidy to work together.