### PR TITLE
refactor: Replace requests with httpx

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -47,7 +47,7 @@ the latest Debian stable release, Debian 13 Trixie.
   via Cyclopts, which we've started to use directly as well to handle colorized
   log output.
 
-- Requests >= 2.32 is now required.
+- Replaced Requests with HTTPX. HTTPX >= 0.28.1 is now required.
 
 - Tornado >= 6.4 is now required.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ classifiers = [
 dynamic = ["version"]
 dependencies = [
     "cyclopts >= 3.12",
+    "httpx >= 0.28.1",
     "platformdirs >= 4.3",
     "pydantic >= 2.10",
     "pygobject >= 3.50",
     "pykka >= 4.1",
-    "requests >= 2.32",
     "rich >= 13.9",
     "tornado >= 6.4",
 ]
@@ -69,14 +69,13 @@ tests = [
     "polyfactory >= 3.1",
     "pytest >= 8.3",
     "pytest-cov >= 5.0",
+    "pytest-httpx >= 0.35",
     "pytest-mock >= 3.14",
-    "responses >= 0.25",
 ]
 typing = [
     "pygobject-stubs >= 2.14.0, != 2.15.0",
     "pyright == 1.1.408",
     "ty == 0.0.14",
-    "types-requests >= 2.32",
 ]
 
 

--- a/src/mopidy/_exts/stream/actor.py
+++ b/src/mopidy/_exts/stream/actor.py
@@ -4,8 +4,8 @@ import re
 import time
 import urllib.parse
 
+import httpx
 import pykka
-import requests
 
 from mopidy import audio as audio_lib
 from mopidy import backend, exceptions
@@ -29,7 +29,7 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
             proxy_config=config["proxy"],
         )
 
-        self._session = http.get_requests_session(
+        self._http_client = http.get_httpx_client(
             proxy_config=config["proxy"],
             user_agent=(f"{Extension.dist_name}/{Extension.version}"),
         )
@@ -55,6 +55,9 @@ class StreamBackend(pykka.ThreadingActor, backend.Backend):
             uri_schemes -= {UriScheme("file")}
         StreamBackend.uri_schemes = sorted(uri_schemes)
 
+    def on_stop(self) -> None:
+        self._http_client.close()
+
 
 class StreamLibraryProvider(backend.LibraryProvider):
     backend: StreamBackend
@@ -71,7 +74,7 @@ class StreamLibraryProvider(backend.LibraryProvider):
             uri,
             timeout=self.backend._timeout,
             scanner=self.backend._scanner,
-            requests_session=self.backend._session,
+            http_client=self.backend._http_client,
         )
 
         if scan_result:
@@ -102,7 +105,7 @@ class StreamPlaybackProvider(backend.PlaybackProvider):
             uri,
             timeout=self.backend._timeout,
             scanner=self.backend._scanner,
-            requests_session=self.backend._session,
+            http_client=self.backend._http_client,
         )
         return unwrapped_uri
 
