### PR TITLE
added a pipewire section to advanced configuration in the docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -108,6 +108,7 @@ watch out for announcements on the `Discourse forum
     :maxdepth: 1
 
     audiosinks
+    pipewire
     icecast
     upnp
 

--- a/docs/pipewire.rst
+++ b/docs/pipewire.rst
@@ -1,0 +1,25 @@
+.. _pipewire:
+
+********
+PipeWire
+********
+
+In order to configure mopidy to work with PipeWire, you need to also have pipewire-pulse
+and run pipewire-pulse as a tcp server, typically in addition to running it via socket.
+
+That is accomplished by setting the following in its configuration. The location depends on your distribution, in Arch Linux it's located at `/usr/share/pipewire/pipewire-pulse.conf`.
+    
+    pulse.properties = {
+        # the addresses this server listens on
+        server.address = [
+            "unix:native"
+            "tcp:4713"
+        ]
+    }
+
+After that is set, configure mopidy to use the pipewire-pulse server (the ports on both configurations must match), in mopidy's config:
+
+    [audio]
+    output = pulsesink server=127.0.0.1:4713
+
+Restart the pipewire-pulse service mopidy, this should be enough to get it working.


### PR DESCRIPTION
I noticed that the documentation didn't show how to get mopidy working with pipewire, but configuring it has [been solved](https://github.com/mopidy/mopidy/issues/1974#issuecomment-797105715) already 4 years ago.

This PR is to add this information to the advanced configuration session. 