### PR TITLE
fix: Use explicit None tests for Gst.Structure.

### DIFF
--- a/src/mopidy/audio/scan.py
+++ b/src/mopidy/audio/scan.py
@@ -309,7 +309,7 @@ def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
 
         structure = msg.get_structure()
 
-        if logger.isEnabledFor(logs.TRACE_LOG_LEVEL) and structure:
+        if logger.isEnabledFor(logs.TRACE_LOG_LEVEL) and structure is not None:
             debug_text = structure.to_string()
             if len(debug_text) > 77:
                 debug_text = debug_text[:77] + "..."
@@ -322,7 +322,7 @@ def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
         elif msg.type == Gst.MessageType.APPLICATION:
             if structure and _get_structure_name(structure) == "have-type":
                 caps = cast(Gst.Structure | None, structure.get_value("caps"))
-                if caps:
+                if caps is not None:
                     mime = _get_structure_name(caps)
                     if mime.startswith("text/") or mime == "application/xml":
                         return tags, mime, have_audio, duration
@@ -335,8 +335,8 @@ def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 missing_message
                 and not mime
                 and (
-                    (structure := missing_message.get_structure())
-                    and (caps := structure.get_value("detail"))
+                    ((structure := missing_message.get_structure()) is not None)
+                    and ((caps := structure.get_value("detail")) is not None)
                     and (mime := _get_structure_name(caps.get_structure(0)))
                 )
             ):

--- a/src/mopidy/audio/scan.py
+++ b/src/mopidy/audio/scan.py
@@ -326,7 +326,7 @@ def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
                     mime = _get_structure_name(caps)
                     if mime.startswith("text/") or mime == "application/xml":
                         return tags, mime, have_audio, duration
-            elif structure and structure.get_name() == "have-audio":
+            elif structure is not None and structure.get_name() == "have-audio":
                 have_audio = True
 
         elif msg.type == Gst.MessageType.ERROR:

--- a/src/mopidy/audio/scan.py
+++ b/src/mopidy/audio/scan.py
@@ -320,7 +320,7 @@ def _process(  # noqa: C901, PLR0911, PLR0912, PLR0915
                 missing_message = msg
 
         elif msg.type == Gst.MessageType.APPLICATION:
-            if structure and _get_structure_name(structure) == "have-type":
+            if structure is not None and _get_structure_name(structure) == "have-type":
                 caps = cast(Gst.Structure | None, structure.get_value("caps"))
                 if caps is not None:
                     mime = _get_structure_name(caps)


### PR DESCRIPTION
`Gst.Structure` may have a `__len__` method which will make a truthy/falsy test return False when `len()` is 0. This results in `audio.scan()` failing to recognize valid audio.

Explicit `...is not None` tests avoid this unpredictability.
See issue #2278.
Currently a draft PR, as I'm not able to fully tests this or just even assess the possible implications.
On my setup it runs fine, that's all I know.

---

Added by jodal, 2026-09-01:

Fixes #2278