### PR TITLE
Update README.rst to stop sending people to gambling site

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -54,7 +54,7 @@ used to select playlists from Spotify.
 .. _Mopidy-MPD: https://mopidy.com/ext/mpd/
 .. _Raspberry Pi: https://www.raspberrypi.org/
 .. _Pirate Audio: https://shop.pimoroni.com/collections/pirate-audio
-.. _Pi Musicbox: https://www.pimusicbox.com/
+.. _Pi Musicbox: https://pimusicbox.github.io/
 
 
 **Getting started**


### PR DESCRIPTION
Changed link to pimusicbox to the project's github page instead of, now defunct, webpage.

The old url for pimusicbox must have been purchased by another company. At best its a gambling site at worst it's hosting malware.