### PR TITLE
docs:Register extension commands with `get_command`

### DIFF
--- a/docs/guides/extensiondev.md
+++ b/docs/guides/extensiondev.md
@@ -261,7 +261,7 @@ def reticulate(*, degrees: int) -> None:
 ```
 
 To register your commands, make sure to return the `app` instance from your
-`mopidy.ext.Extension.get_commands()` implementation.
+`mopidy.ext.Extension.get_command()` implementation.
 
 ## Example web application
 


### PR DESCRIPTION
Small typo in guides: register extension commands with `get_command` instead of `get_commands`.