### PR TITLE
Fix: strip whitespace from media_dirs config entries

### DIFF
--- a/src/mopidy/_exts/file/library.py
+++ b/src/mopidy/_exts/file/library.py
@@ -131,8 +131,8 @@ class FileLibraryProvider(backend.LibraryProvider):
 
     def _get_media_dirs(self, config: config_lib.Config) -> Generator[MediaDir]:
         for entry in config["file"]["media_dirs"]:
-            media_dir_split = entry.split("|", 1)
-            local_path = paths.expand_path(media_dir_split[0])
+            media_dir_split = entry.strip().split("|", 1)
+            local_path = paths.expand_path(media_dir_split[0].strip())
 
             if local_path is None:
                 logger.debug(


### PR DESCRIPTION
Fixes #1965

Extra spaces in file/media_dirs config setting were not being 
ignored, causing valid paths to fail. 

Added .strip() to remove leading/trailing whitespace from each 
entry before processing in _get_media_dirs method.