### PR TITLE
audio: recover from GStreamer stream errors instead of failing silently

### DIFF
--- a/src/mopidy/audio/_gst.py
+++ b/src/mopidy/audio/_gst.py
@@ -316,6 +316,8 @@ class _Handler:
         gst_logger.error(f"GStreamer error: {error.message}")
         gst_logger.debug(f"Got ERROR bus message: error={error!r} debug={debug!r}")
 
+        AudioListener.send("stream_error", error=error.message)
+
         # TODO: is this needed?
         self._audio.stop_playback()
 

--- a/src/mopidy/audio/_listener.py
+++ b/src/mopidy/audio/_listener.py
@@ -91,3 +91,17 @@ class AudioListener(listener.Listener):
         Args:
             tags: The tags that have just been updated.
         """
+
+    def stream_error(self, error: str) -> None:
+        """Called whenever a GStreamer error stops the audio stream.
+
+        This is distinct from :meth:`state_changed` in that it carries the
+        reason playback stopped, so listeners can distinguish an unexpected
+        failure (e.g. a broken sink connection) from a normal stop and react
+        accordingly, such as by retrying playback.
+
+        *MAY* be implemented by actor.
+
+        Args:
+            error: The GStreamer error message.
+        """

--- a/src/mopidy/core/_actor.py
+++ b/src/mopidy/core/_actor.py
@@ -126,6 +126,10 @@ class Core(
         self.playback._on_position_changed(position)
 
     @override
+    def stream_error(self, error: str) -> None:
+        self.playback._on_stream_error(error)
+
+    @override
     def state_changed(
         self,
         old_state: PlaybackState,

--- a/src/mopidy/core/_playback.py
+++ b/src/mopidy/core/_playback.py
@@ -25,6 +25,10 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Max consecutive stream_error recovery attempts for the same track before
+# giving up. Resets to zero as soon as a track starts playing successfully.
+MAX_STREAM_ERROR_RETRIES = 3
+
 
 class PlaybackController:
     """Manages playback state and the currently playing track."""
@@ -52,6 +56,8 @@ class PlaybackController:
 
         self._start_at_position: DurationMs | None = None
         self._start_paused: bool = False
+
+        self._stream_error_count = 0
 
         if self._audio:
             self._audio.set_about_to_finish_callback(self._on_about_to_finish_callback)
@@ -189,6 +195,44 @@ class PlaybackController:
             if self._start_paused:
                 self._start_paused = False
                 self.pause()
+
+    def _on_stream_error(self, error: str) -> None:
+        """Handle a GStreamer stream error by retrying the current track.
+
+        Addresses https://github.com/mopidy/mopidy/issues/1542: previously
+        a stream error (e.g. the audio sink's connection dying) just stopped
+        playback silently, with no attempt to recover and no way for core to
+        even distinguish this from a normal stop. This retries the current
+        track, which causes the backend to rebuild its output pipeline (and
+        thus e.g. re-establish a dropped TCP connection), bounded by
+        MAX_STREAM_ERROR_RETRIES to avoid retrying forever against a
+        persistently broken track or backend.
+        """
+        tl_track = self.get_current_tl_track()
+        if tl_track is None:
+            logger.error("Stream error with no current track, giving up: %s", error)
+            return
+
+        self._stream_error_count += 1
+        if self._stream_error_count > MAX_STREAM_ERROR_RETRIES:
+            logger.error(
+                "Stream error, giving up after %d attempts for %s: %s",
+                self._stream_error_count - 1,
+                tl_track.track.uri,
+                error,
+            )
+            self._stream_error_count = 0
+            self.stop()
+            return
+
+        logger.warning(
+            "Stream error, retrying (%d/%d) for %s: %s",
+            self._stream_error_count,
+            MAX_STREAM_ERROR_RETRIES,
+            tl_track.track.uri,
+            error,
+        )
+        self.play(tlid=tl_track.tlid)
 
     def _on_about_to_finish_callback(self) -> None:
         """Callback that performs a blocking actor call to the real callback.
@@ -518,6 +562,8 @@ class PlaybackController:
     def _trigger_track_playback_started(self) -> None:
         if self.get_current_tl_track() is None:
             return
+
+        self._stream_error_count = 0
 
         logger.debug("Triggering track playback started event")
         tl_track = self.get_current_tl_track()

--- a/tests/core/test_playback.py
+++ b/tests/core/test_playback.py
@@ -5,6 +5,7 @@ import pykka
 import pytest
 
 from mopidy import backend, core
+from mopidy.core import _playback as core_playback
 from mopidy.core._state_storage import PlaybackControllerState
 from mopidy.models import Track
 from mopidy.types import PlaybackState
@@ -1367,3 +1368,66 @@ class TestEndlessLoop(BaseTest):
         self.trigger_about_to_finish()
 
         assert not self.backend.playback.is_call_limit_reached().get()
+
+
+class TestStreamErrorHandling(BaseTest):
+    def test_stream_error_retries_current_track_and_recovers(self):
+        tl_tracks = self.core.tracklist.get_tl_tracks()
+        self.core.playback.play(tl_tracks[0].tlid)
+        self.replay_events()
+
+        assert self.core.playback.get_current_tl_track() == tl_tracks[0]
+        assert self.core.playback.get_state() == PlaybackState.PLAYING
+
+        self.core.on_event("stream_error", error="Error while sending data")
+        self.replay_events()
+
+        # A single error, within the retry budget, should recover playback
+        # of the same track rather than leaving core stopped/desynced.
+        assert self.core.playback.get_current_tl_track() == tl_tracks[0]
+        assert self.core.playback.get_state() == PlaybackState.PLAYING
+
+    def test_stream_error_gives_up_after_max_retries(self):
+        tl_tracks = self.core.tracklist.get_tl_tracks()
+        self.core.playback.play(tl_tracks[0].tlid)
+        self.replay_events()
+
+        # Exhaust the retry budget without ever letting a retry succeed
+        # (no replay_events() in between, so _trigger_track_playback_started
+        # never fires to reset the counter).
+        for _ in range(core_playback.MAX_STREAM_ERROR_RETRIES):
+            self.core.on_event("stream_error", error="boom")
+            assert self.core.playback.get_state() != PlaybackState.STOPPED
+
+        # One error beyond the budget should give up and stop.
+        self.core.on_event("stream_error", error="boom")
+        assert self.core.playback.get_state() == PlaybackState.STOPPED
+
+    def test_stream_error_count_resets_after_successful_playback(self):
+        tl_tracks = self.core.tracklist.get_tl_tracks()
+        self.core.playback.play(tl_tracks[0].tlid)
+        self.replay_events()
+
+        for _ in range(core_playback.MAX_STREAM_ERROR_RETRIES - 1):
+            self.core.on_event("stream_error", error="boom")
+
+        assert (
+            self.core.playback._stream_error_count
+            == core_playback.MAX_STREAM_ERROR_RETRIES - 1
+        )
+
+        # A genuine successful start (e.g. once a retry actually works)
+        # must reset the counter rather than carrying it forward, so a
+        # later, unrelated error isn't judged against an already-used-up
+        # budget.
+        self.core.playback._trigger_track_playback_started()
+        assert self.core.playback._stream_error_count == 0
+
+    def test_stream_error_with_no_current_track_does_nothing(self):
+        assert self.core.playback.get_current_tl_track() is None
+        assert self.core.playback.get_state() == PlaybackState.STOPPED
+
+        self.core.on_event("stream_error", error="boom")
+
+        assert self.core.playback.get_current_tl_track() is None
+        assert self.core.playback.get_state() == PlaybackState.STOPPED


### PR DESCRIPTION
## Problem

When GStreamer's playbin hits a stream error mid-playback (e.g. a broken
sink connection, a dropped network stream), `on_error()` currently just
stops playback in `mopidy.audio` — but `mopidy.core`'s playback state is
never updated to reflect this. Clients querying `core.playback.get_state()`
keep seeing `PLAYING` even though nothing is actually playing anymore,
until something else happens to trigger a state sync.

