### PR TITLE
fix: Allow musicbrainz_id to be any str and support YYYY-MM dates

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -8,6 +8,14 @@ For older releases, see:
 [Changelog 1.x](1.x.md) ·
 [Changelog 0.x](0.x.md)
 
+## Unreleased
+
+- Models: The `musicbrainz_id` fields on [`Album`][mopidy.models.Album],
+  [`Artist`][mopidy.models.Artist], and [`Track`][mopidy.models.Track] are again
+  typed as `str` instead of `UUID`, like in Mopidy < 4.0, to allow scanning
+  collections using alternative identifiers, or multiple identifiers in the same
+  field.
+
 ## v4.0.1 (2026-05-16)
 
 - Deps: Fix support for Cyclopts >= 3.12, < 4.3. We accidentally relied on

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -27,6 +27,13 @@ For older releases, see:
   [`mopidy.types.ReleaseDate`][mopidy.types.ReleaseDate] type, covering all
   three supported date formats.
 
+- Audio: [`convert_tags_to_track()`][mopidy.audio.tags.convert_tags_to_track]
+  now raises [`ScannerError`][mopidy.exceptions.ScannerError] if the tags can't
+  be coerced into a valid [`Track`][mopidy.models.Track]. The `file` and
+  `stream` backends catch this per URI and fall back to a track with just the
+  URI, so that a single file with broken tags no longer fails the lookup of
+  every other URI in the same batch.
+
 ## v4.0.1 (2026-05-16)
 
 - Deps: Fix support for Cyclopts >= 3.12, < 4.3. We accidentally relied on

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -22,10 +22,14 @@ For older releases, see:
   only have a year and a month in their date tag, and such files were previously
   rejected.
 
-- Types: Removed `mopidy.types.Date`, `mopidy.types.Year`, and
+- Types: Deprecated `mopidy.types.Date`, `mopidy.types.Year`, and
   `mopidy.types.DateOrYear`. They are replaced by a single
   [`mopidy.types.ReleaseDate`][mopidy.types.ReleaseDate] type, covering all
-  three supported date formats.
+  three supported date formats. The old names remain importable, but they are
+  now `str` subclasses instead of `NewType`s, so they are not assignable to
+  `ReleaseDate` and using them will fail type checking. At runtime they still
+  behave as strings, and instantiating them emits a `DeprecationWarning`. They
+  will be removed in a future release.
 
 - Audio: [`convert_tags_to_track()`][mopidy.audio.tags.convert_tags_to_track]
   now raises [`ScannerError`][mopidy.exceptions.ScannerError] if the tags can't

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -16,6 +16,17 @@ For older releases, see:
   collections using alternative identifiers, or multiple identifiers in the same
   field.
 
+- Models: The `date` field on [`Album`][mopidy.models.Album] and
+  [`Track`][mopidy.models.Track] now also accepts the `YYYY-MM` format, in
+  addition to `YYYY` and `YYYY-MM-DD`. GStreamer emits `YYYY-MM` for files that
+  only have a year and a month in their date tag, and such files were previously
+  rejected.
+
+- Types: Removed `mopidy.types.Date`, `mopidy.types.Year`, and
+  `mopidy.types.DateOrYear`. They are replaced by a single
+  [`mopidy.types.ReleaseDate`][mopidy.types.ReleaseDate] type, covering all
+  three supported date formats.
+
 ## v4.0.1 (2026-05-16)
 
 - Deps: Fix support for Cyclopts >= 3.12, < 4.3. We accidentally relied on

--- a/src/mopidy/_exts/stream/actor.py
+++ b/src/mopidy/_exts/stream/actor.py
@@ -82,11 +82,15 @@ class StreamLibraryProvider(backend.LibraryProvider):
         )
 
         if scan_result:
-            track = tags.convert_tags_to_track(
-                scan_result.tags,
-                uri=uri,
-                length=scan_result.duration,
-            )
+            try:
+                track = tags.convert_tags_to_track(
+                    scan_result.tags,
+                    uri=uri,
+                    length=scan_result.duration,
+                )
+            except exceptions.ScannerError as e:
+                logger.warning("Failed looking up %s: %s", uri, e)
+                track = Track(uri=uri)
         else:
             logger.warning("Problem looking up %s", uri)
             track = Track(uri=uri)

--- a/src/mopidy/audio/tags.py
+++ b/src/mopidy/audio/tags.py
@@ -4,6 +4,7 @@ import logging
 import numbers
 from typing import Any
 
+from mopidy import exceptions
 from mopidy._lib import logs
 from mopidy._lib.gi import GLib, Gst
 from mopidy.models import Album, Artist, Track
@@ -131,7 +132,14 @@ def convert_tags_to_track(
     length: DurationMs | None = None,
     last_modified: int | None = None,
 ) -> Track:
