### PR TITLE
fix: Work around GLib >= 2.88 with pygobject < 3.55.3 crash

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -32,6 +32,9 @@ the latest Debian stable release, Debian 13 Trixie.
 - PyGObject >= 3.50 is now an explicit Python dependency. Previously we assumed
   that you would install this together with your GStreamer installation.
 
+    We also added a workaround to not crash when using PyGObject < 3.55.3
+    together with GLib >= 2.88. (!2248)
+
 - Pykka >= 4.1 is now required.
 
 - Pydantic >= 2.10 is now required. This is a new dependency for Mopidy to

--- a/src/mopidy/_lib/gi.py
+++ b/src/mopidy/_lib/gi.py
@@ -27,6 +27,18 @@ except ValueError:
 
 from gi.repository import GLib, GObject, Gst, GstBase, GstPbutils
 
+try:
+    # GLib 2.88 split Unix-specific APIs into a separate typelib
+    gi.require_version("GLibUnix", "2.0")
+    from gi.repository import (
+        GLibUnix,  # pyright: ignore[reportAttributeAccessIssue]  # ty:ignore[unresolved-import]
+    )
+
+    _unix_signal_add = GLibUnix.signal_add
+except (ValueError, ImportError, AttributeError):
+    # Remove this branch once we require GLib >= 2.88 and pygobject >= 3.55.3
+    _unix_signal_add = GLib.unix_signal_add
+
 logger = logging.getLogger(__name__)
 
 Gst.init([])
@@ -46,7 +58,7 @@ if Gst.version() < REQUIRED_GST_VERSION:
 def create_glib_loop() -> GLib.MainLoop:
     logger.debug("Creating GLib mainloop")
     loop = GLib.MainLoop()
-    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, _on_sigterm, loop)
+    _unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, _on_sigterm, loop)
     _use_glib_loop_for_dbus()
     return loop
 


### PR DESCRIPTION
GLib 2.88 split out a `GLibUnix` module and moved the `GLib.unix_signal_add()` function there. 

pygobject 3.55.3 made both the old and new import work, but if using an older pygobject, Mopidy would crash on startup with:

```python
Traceback (most recent call last):
  File "/home/jodal/mopidy-dev/.venv/bin/mopidy", line 10, in <module>
    sys.exit(app.meta())
             ~~~~~~~~^^
  File "/home/jodal/mopidy-dev/.venv/lib/python3.14/site-packages/cyclopts/core.py", line 1889, in __call__
    result = _run_maybe_async_command(command, bound, resolved_backend)
  File "/home/jodal/mopidy-dev/.venv/lib/python3.14/site-packages/cyclopts/_run.py", line 50, in _run_maybe_async_command
    return command(*bound.args, **bound.kwargs)
  File "/home/jodal/mopidy-dev/mopidy/src/mopidy/_app/cli.py", line 201, in launcher
    app(tokens)
    ~~~^^^^^^^^
  File "/home/jodal/mopidy-dev/.venv/lib/python3.14/site-packages/cyclopts/core.py", line 1889, in __call__
    result = _run_maybe_async_command(command, bound, resolved_backend)
  File "/home/jodal/mopidy-dev/.venv/lib/python3.14/site-packages/cyclopts/_run.py", line 50, in _run_maybe_async_command
    return command(*bound.args, **bound.kwargs)
  File "/home/jodal/mopidy-dev/mopidy/src/mopidy/_app/server.py", line 44, in command
    loop = gi.create_glib_loop()
  File "/home/jodal/mopidy-dev/mopidy/src/mopidy/_lib/gi.py", line 49, in create_glib_loop
    GLib.unix_signal_add(GLib.PRIORITY_DEFAULT, signal.SIGTERM, _on_sigterm, loop)
    ^^^^^^^^^^^^^^^^^^^^
  File "/home/jodal/mopidy-dev/.venv/lib/python3.14/site-packages/gi/overrides/__init__.py", line 36, in __getattr__
    return getattr(self._introspection_module, name)
  File "/home/jodal/mopidy-dev/.venv/lib/python3.14/site-packages/gi/module.py", line 120, in __getattr__
    raise AttributeError(f"{self.__name__!r} object has no attribute {name!r}")
AttributeError: 'gi.repository.GLib' object has no attribute 'unix_signal_add'
```

This PR adds conditional imports to attempt to keep working with all version combinations.