### PR TITLE
chore: add Nix flake development environment

### DIFF
--- a/.github/workflows/nix.yml
+++ b/.github/workflows/nix.yml
@@ -1,0 +1,24 @@
+name: Nix
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  flake-check:
+    # This workflow is intentionally separate from the main CI matrix.
+    # Its purpose is to warn us when the flake-backed development environment
+    # stops evaluating/building cleanly, so `nix shell`/`nix develop` keep working.
+    name: Keep Nix shell working
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v6
+      - uses: cachix/install-nix-action@v31
+      - name: Verify flake outputs used by the Nix shell
+        run: nix flake check

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 /site/
 __pycache__/
 mopidy.log*
+.envrc
+.direnv
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,48 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "pyproject-nix": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781812259,
+        "narHash": "sha256-uRqDouxg3b0EuOHQd1HhmFZouHebM7pz+H6EWAXd3FM=",
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "rev": "d9847acff422152a03764fd60c96ae0dd9f9fa73",
+        "type": "github"
+      },
+      "original": {
+        "owner": "pyproject-nix",
+        "repo": "pyproject.nix",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "pyproject-nix": "pyproject-nix"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,137 @@
+{
+  description = "Mopidy development flake";
+
+  inputs.nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  inputs.pyproject-nix.url = "github:pyproject-nix/pyproject.nix";
+  inputs.pyproject-nix.inputs.nixpkgs.follows = "nixpkgs";
+
+  outputs =
+    { self, nixpkgs, pyproject-nix }:
+    let
+      lib = nixpkgs.lib;
+      forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+      mopidyVersion = "4.0.0";
+      project = pyproject-nix.lib.project.loadPyproject {
+        projectRoot = ./.;
+      };
+    in
+    let
+      perSystem =
+        system:
+        let
+          pkgs = import nixpkgs { inherit system; };
+          python = pkgs.python313;
+          pyPkgs = python.pkgs // {
+            pygobject = python.pkgs.pygobject3;
+            rumdl = pkgs.rumdl;
+            zensical = pkgs.zensical;
+          };
+
+          mopidyAttrs = project.renderers.buildPythonPackage {
+            inherit python;
+            pythonPackages = pyPkgs;
+            inherit project;
+          };
+
+          mopidy = pyPkgs.buildPythonApplication (
+            mopidyAttrs
+            // {
+              version = mopidyVersion;
+
+              nativeBuildInputs = (mopidyAttrs.nativeBuildInputs or [ ]) ++ [
+                pkgs.wrapGAppsNoGuiHook
+              ];
+
+              preBuild = (mopidyAttrs.preBuild or "") + ''
+                export SETUPTOOLS_SCM_PRETEND_VERSION=${mopidyVersion}
+              '';
+            }
+          );
+
+          pythonEnv = python.withPackages (
+            ps:
+            (project.renderers.withPackages {
+              inherit python;
+              pythonPackages = pyPkgs;
+              inherit project;
+              groups = [
+                "docs"
+                "rumdl"
+                "ruff"
+                "tests"
+              ];
+            } ps)
+            ++ [
+              ps.tox
+              ps.ty
+              ps."pygobject-stubs"
+            ]
+          );
+
+          gstreamerRuntime = with pkgs.gst_all_1; [
+            gstreamer
+            gst-plugins-base
+            gst-plugins-good
+          ] ++ [
+            pkgs.glib-networking
+            pkgs.gobject-introspection
+          ];
+
+          cairoBuildInputs = [
+            pkgs.cairo
+            pkgs.libxcb
+            pkgs.libx11
+            pkgs.xorgproto
+          ];
+
+          cairoIncludePath = pkgs.lib.makeSearchPathOutput "dev" "include" cairoBuildInputs;
+          cairoIncludeFlags = lib.concatMapStringsSep " " (path: "-I${path}") (
+            lib.splitString ":" cairoIncludePath
+          );
+        in
+        {
+          packages = {
+            default = mopidy;
+            mopidy = mopidy;
+            pythonEnv = pythonEnv;
+          };
+
+          devShells.default = pkgs.mkShell {
+            packages = [
+              mopidy
+              pythonEnv
+            ] ++ gstreamerRuntime ++ [
+              pkgs.cairo
+              pkgs.libxcb
+              pkgs.meson
+              pkgs.ninja
+              pkgs.pkg-config
+              pkgs.pyright
+              pkgs.python314
+              pkgs.uv
+              pkgs.libx11
+              pkgs.xorgproto
+            ];
+
+            env = {
+              UV_NO_MANAGED_PYTHON = "1";
+              UV_PYTHON_DOWNLOADS = "never";
+            };
+
+            shellHook = ''
+              export CPATH="${cairoIncludePath}''${CPATH:+:$CPATH}"
+              export CFLAGS="${cairoIncludeFlags} ''${CFLAGS:+$CFLAGS}"
+              export CPPFLAGS="${cairoIncludeFlags} ''${CPPFLAGS:+$CPPFLAGS}"
+              export NIX_CFLAGS_COMPILE="${cairoIncludeFlags} ''${NIX_CFLAGS_COMPILE:+$NIX_CFLAGS_COMPILE}"
+              export PYTHONPATH="$PWD/src:${mopidy}/${python.sitePackages}''${PYTHONPATH:+:$PYTHONPATH}"
+              export GI_TYPELIB_PATH="${pkgs.lib.makeSearchPathOutput "lib" "lib/girepository-1.0" gstreamerRuntime}''${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+              export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gstreamerRuntime}''${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
+            '';
+          };
+        };
+    in
+    {
+      packages = forAllSystems (system: (perSystem system).packages);
+      devShells = forAllSystems (system: (perSystem system).devShells);
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -62,6 +62,7 @@
               ];
             } ps)
             ++ [
+              ps.pygobject3
               ps.tox
               ps.ty
               ps."pygobject-stubs"
@@ -88,8 +89,19 @@
           cairoIncludeFlags = lib.concatMapStringsSep " " (path: "-I${path}") (
             lib.splitString ":" cairoIncludePath
           );
+          giTypelibPath = pkgs.lib.makeSearchPathOutput "lib" "lib/girepository-1.0" gstreamerRuntime;
+          gstPluginSystemPath = pkgs.lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gstreamerRuntime;
         in
         {
+          checks.gst-smoke = pkgs.runCommand "gst-smoke" {
+            nativeBuildInputs = [ pythonEnv ] ++ gstreamerRuntime;
+          } ''
+            export GI_TYPELIB_PATH="${giTypelibPath}''${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+            export GST_PLUGIN_SYSTEM_PATH_1_0="${gstPluginSystemPath}''${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
+            python -c 'import gi; gi.require_version("Gst", "1.0"); from gi.repository import Gst; print(Gst.version_string())'
+            touch "$out"
+          '';
+
           packages = {
             default = mopidy;
             mopidy = mopidy;
@@ -98,8 +110,8 @@
 
           devShells.default = pkgs.mkShell {
             packages = [
-              mopidy
               pythonEnv
+              mopidy
             ] ++ gstreamerRuntime ++ [
               pkgs.cairo
               pkgs.libxcb
@@ -124,13 +136,14 @@
               export CPPFLAGS="${cairoIncludeFlags} ''${CPPFLAGS:+$CPPFLAGS}"
               export NIX_CFLAGS_COMPILE="${cairoIncludeFlags} ''${NIX_CFLAGS_COMPILE:+$NIX_CFLAGS_COMPILE}"
               export PYTHONPATH="$PWD/src:${mopidy}/${python.sitePackages}''${PYTHONPATH:+:$PYTHONPATH}"
-              export GI_TYPELIB_PATH="${pkgs.lib.makeSearchPathOutput "lib" "lib/girepository-1.0" gstreamerRuntime}''${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
-              export GST_PLUGIN_SYSTEM_PATH_1_0="${pkgs.lib.makeSearchPathOutput "lib" "lib/gstreamer-1.0" gstreamerRuntime}''${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
+              export GI_TYPELIB_PATH="${giTypelibPath}''${GI_TYPELIB_PATH:+:$GI_TYPELIB_PATH}"
+              export GST_PLUGIN_SYSTEM_PATH_1_0="${gstPluginSystemPath}''${GST_PLUGIN_SYSTEM_PATH_1_0:+:$GST_PLUGIN_SYSTEM_PATH_1_0}"
             '';
           };
         };
     in
     {
+      checks = forAllSystems (system: (perSystem system).checks);
       packages = forAllSystems (system: (perSystem system).packages);
       devShells = forAllSystems (system: (perSystem system).devShells);
     };

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
     let
       lib = nixpkgs.lib;
       forAllSystems = lib.genAttrs lib.systems.flakeExposed;
+      # WARNING: Keep this in sync with the Mopidy release version.
       mopidyVersion = "4.0.0";
       project = pyproject-nix.lib.project.loadPyproject {
         projectRoot = ./.;
@@ -36,6 +37,10 @@
           mopidy = pyPkgs.buildPythonApplication (
             mopidyAttrs
             // {
+              # TODO: Find a better way to keep version tracking. Nix builds use
+              # a source snapshot without the Git metadata that setuptools-scm
+              # normally reads, so we currently have to pin and inject the
+              # version manually to avoid broken package versions.
               version = mopidyVersion;
 
               nativeBuildInputs = (mopidyAttrs.nativeBuildInputs or [ ]) ++ [

--- a/src/mopidy/_lib/paths.py
+++ b/src/mopidy/_lib/paths.py
@@ -1,4 +1,3 @@
-import configparser
 import logging
 import os
 import pathlib
@@ -22,6 +21,84 @@ XDG_USER_DIR_DEFAULTS = {
     "XDG_PICTURES_DIR": "Pictures",
     "XDG_VIDEOS_DIR": "Videos",
 }
+
+XDG_USER_DIR_NAMES = {
+    name.removeprefix("XDG_").removesuffix("_DIR") for name in XDG_USER_DIR_DEFAULTS
+}
+
+
+def _unescape_xdg_user_dir_value(value: str) -> str:
+    """Decode backslash escapes from XDG user-dir values.
+
+    ``user-dirs.dirs`` is shell-sourceable, so quoted values may contain simple
+    backslash escapes even though Mopidy intentionally does not evaluate shell.
+    """
+    chars: list[str] = []
+    escaped = False
+
+    for char in value:
+        if escaped:
+            chars.append(char)
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        chars.append(char)
+
+    if escaped:
+        chars.append("\\")
+
+    return "".join(chars)
+
+
+def _parse_xdg_assignment_line(
+    line: str, substitutions: dict[str, str] | None = None
+) -> tuple[str, str] | None:
+    """Parse a simple ``KEY=VALUE`` assignment used by XDG user-dir files.
+
+    Both XDG helper files are line-oriented assignment files. We share the
+    minimal parsing here so the file-specific helpers can stay focused on the
+    rules that differ between the two formats.
+    """
+    key, separator, value = line.partition("=")
+    if not separator:
+        return None
+
+    key = key.strip()
+    value = value.strip()
+
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in {'"', "'"}:
+        value = _unescape_xdg_user_dir_value(value[1:-1])
+
+    for old, new in (substitutions or {}).items():
+        value = value.replace(old, new, 1) if value.startswith(old) else value
+
+    return key, value
+
+
+def _parse_xdg_user_dir_line(
+    line: str, home: pathlib.Path
+) -> tuple[str, pathlib.Path] | None:
+    """Parse one ``user-dirs.dirs`` line into a resolved path.
+
+    We accept the documented forms plus a narrow shell-sourceable subset, but
+    still validate the result as either an absolute path or a ``$HOME``
+    descendant before treating it as an XDG user dir.
+    """
+    if parsed_line := _parse_xdg_assignment_line(line, {"$HOME": str(home)}):
+        key, value = parsed_line
+    else:
+        return None
+
+    if key not in XDG_USER_DIR_DEFAULTS:
+        return None
+    if value.startswith((str(home) + "/", "/")):
+        path = pathlib.Path(value).resolve()
+    else:
+        return None
+
+    return key, path
 
 
 def get_xdg_dirs() -> dict[str, pathlib.Path]:
@@ -56,6 +133,13 @@ def get_xdg_dirs() -> dict[str, pathlib.Path]:
 def _read_xdg_user_dir_defaults(
     xdg_defaults_dir: pathlib.Path,
 ) -> dict[str, pathlib.Path]:
+    """Read defaults from ``user-dirs.defaults(5)``.
+
+    The man page documents lines of the form ``NAME=VALUE``, where ``VALUE`` is
+    a relative path from the home directory. We also tolerate surrounding
+    whitespace and optional quoting so lightly hand-edited files still work,
+    while keeping the stricter "relative path only" rule from the format.
+    """
     defaults_file = xdg_defaults_dir / "user-dirs.defaults"
     home = pathlib.Path.home()
 
@@ -71,33 +155,44 @@ def _read_xdg_user_dir_defaults(
         line = line.strip()
         if not line or line.startswith("#"):
             continue
-        key, separator, value = line.partition("=")
-        if not separator:
+
+        if parsed_line := _parse_xdg_assignment_line(line):
+            key, value = parsed_line
+        else:
             continue
-        result[f"XDG_{key.strip()}_DIR"] = (home / value.strip()).resolve()
+
+        if key not in XDG_USER_DIR_NAMES:
+            continue
+        if not value or pathlib.Path(value).is_absolute():
+            continue
+        result[f"XDG_{key}_DIR"] = (home / value).resolve()
 
     return result
 
 
 def _read_xdg_user_dirs(dirs_file: pathlib.Path) -> dict[str, pathlib.Path]:
+    """Read user overrides from ``user-dirs.dirs(5)``.
+
+    The man page documents lines of the form ``XDG_NAME_DIR=VALUE``, where
+    ``VALUE`` must be quoted and be either ``"$HOME/Path"`` or ``"/Path"``.
+    We additionally accept a small shell-sourceable subset with surrounding
+    whitespace and unquoted ``$HOME/...`` or absolute paths so we stay tolerant
+    of realistic manual edits without trying to implement shell.
+    """
     if not dirs_file.exists():
         return {}
 
-    data = dirs_file.read_bytes()
-    data = b"[XDG_USER_DIRS]\n" + data
-    data = data.replace(b"$HOME", bytes(pathlib.Path.home()))
-    data = data.replace(b'"', b"")
-
-    config = configparser.RawConfigParser()
-    config.read_string(data.decode())
-
     result: dict[str, pathlib.Path] = {}
-    for k, v in config.items("XDG_USER_DIRS"):
-        if v is None:  # pyright: ignore[reportUnnecessaryComparison]
+    home = pathlib.Path.home()
+
+    for line in dirs_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
             continue
-        if isinstance(k, bytes):
-            k = k.decode()
-        result[k.upper()] = pathlib.Path(v).resolve()
+
+        if parsed_line := _parse_xdg_user_dir_line(line, home):
+            key, path = parsed_line
+            result[key] = path
 
     return result
 
@@ -115,7 +210,9 @@ def _get_xdg_user_dirs(
     implementation instead of using `glib.get_user_special_dir` we make it
     possible for many extensions to run their test suites, which are importing
     parts of Mopidy, in a virtualenv with global site-packages disabled, and
-    thus no `glib` available.
+    thus no `glib` available. The ordering mirrors the XDG tooling model so we
+    can honor builtin defaults, system defaults, and user overrides without a
+    runtime GLib dependency.
     """
     result = _read_xdg_user_dir_defaults(xdg_defaults_dir)
     result.update(_read_xdg_user_dirs(xdg_config_dir / "user-dirs.dirs"))

--- a/src/mopidy/_lib/paths.py
+++ b/src/mopidy/_lib/paths.py
@@ -11,6 +11,18 @@ from mopidy.types import Uri
 
 logger = logging.getLogger(__name__)
 
+# https://cgit.freedesktop.org/xdg/xdg-user-dirs/tree/user-dirs.defaults
+XDG_USER_DIR_DEFAULTS = {
+    "XDG_DESKTOP_DIR": "Desktop",
+    "XDG_DOWNLOAD_DIR": "Downloads",
+    "XDG_TEMPLATES_DIR": "Templates",
+    "XDG_PUBLICSHARE_DIR": "Public",
+    "XDG_DOCUMENTS_DIR": "Documents",
+    "XDG_MUSIC_DIR": "Music",
+    "XDG_PICTURES_DIR": "Pictures",
+    "XDG_VIDEOS_DIR": "Videos",
+}
+
 
 def get_xdg_dirs() -> dict[str, pathlib.Path]:
     """Returns a dict of all the known XDG Base Directories for the current user.
@@ -41,17 +53,33 @@ def get_xdg_dirs() -> dict[str, pathlib.Path]:
     return dirs
 
 
-def _get_xdg_user_dirs(xdg_config_dir: pathlib.Path) -> dict[str, pathlib.Path]:
-    """Returns a dict of XDG dirs read from `$XDG_CONFIG_HOME/user-dirs.dirs`.
+def _read_xdg_user_dir_defaults(
+    xdg_defaults_dir: pathlib.Path,
+) -> dict[str, pathlib.Path]:
+    defaults_file = xdg_defaults_dir / "user-dirs.defaults"
+    home = pathlib.Path.home()
 
-    This is used at import time for most users of Mopidy. By rolling our own
-    implementation instead of using `glib.get_user_special_dir` we make it
-    possible for many extensions to run their test suites, which are importing
-    parts of Mopidy, in a virtualenv with global site-packages disabled, and
-    thus no `glib` available.
-    """
-    dirs_file = xdg_config_dir / "user-dirs.dirs"
+    result = {
+        key: (home / relative_path).resolve()
+        for key, relative_path in XDG_USER_DIR_DEFAULTS.items()
+    }
 
+    if not defaults_file.exists():
+        return result
+
+    for line in defaults_file.read_text().splitlines():
+        line = line.strip()
+        if not line or line.startswith("#"):
+            continue
+        key, separator, value = line.partition("=")
+        if not separator:
+            continue
+        result[f"XDG_{key.strip()}_DIR"] = (home / value.strip()).resolve()
+
+    return result
+
+
+def _read_xdg_user_dirs(dirs_file: pathlib.Path) -> dict[str, pathlib.Path]:
     if not dirs_file.exists():
         return {}
 
@@ -71,6 +99,26 @@ def _get_xdg_user_dirs(xdg_config_dir: pathlib.Path) -> dict[str, pathlib.Path]:
             k = k.decode()
         result[k.upper()] = pathlib.Path(v).resolve()
 
+    return result
+
+
+def _get_xdg_user_dirs(
+    xdg_config_dir: pathlib.Path,
+    xdg_defaults_dir: pathlib.Path = pathlib.Path("/etc/xdg"),
+) -> dict[str, pathlib.Path]:
+    """Returns XDG user dirs from builtin, system, and user defaults.
+
+    Builtin defaults are overlaid by `$XDG_DEFAULTS_DIR/user-dirs.defaults`,
+    then by `$XDG_CONFIG_HOME/user-dirs.dirs`.
+
+    This is used at import time for most users of Mopidy. By rolling our own
+    implementation instead of using `glib.get_user_special_dir` we make it
+    possible for many extensions to run their test suites, which are importing
+    parts of Mopidy, in a virtualenv with global site-packages disabled, and
+    thus no `glib` available.
+    """
+    result = _read_xdg_user_dir_defaults(xdg_defaults_dir)
+    result.update(_read_xdg_user_dirs(xdg_config_dir / "user-dirs.dirs"))
     return result
 
 

--- a/tests/_app/test_config.py
+++ b/tests/_app/test_config.py
@@ -1,10 +1,14 @@
+from importlib import metadata
 from pathlib import Path
 
 import pytest
 
 import mopidy
 from mopidy._app.config import ConfigLoader
-from mopidy._app.extensions import ExtensionManager
+from mopidy._app.extensions import ExtensionManager, ExtensionRecord, ExtensionStatus
+from mopidy._exts.file import Extension as FileExtension
+from mopidy._exts.m3u import Extension as M3UExtension
+from mopidy._lib import paths
 
 
 def test_load_raw_config():
@@ -187,3 +191,39 @@ def test_config_errors():
         config_manager.errors["core"]["max_tracklist_length"]
         == "invalid literal for int() with base 10: 'not-an-integer'"
     )
+
+
+def test_validate_defaults_with_xdg_user_dir_fallbacks():
+    file_extension = FileExtension()
+    m3u_extension = M3UExtension()
+    extensions = ExtensionManager(
+        {
+            "file": ExtensionRecord(
+                ext_name="file",
+                entry_point=metadata.EntryPoint("file", "mopidy:file", "mopidy.ext"),
+                status=ExtensionStatus.ENABLED,
+                extension=file_extension,
+                config_schema=file_extension.get_config_schema(),
+                config_defaults=file_extension.get_default_config(),
+            ),
+            "m3u": ExtensionRecord(
+                ext_name="m3u",
+                entry_point=metadata.EntryPoint("m3u", "mopidy:m3u", "mopidy.ext"),
+                status=ExtensionStatus.ENABLED,
+                extension=m3u_extension,
+                config_schema=m3u_extension.get_config_schema(),
+                config_defaults=m3u_extension.get_default_config(),
+            ),
+        }
+    )
+
+    config_loader = ConfigLoader.only_defaults(extensions=extensions)
+    config_manager = config_loader.validate()
+
+    assert "file" not in config_manager.errors
+    assert "m3u" not in config_manager.errors
+    assert config_manager.config["file"]["media_dirs"] == (
+        "$XDG_MUSIC_DIR|Music",
+        "~/|Home",
+    )
+    assert config_manager.config["m3u"]["base_dir"] == str(paths.XDG_DIRS["XDG_MUSIC_DIR"])

--- a/tests/_app/test_config.py
+++ b/tests/_app/test_config.py
@@ -226,4 +226,6 @@ def test_validate_defaults_with_xdg_user_dir_fallbacks():
         "$XDG_MUSIC_DIR|Music",
         "~/|Home",
     )
-    assert config_manager.config["m3u"]["base_dir"] == str(paths.XDG_DIRS["XDG_MUSIC_DIR"])
+    assert config_manager.config["m3u"]["base_dir"] == str(
+        paths.XDG_DIRS["XDG_MUSIC_DIR"]
+    )

--- a/tests/_lib/test_paths_xdg.py
+++ b/tests/_lib/test_paths_xdg.py
@@ -63,7 +63,7 @@ def test_user_dirs_defaults_file_overrides_builtin_defaults(tmpdir):
         fh.write("MUSIC=Audio\n")
         fh.write("DOWNLOAD=Files\n")
 
-    result = paths._get_xdg_user_dirs(  # noqa: SLF001
+    result = paths._get_xdg_user_dirs(
         xdg_config_dir=Path("/does/not/exist"),
         xdg_defaults_dir=Path(tmpdir),
     )
@@ -82,7 +82,7 @@ def test_user_dirs_file_overrides_defaults_file(tmpdir):
     with (xdg_config_dir / "user-dirs.dirs").open("w") as fh:
         fh.write('XDG_MUSIC_DIR="$HOME/Music2"\n')
 
-    result = paths._get_xdg_user_dirs(  # noqa: SLF001
+    result = paths._get_xdg_user_dirs(
         xdg_config_dir=xdg_config_dir,
         xdg_defaults_dir=Path(tmpdir),
     )

--- a/tests/_lib/test_paths_xdg.py
+++ b/tests/_lib/test_paths_xdg.py
@@ -72,6 +72,30 @@ def test_user_dirs_defaults_file_overrides_builtin_defaults(tmpdir):
     assert result["XDG_DOWNLOAD_DIR"] == Path("~/Files").expanduser()
 
 
+def test_user_dirs_defaults_file_ignores_absolute_paths(tmpdir):
+    with (Path(tmpdir) / "user-dirs.defaults").open("w") as fh:
+        fh.write("MUSIC=/srv/media\n")
+
+    result = paths._get_xdg_user_dirs(
+        xdg_config_dir=Path("/does/not/exist"),
+        xdg_defaults_dir=Path(tmpdir),
+    )
+
+    assert result["XDG_MUSIC_DIR"] == Path("~/Music").expanduser()
+
+
+def test_user_dirs_defaults_file_tolerates_whitespace_and_quotes(tmpdir):
+    with (Path(tmpdir) / "user-dirs.defaults").open("w") as fh:
+        fh.write(' MUSIC = "Audio Files"\n')
+
+    result = paths._get_xdg_user_dirs(
+        xdg_config_dir=Path("/does/not/exist"),
+        xdg_defaults_dir=Path(tmpdir),
+    )
+
+    assert result["XDG_MUSIC_DIR"] == Path("~/Audio Files").expanduser()
+
+
 def test_user_dirs_file_overrides_defaults_file(tmpdir):
     xdg_config_dir = Path(tmpdir) / "config"
     xdg_config_dir.mkdir()
@@ -88,6 +112,36 @@ def test_user_dirs_file_overrides_defaults_file(tmpdir):
     )
 
     assert result["XDG_MUSIC_DIR"] == Path("~/Music2").expanduser()
+
+
+def test_user_dirs_file_accepts_reasonably_sourceable_value_forms(tmpdir):
+    xdg_config_dir = Path(tmpdir) / "config"
+    xdg_config_dir.mkdir()
+
+    with (xdg_config_dir / "user-dirs.dirs").open("w") as fh:
+        fh.write("XDG_MUSIC_DIR=$HOME/Music\n")
+        fh.write(" XDG_DOWNLOAD_DIR = /srv/downloads\n")
+        fh.write('XDG_PICTURES_DIR="/srv/pictures"\n')
+
+    result = paths._read_xdg_user_dirs(xdg_config_dir / "user-dirs.dirs")
+
+    assert result["XDG_MUSIC_DIR"] == Path("~/Music").expanduser()
+    assert result["XDG_DOWNLOAD_DIR"] == Path("/srv/downloads")
+    assert result["XDG_PICTURES_DIR"] == Path("/srv/pictures")
+
+
+def test_user_dirs_file_ignores_unsupported_shell_forms(tmpdir):
+    xdg_config_dir = Path(tmpdir) / "config"
+    xdg_config_dir.mkdir()
+
+    with (xdg_config_dir / "user-dirs.dirs").open("w") as fh:
+        fh.write('XDG_MUSIC_DIR="$HOME"/Music\n')
+        fh.write('XDG_DOWNLOAD_DIR="${HOME}/Downloads"\n')
+
+    result = paths._read_xdg_user_dirs(xdg_config_dir / "user-dirs.dirs")
+
+    assert "XDG_MUSIC_DIR" not in result
+    assert "XDG_DOWNLOAD_DIR" not in result
 
 
 def test_user_dirs_when_no_dirs_file(environ, tmpdir):

--- a/tests/_lib/test_paths_xdg.py
+++ b/tests/_lib/test_paths_xdg.py
@@ -54,7 +54,40 @@ def test_user_dirs(environ, tmpdir):
     result = paths.get_xdg_dirs()
 
     assert result["XDG_MUSIC_DIR"] == Path("~/Music2").expanduser()
-    assert "XDG_DOWNLOAD_DIR" not in result
+    assert result["XDG_DOWNLOAD_DIR"] == Path("~/Downloads").expanduser()
+
+
+def test_user_dirs_defaults_file_overrides_builtin_defaults(tmpdir):
+    with (Path(tmpdir) / "user-dirs.defaults").open("w") as fh:
+        fh.write("# Some comments\n")
+        fh.write("MUSIC=Audio\n")
+        fh.write("DOWNLOAD=Files\n")
+
+    result = paths._get_xdg_user_dirs(  # noqa: SLF001
+        xdg_config_dir=Path("/does/not/exist"),
+        xdg_defaults_dir=Path(tmpdir),
+    )
+
+    assert result["XDG_MUSIC_DIR"] == Path("~/Audio").expanduser()
+    assert result["XDG_DOWNLOAD_DIR"] == Path("~/Files").expanduser()
+
+
+def test_user_dirs_file_overrides_defaults_file(tmpdir):
+    xdg_config_dir = Path(tmpdir) / "config"
+    xdg_config_dir.mkdir()
+
+    with (Path(tmpdir) / "user-dirs.defaults").open("w") as fh:
+        fh.write("MUSIC=Audio\n")
+
+    with (xdg_config_dir / "user-dirs.dirs").open("w") as fh:
+        fh.write('XDG_MUSIC_DIR="$HOME/Music2"\n')
+
+    result = paths._get_xdg_user_dirs(  # noqa: SLF001
+        xdg_config_dir=xdg_config_dir,
+        xdg_defaults_dir=Path(tmpdir),
+    )
+
+    assert result["XDG_MUSIC_DIR"] == Path("~/Music2").expanduser()
 
 
 def test_user_dirs_when_no_dirs_file(environ, tmpdir):
@@ -62,5 +95,5 @@ def test_user_dirs_when_no_dirs_file(environ, tmpdir):
 
     result = paths.get_xdg_dirs()
 
-    assert "XDG_MUSIC_DIR" not in result
-    assert "XDG_DOWNLOAD_DIR" not in result
+    assert result["XDG_MUSIC_DIR"] == Path("~/Music").expanduser()
+    assert result["XDG_DOWNLOAD_DIR"] == Path("~/Downloads").expanduser()


### PR DESCRIPTION
This gives Nix-pilled contributors an easy way to get a working development environment with the right dependencies preconfigured. It also alows nix users to reuse this as a package for run fromt git, but this is a side effect, not the intended outcome. My goal is to make it easy to to work on e.g. `mopidy-spotify` in a nix environment.

- add `flake.nix` and `flake.lock`
- define a ready-to-use development shell for this repository
- include Python tools, project dependencies, and required system libraries
- add a small check that verifies the packaged environment still works
- document the current version pinning workaround used for builds
- add minimal CI for `nix flake check` to catch if it stops working