-    """Convert our normalized tags to a track."""
+    """Convert our normalized tags to a track.
+
+    Raises:
+        exceptions.ScannerError: If the tags can't be coerced into a valid
+            `Track`. Callers scanning multiple URIs should catch this per URI,
+            so that a single file with broken tags doesn't fail the entire scan
+            or lookup.
+    """
     album_kwargs = {}
     track_kwargs = {}
 
@@ -181,16 +189,20 @@ def convert_tags_to_track(
     track_kwargs = {k: v for k, v in track_kwargs.items() if v}
     album_kwargs = {k: v for k, v in album_kwargs.items() if v}
 
-    # Only bother with album if we have a name to show.
-    if album_kwargs.get("name"):
-        track_kwargs["album"] = Album(**album_kwargs)
+    try:
+        # Only bother with album if we have a name to show.
+        if album_kwargs.get("name"):
+            track_kwargs["album"] = Album(**album_kwargs)
 
-    return Track(
-        **track_kwargs,
-        uri=uri,
-        length=length,
-        last_modified=last_modified,
-    )
+        return Track(
+            **track_kwargs,
+            uri=uri,
+            length=length,
+            last_modified=last_modified,
+        )
+    except ValueError as exc:
+        msg = f"Invalid tags: {exc}"
+        raise exceptions.ScannerError(msg) from exc
 
 
 def _artists(

--- a/src/mopidy/models/_models.py
+++ b/src/mopidy/models/_models.py
@@ -4,7 +4,7 @@ from pydantic.fields import Field
 from pydantic.types import NonNegativeInt
 
 from mopidy.models._base import BaseModel
-from mopidy.types import DateOrYear, DurationMs, Uri
+from mopidy.types import DurationMs, ReleaseDate, Uri
 
 
 class Image(BaseModel):
@@ -72,11 +72,11 @@ class Album(BaseModel):
     num_discs: NonNegativeInt | None = None
     """The number of discs in the album."""
 
-    date: DateOrYear | None = Field(
+    date: ReleaseDate | None = Field(
         default=None,
-        pattern=r"^\d{4}(-\d{2}-\d{2})?$",
+        pattern=r"^\d{4}(-\d{2}(-\d{2})?)?$",
     )
-    """The album release date. A string formatted as "YYYY" or "YYYY-MM-DD"."""
+    """The album release date, formatted as "YYYY", "YYYY-MM", or "YYYY-MM-DD"."""
 
     musicbrainz_id: str | None = None
     """The MusicBrainz ID of the album."""
@@ -118,11 +118,11 @@ class Track(BaseModel):
     disc_no: NonNegativeInt | None = None
     """The disc number in the album."""
 
-    date: DateOrYear | None = Field(
+    date: ReleaseDate | None = Field(
         default=None,
-        pattern=r"^\d{4}(-\d{2}-\d{2})?$",
+        pattern=r"^\d{4}(-\d{2}(-\d{2})?)?$",
     )
-    """The track release date. A string formatted as "YYYY" or "YYYY-MM-DD"."""
+    """The track release date, formatted as "YYYY", "YYYY-MM", or "YYYY-MM-DD"."""
 
     length: DurationMs | None = None
     """The track length in milliseconds."""

--- a/src/mopidy/models/_models.py
+++ b/src/mopidy/models/_models.py
@@ -1,5 +1,4 @@
 from typing import Literal
-from uuid import UUID
 
 from pydantic.fields import Field
 from pydantic.types import NonNegativeInt
@@ -45,7 +44,7 @@ class Artist(BaseModel):
     sortname: str | None = None
     """Artist name for better sorting, e.g. with articles stripped."""
 
-    musicbrainz_id: UUID | None = None
+    musicbrainz_id: str | None = None
     """The MusicBrainz ID of the artist."""
 
 
@@ -79,7 +78,7 @@ class Album(BaseModel):
     )
     """The album release date. A string formatted as "YYYY" or "YYYY-MM-DD"."""
 
-    musicbrainz_id: UUID | None = None
+    musicbrainz_id: str | None = None
     """The MusicBrainz ID of the album."""
 
 
@@ -134,7 +133,7 @@ class Track(BaseModel):
     comment: str | None = None
     """The track comment."""
 
-    musicbrainz_id: UUID | None = None
+    musicbrainz_id: str | None = None
     """The MusicBrainz ID of the track."""
 
     last_modified: NonNegativeInt | None = None

--- a/src/mopidy/types.py
+++ b/src/mopidy/types.py
@@ -5,14 +5,8 @@ from collections.abc import Iterable
 from typing import Literal, NewType, TypeVar
 
 # Date types
-Date = NewType("Date", str)
-"""A date string on the form `YYYY-MM-DD`."""
-
-Year = NewType("Year", str)
-"""A year string on the form `YYYY`."""
-
-type DateOrYear = Date | Year
-"""A [Date][mopidy.types.Date] or [Year][mopidy.types.Year]."""
+ReleaseDate = NewType("ReleaseDate", str)
+"""A date string on the form `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`."""
 
 
 # Integer types

--- a/src/mopidy/types.py
+++ b/src/mopidy/types.py
@@ -3,10 +3,28 @@ from __future__ import annotations
 import enum
 from collections.abc import Iterable
 from typing import Literal, NewType, TypeVar
+from warnings import deprecated
 
 # Date types
 ReleaseDate = NewType("ReleaseDate", str)
 """A date string on the form `YYYY`, `YYYY-MM`, or `YYYY-MM-DD`."""
+
+
+@deprecated("Use ReleaseDate instead")
+class DateOrYear(str):
+    """Deprecated alias for [ReleaseDate][mopidy.types.ReleaseDate]."""
+
+    __slots__ = ()
+
+
+@deprecated("Use ReleaseDate instead")
+class Date(DateOrYear):  # ty: ignore[deprecated]
+    """Deprecated alias for [ReleaseDate][mopidy.types.ReleaseDate]."""
+
+
+@deprecated("Use ReleaseDate instead")
+class Year(DateOrYear):  # ty: ignore[deprecated]
+    """Deprecated alias for [ReleaseDate][mopidy.types.ReleaseDate]."""
 
 
 # Integer types

--- a/tests/_exts/file/test_lookup.py
+++ b/tests/_exts/file/test_lookup.py
@@ -31,3 +31,25 @@ def test_lookup(provider, track_uri):
         track = result[0]
         assert track.uri == track_uri
         assert track.name == "song1.wav"
+
+
+def test_lookup_with_invalid_tags(provider):
+    """A file with tags we can't validate is still listed, just without tags."""
+    track_uri = paths.path_to_uri(path_to_data_dir("song1.wav"))
+    real_scan = provider._scanner.scan
+
+    def scan_with_invalid_tags(uri, *args, **kwargs):
+        result = real_scan(uri, *args, **kwargs)
+        return result._replace(tags=result.tags | {"track-number": [-1]})
+
+    with mock.patch.object(
+        provider._scanner,
+        "scan",
+        side_effect=scan_with_invalid_tags,
+    ):
+        result = provider.lookup(track_uri)
+
+    assert len(result) == 1
+    assert result[0].uri == track_uri
+    assert result[0].name == "song1.wav"
+    assert result[0].track_no is None

--- a/tests/audio/test_tags.py
+++ b/tests/audio/test_tags.py
@@ -1,5 +1,8 @@
 import unittest
 
+import pytest
+
+from mopidy import exceptions
 from mopidy._lib.gi import GLib, GObject, Gst
 from mopidy.audio import tags
 from mopidy.models import Album, Artist, Track
@@ -74,6 +77,21 @@ class TestConvertTaglist:
 
         assert isinstance(result[Gst.TAG_DATE_TIME][0], str)
         assert result[Gst.TAG_DATE_TIME][0] == "2014-01-07T14:13:12Z"
+
+    def test_date_time_tag_partial(self):
+        # GStreamer emits partial dates when the tag only has a year, or a year
+        # and a month. Both must be accepted by the `date` field on our models.
+        taglist = self.make_taglist(
+            Gst.TAG_DATE_TIME,
+            [Gst.DateTime.new_y(2014)],
+        )
+        assert tags.convert_taglist(taglist)[Gst.TAG_DATE_TIME] == ["2014"]
+
+        taglist = self.make_taglist(
+            Gst.TAG_DATE_TIME,
+            [Gst.DateTime.new_ym(2014, 1)],
+        )
+        assert tags.convert_taglist(taglist)[Gst.TAG_DATE_TIME] == ["2014-01"]
 
     def test_string_tag(self):
         taglist = self.make_taglist(Gst.TAG_ARTIST, [b"ABBA", b"ACDC"])
@@ -231,6 +249,25 @@ class TagsToTrackTest(unittest.TestCase):
         del self.tags["date"]
         self.tags["datetime"] = ["2006-01-01T14:13:12Z"]
         self.check(self.track)
+
+    def test_year_month_datetime_instead_of_date(self):
+        del self.tags["date"]
+        self.tags["datetime"] = ["2006-01"]
+        self.check(
+            self.track.replace(
+                album=self.track.album.replace(date="2006-01"),
+                date="2006-01",
+            ),
+        )
+
+    def test_invalid_tags_raises_scanner_error(self):
+        self.tags["track-number"] = [-1]
+        with pytest.raises(exceptions.ScannerError):
+            tags.convert_tags_to_track(
+                self.tags,
+                uri=Uri("dummy:track:test"),
+                length=12345,
+            )
 
     def test_missing_track_comment(self):
         del self.tags["comment"]

--- a/tests/models/test_album.py
+++ b/tests/models/test_album.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import pydantic
 import pytest
 
@@ -59,7 +57,7 @@ def test_date():
 def test_musicbrainz_id():
     mb_id = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
     album = AlbumFactory.build(musicbrainz_id=mb_id)
-    assert album.musicbrainz_id == UUID(mb_id)
+    assert album.musicbrainz_id == mb_id
     with pytest.raises(pydantic.ValidationError):
         album.musicbrainz_id = None
 

--- a/tests/models/test_album.py
+++ b/tests/models/test_album.py
@@ -46,12 +46,20 @@ def test_num_discs():
         album.num_discs = None
 
 
-def test_date():
-    date = "1977-01-01"
+@pytest.mark.parametrize("date", ["1977", "1977-01", "1977-01-01"])
+def test_date(date):
     album = AlbumFactory.build(date=date)
     assert album.date == date
     with pytest.raises(pydantic.ValidationError):
         album.date = None
+
+
+@pytest.mark.parametrize(
+    "date", ["77", "1977-1-1", "1977/01/01", "1977-01-01T00:00:00"]
+)
+def test_date_rejects_invalid(date):
+    with pytest.raises(pydantic.ValidationError):
+        AlbumFactory.build(date=date)
 
 
 def test_musicbrainz_id():

--- a/tests/models/test_artist.py
+++ b/tests/models/test_artist.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import pydantic
 import pytest
 
@@ -27,7 +25,7 @@ def test_name():
 def test_musicbrainz_id():
     mb_id = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
     artist = ArtistFactory.build(musicbrainz_id=mb_id)
-    assert artist.musicbrainz_id == UUID(mb_id)
+    assert artist.musicbrainz_id == mb_id
     with pytest.raises(pydantic.ValidationError):
         artist.musicbrainz_id = None
 

--- a/tests/models/test_track.py
+++ b/tests/models/test_track.py
@@ -1,5 +1,3 @@
-from uuid import UUID
-
 import pydantic
 import pytest
 
@@ -99,7 +97,7 @@ def test_bitrate():
 def test_musicbrainz_id():
     mb_id = "0383dadf-2a4e-4d10-a46a-e9e041da8eb3"
     track = TrackFactory.build(musicbrainz_id=mb_id)
-    assert track.musicbrainz_id == UUID(mb_id)
+    assert track.musicbrainz_id == mb_id
     with pytest.raises(pydantic.ValidationError):
         track.musicbrainz_id = None
 

--- a/tests/models/test_track.py
+++ b/tests/models/test_track.py
@@ -70,12 +70,20 @@ def test_disc_no():
         track.disc_no = None
 
 
-def test_date():
-    date = "1977-01-01"
+@pytest.mark.parametrize("date", ["1977", "1977-01", "1977-01-01"])
+def test_date(date):
     track = TrackFactory.build(date=date)
     assert track.date == date
     with pytest.raises(pydantic.ValidationError):
         track.date = None
+
+
+@pytest.mark.parametrize(
+    "date", ["77", "1977-1-1", "1977/01/01", "1977-01-01T00:00:00"]
+)
+def test_date_rejects_invalid(date):
+    with pytest.raises(pydantic.ValidationError):
+        TrackFactory.build(date=date)
 
 
 def test_length():

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -1,0 +1,35 @@
+import pytest
+
+from mopidy.models import Album
+from mopidy.types import Date, DateOrYear, Year
+
+
+@pytest.mark.parametrize(
+    ("cls", "value"),
+    [
+        (DateOrYear, "1977"),
+        (Date, "1977-01-01"),
+        (Year, "1977"),
+    ],
+)
+def test_deprecated_date_types_warn(cls, value):
+    with pytest.warns(DeprecationWarning, match="Use ReleaseDate instead"):
+        result = cls(value)
+
+    assert result == value
+    assert isinstance(result, str)
+
+
+def test_deprecated_date_types_are_accepted_by_models():
+    with pytest.warns(DeprecationWarning, match="Use ReleaseDate instead"):
+        date = Date("1977-01-01")
+
+    album = Album(name="Album", date=date)
+
+    assert album.date == "1977-01-01"
+    assert type(album.date) is str
+
+
+def test_date_and_year_are_subtypes_of_date_or_year():
+    assert issubclass(Date, DateOrYear)
+    assert issubclass(Year, DateOrYear)


### PR DESCRIPTION
See individual commits for details.

This should address most of the feedback from @fatg3erman in mopidy/mopidy-local#92.