### PR TITLE
strip whitespace from media_dirs entries

### DIFF
--- a/src/mopidy/_exts/file/library.py
+++ b/src/mopidy/_exts/file/library.py
@@ -131,7 +131,7 @@ class FileLibraryProvider(backend.LibraryProvider):
 
     def _get_media_dirs(self, config: config_lib.Config) -> Generator[MediaDir]:
         for entry in config["file"]["media_dirs"]:
-            media_dir_split = entry.split("|", 1)
+            media_dir_split = [part.strip() for part in entry.split("|", 1)]
             local_path = paths.expand_path(media_dir_split[0])
 
             if local_path is None:
@@ -144,7 +144,7 @@ class FileLibraryProvider(backend.LibraryProvider):
                 logger.warning(
                     "%s is not a directory. Please create the directory or "
                     "update the file/media_dirs config value.",
-                    local_path,
+                    local_path.as_uri(),
                 )
                 continue
 

--- a/tests/_exts/file/test_browse.py
+++ b/tests/_exts/file/test_browse.py
@@ -54,3 +54,16 @@ def test_file_root_directory(provider, expected):
         return
     assert ref.name == "Files"
     assert (ref.uri == "file:root") == expected
+
+
+@pytest.mark.parametrize(
+    "media_dirs",
+    [
+        [f"  {path_to_data_dir('')}  |  My Music  "],
+        [f"{path_to_data_dir('')} | My Music"],
+    ],
+)
+def test_media_dirs_whitespace_is_stripped(provider):
+    media_dir = provider._media_dirs[0]
+    assert media_dir["path"] == path_to_data_dir("")
+    assert media_dir["name"] == "My Music"


### PR DESCRIPTION
Fixes #1965.

Config lines like `media_dirs = /music/flac | NAS` kept the surrounding spaces, so the path became `/music/flac ` and you'd get a confusing "is not a directory" warning.

Now each part is stripped before use, and the warning prints the path as a uri so a stray trailing space actually shows up (`...%20`).

Added a test in tests/_exts/file/test_browse.py.

Couldn't run the suite locally (pygobject won't build on Windows), so relying on CI for the run.