### PR TITLE
Add Mopicon to list of standalone applications

### DIFF
--- a/docs/clients.rst
+++ b/docs/clients.rst
@@ -69,6 +69,7 @@ Lastly, there are Mopidy clients implemented as standalone
 applications:
 
 - `Argos <https://github.com/orontee/argos>`_
+- `Mopicon <https://github.com/nerk/mopicon>`_
 
 .. _mpd-clients:
 


### PR DESCRIPTION
Add 'Mopicon' Flutter standalone application to list of available clients.