@@ -111,7 +114,7 @@ def _unwrap_stream(  # noqa: PLR0911  # TODO: cleanup the return value of this.
     uri: Uri,
     timeout: float,
     scanner: scan.Scanner,
-    requests_session: requests.Session,
+    http_client: httpx.Client,
 ) -> tuple[Uri | None, scan._Result | None]:
     """Get a stream URI from a playlist URI, `uri`.
 
@@ -166,7 +169,7 @@ def _unwrap_stream(  # noqa: PLR0911  # TODO: cleanup the return value of this.
                 timeout,
             )
             return None, None
-        content = http.download(requests_session, uri, timeout=download_timeout / 1000)
+        content = http.download(http_client, uri, timeout=download_timeout / 1000)
 
         if content is None:
             logger.info(

--- a/src/mopidy/_exts/stream/http.py
+++ b/src/mopidy/_exts/stream/http.py
@@ -4,7 +4,7 @@ import logging
 import time
 from typing import TYPE_CHECKING
 
-import requests
+import httpx
 
 from mopidy import httpclient
 
@@ -14,58 +14,55 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def get_requests_session(
+def get_httpx_client(
     proxy_config: ProxyConfig,
     user_agent: str,
-) -> requests.Session:
-    session = requests.Session()
-
-    if proxy := httpclient.format_proxy(proxy_config):
-        session.proxies.update({"http": proxy, "https": proxy})
-
-    full_user_agent = httpclient.format_user_agent(user_agent)
-    session.headers.update({"user-agent": full_user_agent})
-
-    return session
+) -> httpx.Client:
+    return httpx.Client(
+        proxy=httpclient.format_proxy(proxy_config),
+        headers={"user-agent": httpclient.format_user_agent(user_agent)},
+        follow_redirects=True,
+    )
 
 
 def download(
-    session: requests.Session,
+    client: httpx.Client,
     uri: str,
     timeout: float = 1.0,
     chunk_size: int = 4096,
 ) -> bytes | None:
     try:
-        response = session.get(uri, stream=True, timeout=timeout)
-    except requests.exceptions.Timeout:
+        with client.stream("GET", uri, timeout=timeout) as response:
+            content = []
+            deadline = time.time() + timeout
+            for chunk in response.iter_bytes(chunk_size):
+                content.append(chunk)
+                if time.time() > deadline:
+                    logger.warning(
+                        "Download of %r failed due to download taking more than %.3fs",
+                        uri,
+                        timeout,
+                    )
+                    return None
+
+            if not response.is_success:
+                logger.warning(
+                    "Problem downloading %r: %s", uri, response.reason_phrase
+                )
+                return None
+
+            return b"".join(content)
+    except httpx.TimeoutException:
         logger.warning(
             "Download of %r failed due to connection timeout after %.3fs",
             uri,
             timeout,
         )
         return None
-    except requests.exceptions.InvalidSchema:
+    except httpx.UnsupportedProtocol:
         logger.warning("Download of %r failed due to unsupported schema", uri)
         return None
-    except requests.exceptions.RequestException as exc:
+    except httpx.HTTPError as exc:
         logger.warning("Download of %r failed: %s", uri, exc)
         logger.debug("Download exception details", exc_info=True)
         return None
-
-    content = []
-    deadline = time.time() + timeout
-    for chunk in response.iter_content(chunk_size):
-        content.append(chunk)
-        if time.time() > deadline:
-            logger.warning(
-                "Download of %r failed due to download taking more than %.3fs",
-                uri,
-                timeout,
-            )
-            return None
-
-    if not response.ok:
-        logger.warning("Problem downloading %r: %s", uri, response.reason)
-        return None
-
-    return b"".join(content)

--- a/tests/_exts/stream/test_http.py
+++ b/tests/_exts/stream/test_http.py
@@ -1,8 +1,8 @@
 from unittest import mock
 
+import httpx
 import pytest
-import requests
-import responses
+from pytest_httpx import HTTPXMock
 
 from mopidy._exts.stream import http
 
@@ -12,31 +12,28 @@ BODY = "This is the contents of foo.txt."
 
 
 @pytest.fixture
-def session():
-    return requests.Session()
+def client():
+    client = httpx.Client()
+    yield client
+    client.close()
 
 
-@pytest.fixture
-def session_mock():
-    return mock.Mock(spec=requests.Session)
+def test_download_on_server_side_error(httpx_mock: HTTPXMock, client, caplog):
+    httpx_mock.add_response(url=URI, status_code=500, text=BODY)
 
-
-@responses.activate
-def test_download_on_server_side_error(session, caplog):
-    responses.add(responses.GET, URI, body=BODY, status=500)
-
-    result = http.download(session, URI)
+    result = http.download(client, URI)
 
     assert result is None
     assert "Problem downloading" in caplog.text
 
 
-def test_download_times_out_if_connection_times_out(session_mock, caplog):
-    session_mock.get.side_effect = requests.exceptions.Timeout
+def test_download_times_out_if_connection_times_out(
+    httpx_mock: HTTPXMock, client, caplog
+):
+    httpx_mock.add_exception(httpx.TimeoutException("timed out"), url=URI)
 
-    result = http.download(session_mock, URI, timeout=1.0)
+    result = http.download(client, URI, timeout=1.0)
 
-    session_mock.get.assert_called_once_with(URI, timeout=1.0, stream=True)
     assert result is None
     assert (
         f"Download of {URI!r} failed due to connection timeout after 1.000s"
@@ -44,14 +41,13 @@ def test_download_times_out_if_connection_times_out(session_mock, caplog):
     )
 
 
-@responses.activate
-def test_download_times_out_if_download_is_slow(session, caplog):
-    responses.add(responses.GET, URI, body=BODY, content_type="text/plain")
+def test_download_times_out_if_download_is_slow(httpx_mock: HTTPXMock, client, caplog):
+    httpx_mock.add_response(url=URI, status_code=200, text=BODY)
 
     with mock.patch.object(http, "time") as time_mock:
         time_mock.time.side_effect = [0, TIMEOUT + 1]
 
-        result = http.download(session, URI)
+        result = http.download(client, URI)
 
     assert result is None
     assert (

--- a/tests/_exts/stream/test_playback.py
+++ b/tests/_exts/stream/test_playback.py
@@ -2,9 +2,9 @@ import logging
 from pathlib import Path
 from unittest import mock
 
+import httpx
 import pytest
-import requests.exceptions
-import responses
+from pytest_httpx import HTTPXMock
 
 from mopidy import exceptions
 from mopidy._exts.stream import actor
@@ -56,8 +56,9 @@ def provider(backend):
 
 
 class TestTranslateURI:
-    @responses.activate
-    def test_audio_stream_returns_same_uri(self, scanner, provider):
+    def test_audio_stream_returns_same_uri(
+        self, httpx_mock: HTTPXMock, scanner, provider
+    ):
         scanner.scan.side_effect = [
             # Set playable to False to test detection by mimetype
             mock.Mock(mime="audio/mpeg", playable=False),
@@ -68,8 +69,9 @@ class TestTranslateURI:
         scanner.scan.assert_called_once_with(STREAM_URI, timeout=mock.ANY)
         assert result == STREAM_URI
 
-    @responses.activate
-    def test_playable_ogg_stream_is_not_considered_a_playlist(self, scanner, provider):
+    def test_playable_ogg_stream_is_not_considered_a_playlist(
+        self, httpx_mock: HTTPXMock, scanner, provider
+    ):
         scanner.scan.side_effect = [
             # Set playable to True to ignore detection as possible playlist
             mock.Mock(mime="application/ogg", playable=True),
@@ -80,8 +82,9 @@ class TestTranslateURI:
         scanner.scan.assert_called_once_with(STREAM_URI, timeout=mock.ANY)
         assert result == STREAM_URI
 
-    @responses.activate
-    def test_text_playlist_with_mpeg_stream(self, scanner, provider, caplog):
+    def test_text_playlist_with_mpeg_stream(
+        self, httpx_mock: HTTPXMock, scanner, provider, caplog
+    ):
         caplog.set_level(logging.DEBUG)
         scanner.scan.side_effect = [
             # Scanning playlist
@@ -89,11 +92,11 @@ class TestTranslateURI:
             # Scanning stream
             mock.Mock(mime="audio/mpeg", playable=True),
         ]
-        responses.add(
-            responses.GET,
-            PLAYLIST_URI,
-            body=BODY,
-            content_type="audio/x-mpegurl",
+        httpx_mock.add_response(
+            url=PLAYLIST_URI,
+            status_code=200,
+            text=BODY,
+            headers={"content-type": "audio/x-mpegurl"},
         )
 
         result = provider.translate_uri(PLAYLIST_URI)
@@ -110,26 +113,25 @@ class TestTranslateURI:
         assert f"Unwrapping stream from URI: {STREAM_URI}" in caplog.text
         assert f"Unwrapped potential audio/mpeg stream: {STREAM_URI}" in caplog.text
 
-        # Check proper Requests session setup
-        assert (
-            responses.calls[0]
-            .request.headers["User-Agent"]
-            .startswith("mopidy-stream/")
-        )
+        # Check proper HTTPX client setup
+        request = httpx_mock.get_request()
+        assert request is not None
+        assert request.headers["User-Agent"].startswith("mopidy-stream/")
 
-    @responses.activate
-    def test_xml_playlist_with_mpeg_stream(self, scanner, provider):
+    def test_xml_playlist_with_mpeg_stream(
+        self, httpx_mock: HTTPXMock, scanner, provider
+    ):
         scanner.scan.side_effect = [
             # Scanning playlist
             mock.Mock(mime="application/xspf+xml", playable=False),
             # Scanning stream
             mock.Mock(mime="audio/mpeg", playable=True),
         ]
-        responses.add(
-            responses.GET,
-            PLAYLIST_URI,
-            body=BODY,
-            content_type="application/xspf+xml",
+        httpx_mock.add_response(
+            url=PLAYLIST_URI,
+            status_code=200,
+            text=BODY,
+            headers={"content-type": "application/xspf+xml"},
         )
 
         result = provider.translate_uri(PLAYLIST_URI)
@@ -140,8 +142,9 @@ class TestTranslateURI:
         ]
         assert result == STREAM_URI
 
-    @responses.activate
-    def test_scan_fails_but_playlist_parsing_succeeds(self, scanner, provider, caplog):
+    def test_scan_fails_but_playlist_parsing_succeeds(
+        self, httpx_mock: HTTPXMock, scanner, provider, caplog
+    ):
         caplog.set_level(logging.DEBUG)
         scanner.scan.side_effect = [
             # Scanning playlist
@@ -149,11 +152,11 @@ class TestTranslateURI:
             # Scanning stream
             mock.Mock(mime="audio/mpeg", playable=True),
         ]
-        responses.add(
-            responses.GET,
-            PLAYLIST_URI,
-            body=BODY,
-            content_type="audio/x-mpegurl",
+        httpx_mock.add_response(
+            url=PLAYLIST_URI,
+            status_code=200,
+            text=BODY,
+            headers={"content-type": "audio/x-mpegurl"},
         )
 
         result = provider.translate_uri(PLAYLIST_URI)
@@ -164,15 +167,16 @@ class TestTranslateURI:
         assert f"Unwrapped potential audio/mpeg stream: {STREAM_URI}" in caplog.text
         assert result == STREAM_URI
 
-    @responses.activate
-    def test_scan_fails_and_playlist_parsing_fails(self, scanner, provider, caplog):
+    def test_scan_fails_and_playlist_parsing_fails(
+        self, httpx_mock: HTTPXMock, scanner, provider, caplog
+    ):
         caplog.set_level(logging.DEBUG)
         scanner.scan.side_effect = exceptions.ScannerError("some failure")
-        responses.add(
-            responses.GET,
-            STREAM_URI,
-            body=b"some audio data",
-            content_type="audio/mpeg",
+        httpx_mock.add_response(
+            url=STREAM_URI,
+            status_code=200,
+            content=b"some audio data",
+            headers={"content-type": "audio/mpeg"},
         )
 
         result = provider.translate_uri(STREAM_URI)
@@ -185,16 +189,13 @@ class TestTranslateURI:
         )
         assert result == STREAM_URI
 
-    @responses.activate
-    def test_failed_download_returns_none(self, scanner, provider, caplog):
+    def test_failed_download_returns_none(
+        self, httpx_mock: HTTPXMock, scanner, provider, caplog
+    ):
         caplog.set_level(logging.DEBUG)
         scanner.scan.side_effect = [mock.Mock(mime="text/foo", playable=False)]
 
-        responses.add(
-            responses.GET,
-            PLAYLIST_URI,
-            body=requests.exceptions.HTTPError("Kaboom"),
-        )
+        httpx_mock.add_exception(httpx.HTTPError("Kaboom"), url=PLAYLIST_URI)
 
         result = provider.translate_uri(PLAYLIST_URI)
 
@@ -204,15 +205,17 @@ class TestTranslateURI:
             f"Unwrapping stream from URI ({PLAYLIST_URI}) failed: error downloading URI"
         ) in caplog.text
 
-    @responses.activate
-    def test_playlist_references_itself(self, scanner, provider, caplog):
+    def test_playlist_references_itself(
+        self, httpx_mock: HTTPXMock, scanner, provider, caplog
+    ):
         caplog.set_level(logging.DEBUG)
         scanner.scan.side_effect = [mock.Mock(mime="text/foo", playable=False)]
-        responses.add(
-            responses.GET,
-            PLAYLIST_URI,
-            body=BODY.replace(STREAM_URI, PLAYLIST_URI),
-            content_type="audio/x-mpegurl",
+        httpx_mock.add_response(
+            url=PLAYLIST_URI,
+            status_code=200,
+            text=BODY.replace(STREAM_URI, PLAYLIST_URI),
+            headers={"content-type": "audio/x-mpegurl"},
+            is_reusable=True,
         )
 
         result = provider.translate_uri(PLAYLIST_URI)
@@ -227,8 +230,9 @@ class TestTranslateURI:
         ) in caplog.text
         assert result is None
 
-    @responses.activate
-    def test_playlist_with_relative_mpeg_stream(self, scanner, provider, caplog):
+    def test_playlist_with_relative_mpeg_stream(
+        self, httpx_mock: HTTPXMock, scanner, provider, caplog
+    ):
         caplog.set_level(logging.DEBUG)
         scanner.scan.side_effect = [
             # Scanning playlist
@@ -236,11 +240,11 @@ class TestTranslateURI:
             # Scanning stream
             mock.Mock(mime="audio/mpeg", playable=True),
         ]
-        responses.add(
-            responses.GET,
-            PLAYLIST_URI,
-            body=BODY.replace(STREAM_URI, Path(STREAM_URI).name),
-            content_type="audio/x-mpegurl",
+        httpx_mock.add_response(
+            url=PLAYLIST_URI,
+            status_code=200,
+            text=BODY.replace(STREAM_URI, Path(STREAM_URI).name),
+            headers={"content-type": "audio/x-mpegurl"},
         )
 
         result = provider.translate_uri(PLAYLIST_URI)


### PR DESCRIPTION
HTTPX is just as solid a choice as Requests, but includes complete type hints and support asyncio and HTTP/2.