### PR TITLE
Add new `appendTrack` method to playlist backends

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ mopidy.log*
 nosetests.xml
 tmp/
 xunit-*.xml
+.pdm-python
+pdm.lock

--- a/src/mopidy/backend.py
+++ b/src/mopidy/backend.py
@@ -435,6 +435,25 @@ class PlaylistsProvider:
         """
         raise NotImplementedError
 
+    def append_track(self, uri: Uri, track: Track) -> Playlist | None:
+        """Add a track at the end of the given playlist.
+
+        Returns the saved playlist or :class:`None` on failure.
+
+        Could be overriden in subclass if it makes sense for the given backend.
+
+        :param uri: the uri of the playlist to modify
+        :param track: the track to append
+        """
+        playlist = self.lookup(uri)
+        if playlist is None:
+            return None
+        new_tracks = [*playlist.tracks, track]
+        new_playlist = playlist.replace(
+            tracks=new_tracks,
+        )
+        return self.save(new_playlist)
+
 
 class BackendListener(listener.Listener):
     """Marker interface for recipients of events sent by the backend actors.
@@ -511,3 +530,4 @@ class PlaylistsProviderProxy:
     lookup = proxy_method(PlaylistsProvider.lookup)
     refresh = proxy_method(PlaylistsProvider.refresh)
     save = proxy_method(PlaylistsProvider.save)
+    append_track = proxy_method(PlaylistsProvider.append_track)

--- a/src/mopidy/core/playlists.py
+++ b/src/mopidy/core/playlists.py
@@ -11,7 +11,7 @@ from pykka.typing import proxy_method
 from mopidy import exceptions
 from mopidy.core import listener
 from mopidy.internal import validation
-from mopidy.models import Playlist, Ref
+from mopidy.models import Playlist, Ref, Track
 from mopidy.types import UriScheme
 
 logger = logging.getLogger(__name__)
@@ -273,6 +273,22 @@ class PlaylistsController:
             return result
 
         return None
+
+    def append_track(self, uri: Uri, track: Track):
+        """Add a track at the end of the given playlist.
+
+        Returns the saved playlist or :class:`None` on failure.
+
+        Could be overriden in subclass if it makes sense for the given backend.
+
+        :param uri: the uri of the playlist to modify
+        :param track: the track to append
+        """
+        uri_scheme = UriScheme(urllib.parse.urlparse(uri).scheme)
+        backend = self.backends.with_playlists.get(uri_scheme, None)
+        if not backend:
+            return None
+        return backend.playlists.append_track(uri, track)
 
 
 class PlaylistsControllerProxy:

--- a/tests/m3u/test_playlists.py
+++ b/tests/m3u/test_playlists.py
@@ -358,6 +358,17 @@ class M3UPlaylistsProviderTest(unittest.TestCase):
 
         assert item_refs is None
 
+    def test_append_track(self):
+        track_a = Track(uri="dummy:a", name="A", length=60000)
+        playlist = self.core.playlists.create("test")
+        playlist = self.core.playlists.save(playlist.replace(tracks=[track_a]))
+
+        track_b = Track(uri="dummy:b", name="B", length=60000)
+        self.core.playlists.append_track(playlist.uri, track_b)
+
+        playlist = self.core.playlists.lookup(playlist.uri)
+        assert len(playlist.tracks) == 2
+
 
 class M3UPlaylistsProviderBaseDirectoryTest(M3UPlaylistsProviderTest):
     def setUp(self):


### PR DESCRIPTION
The intent is to have a shortcut to  append a track to a playlist, with tidal backend where this is a base operation.

Not sure if it needs more testing / changes in other places. 

Please let me know what you think.

Note: also contains a commit to ignore some pdm related files, not sure if appropriate or not.