This is the same underlying gap referenced in the `state_changed` handler
in `core/_actor.py`:

> NOTE: This is a temporary fix for issue #232 while we wait for a more
> permanent solution with the implementation of issue #234.

I ran into this concretely with a `tcpclientsink`-based output (streaming
to an external audio server) whose TCP connection can silently drop; the
underlying issue is the same class of problem as #232/#234 — GStreamer
knows playback has stopped, but core is never told.

## Fix

- `AudioListener` gets a new `stream_error(error: str)` event.
- `audio/_gst.py`'s `on_error()` now emits this event (via
  `AudioListener.send`) before stopping playback, carrying the GStreamer
  error message.
- `core/_actor.py` wires this into `PlaybackController._on_stream_error()`.
- `PlaybackController._on_stream_error()` retries the current track (up
  to `MAX_STREAM_ERROR_RETRIES = 3` attempts) instead of leaving state
  stale, giving up and calling `stop()` if retries are exhausted. The
  retry counter resets on the next successful
  `_trigger_track_playback_started()`.

This doesn't attempt to fully solve #234 (core still doesn't have a
unified way of tracking playback state as GStreamer's actual source of
truth) — it's a narrower fix for the specific case where a stream error
leaves core's state permanently wrong with no path back to a consistent
state.

## Testing

- Added `TestStreamErrorHandling` in `tests/core/test_playback.py`
  covering: retry-and-recover, giving up after max retries, the retry
  counter resetting on success, and the no-op case when there's no
  current track.
- Full `tests/core/test_playback.py`, `tests/audio/test_gst.py`,
  `tests/audio/test_listener.py`, and `tests/core/test_actor.py` suites
  pass (192 tests) against current `main`.
- `ruff check` / `ruff format --check` clean on all changed files (no
  new findings beyond pre-existing, unrelated ones on those files).

Happy to adjust the retry policy (count, backoff, whether it should be
opt-in via config) based on what maintainers think fits best here — I
went with a small fixed retry count as the simplest thing that fixes the
"state gets stuck" problem, not because I'm confident it's the ideal
policy.