### PR TITLE
fix(file): strip whitespace from media_dirs entries

### DIFF
--- a/src/mopidy/_exts/file/library.py
+++ b/src/mopidy/_exts/file/library.py
@@ -131,7 +131,7 @@ class FileLibraryProvider(backend.LibraryProvider):
 
     def _get_media_dirs(self, config: config_lib.Config) -> Generator[MediaDir]:
         for entry in config["file"]["media_dirs"]:
-            media_dir_split = entry.split("|", 1)
+            media_dir_split = [part.strip() for part in entry.split("|", 1)]
             local_path = paths.expand_path(media_dir_split[0])
 
             if local_path is None:


### PR DESCRIPTION
Closes #1965

Strips whitespace from path and name parts of \media_dirs\ config entries, so paths like \/music/Network/flac | NAS\ work correctly instead of failing with trailing/leading whitespace.