### PR TITLE
refactor!: Stop exporting `mopidy.core.PlaybackState`

### DIFF
--- a/docs/api/core.rst
+++ b/docs/api/core.rst
@@ -135,7 +135,7 @@ Playback states
 .. automethod:: mopidy.core.PlaybackController.get_state
 .. automethod:: mopidy.core.PlaybackController.set_state
 
-.. class:: mopidy.core.PlaybackState
+.. class:: mopidy.types.PlaybackState
 
   .. attribute:: STOPPED
     :annotation: = 'stopped'

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -61,6 +61,9 @@ pass a lot less data over the network when using tracklist IDs in API calls.
   - :mod:`mopidy.core.playlists`
   - :mod:`mopidy.core.tracklist`
 
+- Moved :class:`mopidy.core.PlaybackState` to
+  :class:`mopidy.types.PlaybackState`.
+
 Root object
 ^^^^^^^^^^^
 

--- a/src/mopidy/core/__init__.py
+++ b/src/mopidy/core/__init__.py
@@ -3,7 +3,7 @@ from ._history import HistoryController, HistoryControllerProxy
 from ._library import LibraryController, LibraryControllerProxy
 from ._listener import CoreEvent, CoreEventData, CoreListener
 from ._mixer import MixerController, MixerControllerProxy
-from ._playback import PlaybackController, PlaybackControllerProxy, PlaybackState
+from ._playback import PlaybackController, PlaybackControllerProxy
 from ._playlists import PlaylistsController, PlaylistsControllerProxy
 from ._tracklist import TracklistController, TracklistControllerProxy
 
@@ -21,7 +21,6 @@ __all__ = [
     "MixerControllerProxy",
     "PlaybackController",
     "PlaybackControllerProxy",
-    "PlaybackState",
     "PlaylistsController",
     "PlaylistsControllerProxy",
     "TracklistController",

--- a/src/mopidy/core/_listener.py
+++ b/src/mopidy/core/_listener.py
@@ -114,9 +114,9 @@ class CoreListener(listener.Listener):
         *MAY* be implemented by actor.
 
         :param old_state: the state before the change
-        :type old_state: string from :class:`mopidy.core.PlaybackState` field
+        :type old_state: string from :class:`mopidy.types.PlaybackState` field
         :param new_state: the state after the change
-        :type new_state: string from :class:`mopidy.core.PlaybackState` field
+        :type new_state: string from :class:`mopidy.types.PlaybackState` field
         """
 
     def tracklist_changed(self) -> None:

--- a/tests/core/test_listener.py
+++ b/tests/core/test_listener.py
@@ -1,8 +1,9 @@
 import unittest
 from unittest import mock
 
-from mopidy.core import CoreListener, PlaybackState
+from mopidy.core import CoreListener
 from mopidy.models import Playlist, TlTrack, Track
+from mopidy.types import PlaybackState
 
 
 class CoreListenerTest(unittest.TestCase):

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -8,6 +8,7 @@ from mopidy import backend, core
 from mopidy.internal import deprecation
 from mopidy.internal.models import PlaybackControllerState
 from mopidy.models import Track
+from mopidy.types import PlaybackState
 from tests import dummy_audio, dummy_backend
 
 
@@ -850,19 +851,19 @@ class TestUnplayableURI(BaseTest):
 
     def test_pause_changes_state_even_if_track_is_unplayable(self):
         self.core.playback.pause()
-        assert self.core.playback.get_state() == core.PlaybackState.PAUSED
+        assert self.core.playback.get_state() == PlaybackState.PAUSED
 
     def test_resume_does_nothing_if_track_is_unplayable(self):
-        self.core.playback.set_state(core.PlaybackState.PAUSED)
+        self.core.playback.set_state(PlaybackState.PAUSED)
         self.core.playback.resume()
 
-        assert self.core.playback.get_state() == core.PlaybackState.PAUSED
+        assert self.core.playback.get_state() == PlaybackState.PAUSED
 
     def test_stop_changes_state_even_if_track_is_unplayable(self):
-        self.core.playback.set_state(core.PlaybackState.PAUSED)
+        self.core.playback.set_state(PlaybackState.PAUSED)
         self.core.playback.stop()
 
-        assert self.core.playback.get_state() == core.PlaybackState.STOPPED
+        assert self.core.playback.get_state() == PlaybackState.STOPPED
 
     def test_time_position_returns_0_if_track_is_unplayable(self):
         result = self.core.playback.get_time_position()
@@ -870,7 +871,7 @@ class TestUnplayableURI(BaseTest):
         assert result == 0
 
     def test_seek_fails_for_unplayable_track(self):
-        self.core.playback.set_state(core.PlaybackState.PLAYING)
+        self.core.playback.set_state(PlaybackState.PLAYING)
         success = self.core.playback.seek(1000)
 
         assert not success
@@ -905,7 +906,7 @@ class TestSeek(BaseTest):
         self.replay_events()
 
         self.core.playback.seek(1000)
-        assert self.core.playback.get_state() == core.PlaybackState.PLAYING
+        assert self.core.playback.get_state() == PlaybackState.PLAYING
 
     def test_seek_paused_stay_paused(self):
         tl_tracks = self.core.tracklist.get_tl_tracks()
@@ -917,7 +918,7 @@ class TestSeek(BaseTest):
         self.replay_events()
 
         self.core.playback.seek(1000)
-        assert self.core.playback.get_state() == core.PlaybackState.PAUSED
+        assert self.core.playback.get_state() == PlaybackState.PAUSED
 
     def test_seek_race_condition_after_about_to_finish(self):
         tl_tracks = self.core.tracklist.get_tl_tracks()
@@ -938,7 +939,7 @@ class TestSeek(BaseTest):
 
         self.core.playback.seek(1000)
         self.replay_events()
-        assert self.core.playback.get_state() == core.PlaybackState.PLAYING
+        assert self.core.playback.get_state() == PlaybackState.PLAYING
 
 
 class TestStream(BaseTest):


### PR DESCRIPTION
Use `mopidy.types.PlaybackState` instead.