### PR TITLE
[#2196] Provide an `asyncio` loop throughout the application lifetime

### DIFF
--- a/src/mopidy/http/actor.py
+++ b/src/mopidy/http/actor.py
@@ -15,7 +15,7 @@ import tornado.web
 import tornado.websocket
 from pydantic import TypeAdapter
 
-from mopidy import exceptions, zeroconf
+from mopidy import exceptions, loop, zeroconf
 from mopidy.core import CoreEvent, CoreEventData, CoreListener
 from mopidy.http import Extension, handlers
 from mopidy.internal import formatting, network
@@ -131,7 +131,7 @@ class HttpServer(threading.Thread):
     def run(self) -> None:
         # Since we start Tornado in a another thread than the main thread,
         # we must explicitly create an asyncio loop for the current thread.
-        asyncio.set_event_loop(asyncio.new_event_loop())
+        asyncio.set_event_loop(loop.get_or_create_loop())
 
         self.app = tornado.web.Application(
             self._get_request_handlers(),  # pyright: ignore[reportArgumentType]

--- a/src/mopidy/loop.py
+++ b/src/mopidy/loop.py
@@ -1,0 +1,36 @@
+import asyncio
+
+
+def get_or_create_loop() -> asyncio.AbstractEventLoop:
+    """
+    Get the current event loop or create a new one if there is no current event loop.
+    """
+
+    try:
+        return asyncio.get_running_loop()
+    except RuntimeError:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        return loop
+
+
+def stop_loop(loop: asyncio.AbstractEventLoop) -> None:
+    """
+    Stop the event loop and wait for it to finish.
+    """
+
+    try:
+        loop.call_soon_threadsafe(loop.stop)
+    except RuntimeError:
+        pass
+
+    try:
+        loop.run_until_complete(loop.shutdown_asyncgens())
+        loop.run_until_complete(loop.shutdown_default_executor())
+    except (AttributeError, NotImplementedError):
+        pass
+
+    try:
+        loop.close()
+    except RuntimeError:
+        pass


### PR DESCRIPTION
Context: https://github.com/mopidy/mopidy/issues/2196

This PR adds an `asyncio` loop available throughout the application lifetime.

Extensions that want to use the `asyncio` features can then call `asyncio.get_running_loop()` directly, and assume that the loop has already been initialized.

There was already a call to `.set_event_loop()` in the `http` module (used for Tornado) - that's also been changed to avoid creating a new loop and instead reusing the existing one.