### PR TITLE
Pin pygobject for now

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "pydantic >= 2.9",
-    "pygobject >= 3.42",
+    "pygobject >= 3.42, <= 3.50.0",
     "pykka >= 4.1",
     "requests >= 2.28",
     "setuptools >= 66",


### PR DESCRIPTION
Seeing as CI fails to build newer versions of `pygobject`, this pins it to the 3.50.0 version [that does seem to pass CI](https://github.com/mopidy/mopidy/actions/runs/13718677504/job/38369038069).

See https://github.com/akx/mopidy/pull/1 to see this passing on my fork.