### PR TITLE
Adjust models to handle real-world ID3 tags

### DIFF
--- a/src/mopidy/models/_models.py
+++ b/src/mopidy/models/_models.py
@@ -45,7 +45,7 @@ class Artist(BaseModel):
     sortname: str | None = None
     """Artist name for better sorting, e.g. with articles stripped."""
 
-    musicbrainz_id: UUID | None = None
+    musicbrainz_id: str | None = None
     """The MusicBrainz ID of the artist."""
 
 
@@ -75,11 +75,11 @@ class Album(BaseModel):
 
     date: DateOrYear | None = Field(
         default=None,
-        pattern=r"^\d{4}(-\d{2}-\d{2})?$",
+        pattern=r"^\d{4}((-\d{2})+)?$",
     )
-    """The album release date. A string formatted as "YYYY" or "YYYY-MM-DD"."""
+    """The album release date. A string formatted as "YYYY", "YYYY-MM", or" "YYYY-MM-DD"."""
 
-    musicbrainz_id: UUID | None = None
+    musicbrainz_id: str | None = None
     """The MusicBrainz ID of the album."""
 
 
@@ -121,9 +121,9 @@ class Track(BaseModel):
 
     date: DateOrYear | None = Field(
         default=None,
-        pattern=r"^\d{4}(-\d{2}-\d{2})?$",
+        pattern=r"^\d{4}((-\d{2})+)?$",
     )
-    """The track release date. A string formatted as "YYYY" or "YYYY-MM-DD"."""
+    """The track release date. A string formatted as "YYYY", "YYYY-MM", or" "YYYY-MM-DD"."""
 
     length: DurationMs | None = None
     """The track length in milliseconds."""
@@ -134,7 +134,7 @@ class Track(BaseModel):
     comment: str | None = None
     """The track comment."""
 
-    musicbrainz_id: UUID | None = None
+    musicbrainz_id: str | None = None
     """The MusicBrainz ID of the track."""
 
     last_modified: NonNegativeInt | None = None

--- a/src/mopidy/models/_models.py
+++ b/src/mopidy/models/_models.py
@@ -1,5 +1,4 @@
 from typing import Literal
-from uuid import UUID
 
 from pydantic.fields import Field
 from pydantic.types import NonNegativeInt

--- a/src/mopidy/models/_models.py
+++ b/src/mopidy/models/_models.py
@@ -77,7 +77,7 @@ class Album(BaseModel):
         default=None,
         pattern=r"^\d{4}((-\d{2})+)?$",
     )
-    """The album release date. A string formatted as "YYYY", "YYYY-MM", or" "YYYY-MM-DD"."""
+    """The album date. A string formatted as "YYYY", "YYYY-MM", or" "YYYY-MM-DD"."""
 
     musicbrainz_id: str | None = None
     """The MusicBrainz ID of the album."""
@@ -123,7 +123,7 @@ class Track(BaseModel):
         default=None,
         pattern=r"^\d{4}((-\d{2})+)?$",
     )
-    """The track release date. A string formatted as "YYYY", "YYYY-MM", or" "YYYY-MM-DD"."""
+    """The track date. A string formatted as "YYYY", "YYYY-MM", or" "YYYY-MM-DD"."""
 
     length: DurationMs | None = None
     """The track length in milliseconds."""

--- a/tests/models/test_album.py
+++ b/tests/models/test_album.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import pydantic
 import pytest
 

--- a/tests/models/test_album.py
+++ b/tests/models/test_album.py
@@ -59,7 +59,7 @@ def test_date():
 def test_musicbrainz_id():
     mb_id = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
     album = AlbumFactory.build(musicbrainz_id=mb_id)
-    assert album.musicbrainz_id == UUID(mb_id)
+    assert album.musicbrainz_id == mb_id
     with pytest.raises(pydantic.ValidationError):
         album.musicbrainz_id = None
 

--- a/tests/models/test_artist.py
+++ b/tests/models/test_artist.py
@@ -27,7 +27,7 @@ def test_name():
 def test_musicbrainz_id():
     mb_id = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
     artist = ArtistFactory.build(musicbrainz_id=mb_id)
-    assert artist.musicbrainz_id == UUID(mb_id)
+    assert artist.musicbrainz_id == mb_id
     with pytest.raises(pydantic.ValidationError):
         artist.musicbrainz_id = None
 

--- a/tests/models/test_artist.py
+++ b/tests/models/test_artist.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import pydantic
 import pytest
 

--- a/tests/models/test_track.py
+++ b/tests/models/test_track.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import pydantic
 import pytest
 

--- a/tests/models/test_track.py
+++ b/tests/models/test_track.py
@@ -99,7 +99,7 @@ def test_bitrate():
 def test_musicbrainz_id():
     mb_id = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
     track = TrackFactory.build(musicbrainz_id=mb_id)
-    assert track.musicbrainz_id == UUID(mb_id)
+    assert track.musicbrainz_id == mb_id
     with pytest.raises(pydantic.ValidationError):
         track.musicbrainz_id = None
 


### PR DESCRIPTION
As described here https://github.com/mopidy/mopidy-local/issues/92, in the real world, ID3 tags don't always conform to what you'd like them to if you're being strict about your internal datatypes.

In particular with my collection of 21,000 files I had about 3000 that couldn't be scanned by mopidy local scan due to their tags not meeting the exact requirements of mopidy's new models. There is no chance at all that I can fix the tags, indeed some of them have come from Musicbrainz so mopidy needs to be able to handle them. I proposed in that link that they should be sanitised before being added to models but in fact this simple change makes all but 129 of those files scannable, and that is a manageable number to fix myself.

Firstly we need to handle dates in the formats yyyy, yyyy-mm, and yyyy-mm-dd

Secondly you cannot safely assume that any musicbrainz ID tag actually contains a UUID. A lot of mine have Discogs IDs in them, and I haven't put those in there deliberatley that's simply how whatever tagger I was using at the time tagged them.
