### PR TITLE
fix: Bump tornado from >= 6.4 to >= 6.4.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "pygobject >= 3.50",
     "pykka >= 4.1",
     "rich >= 13.9",
-    "tornado >= 6.4",
+    "tornado >= 6.4.2",
 ]
 
 [project.urls]


### PR DESCRIPTION
6.4.2 is the exact version in Debian stable, and we seem to be relying on testing improvements that landed in 6.4.1.