### PR TITLE
Upgrade Ruff

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ docs = [
     "sphinx-autodoc-typehints >= 1.12",
     "sphinx-rtd-theme >= 1.2",
 ]
-ruff = ["ruff == 0.9.9"]
+ruff = ["ruff == 0.11.0"]
 tests = [
     "pytest >= 7.2",
     "pytest-cov >= 4.0",
@@ -144,6 +144,7 @@ ignore = [
     "TD002",   # missing-todo-author
     "TD003",   # missing-todo-link
     "TC003",   # typing-only-standard-library-import
+    "TC006",   # runtime-cast-value
     "TRY003",  # raise-vanilla-args
     "TRY400",  # error-instead-of-exception
     #

--- a/src/mopidy/core/library.py
+++ b/src/mopidy/core/library.py
@@ -58,7 +58,7 @@ class LibraryController:
         uris: Iterable[Uri] | None,
     ) -> dict[BackendProxy, list[Uri] | None]:
         if not uris:
-            return {b: None for b in self.backends.with_library.values()}
+            return dict.fromkeys(self.backends.with_library.values())
 
         result: dict[BackendProxy, list[Uri] | None] = collections.defaultdict(list)
         for uri in uris:
@@ -205,7 +205,7 @@ class LibraryController:
             if backend_uris
         }
 
-        results: dict[Uri, tuple[Image, ...]] = {uri: () for uri in uris}
+        results: dict[Uri, tuple[Image, ...]] = dict.fromkeys(uris, ())
         for backend, future in futures.items():
             with _backend_error_handling(backend):
                 if future.get() is None:

--- a/src/mopidy/http/actor.py
+++ b/src/mopidy/http/actor.py
@@ -223,7 +223,7 @@ class HttpServer(threading.Thread):
         else:
             cookie_secret = file_path.read_text().strip()
             if not cookie_secret:
-                logging.error(
+                logger.error(
                     f"HTTP server could not find cookie secret in {file_path}",
                 )
         return cookie_secret


### PR DESCRIPTION
This PR upgrades Ruff from 0.9.9 to 0.11.0, [disables one noisy rule](https://docs.astral.sh/ruff/rules/runtime-cast-value/) and fixes the rest. (That `logging.error` was a good catch from [`LOG015`](https://docs.astral.sh/ruff/rules/root-logger-call/)).