### PR TITLE
Require at least cycleopts 4.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
-    "cyclopts >= 3.12",
+    "cyclopts >= 4.3",
     "httpx >= 0.28.1",
     "platformdirs >= 4.3",
     "pydantic >= 2.10",


### PR DESCRIPTION
With any version lower I get the following errors in the tests:
```
tests/_app/test_cli.py:5: in <module>
    from mopidy._app import cli
src/mopidy/_app/cli.py:57: in <module>
    @Parameter(
../.venv/lib/python3.14/site-packages/cyclopts/utils.py:56: in new_init
    original_init(self, *args, **kwargs)
E   TypeError: Parameter.__init__() got an unexpected keyword argument 'n_tokens'
```