### PR TITLE
fix(http): set Access-Control-Max-Age CORS header to avoid preflighting every request (#2043)

### DIFF
--- a/src/mopidy/_exts/http/handlers.py
+++ b/src/mopidy/_exts/http/handlers.py
@@ -277,6 +277,7 @@ class JsonRpcHandler(tornado.web.RequestHandler):
     def set_cors_headers(self, origin: str) -> None:
         self.set_header("Access-Control-Allow-Origin", f"{origin}")
         self.set_header("Access-Control-Allow-Headers", "Content-Type")
+        self.set_header("Access-Control-Max-Age", "86400")
 
     def options(self) -> Awaitable[None] | None:  # ty:ignore[invalid-method-override]
         if self.csrf_protection:

--- a/src/mopidy/_exts/http/handlers.py
+++ b/src/mopidy/_exts/http/handlers.py
@@ -5,7 +5,7 @@ import logging
 import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, cast, override
 
 import tornado.escape
 import tornado.ioloop
@@ -318,9 +318,10 @@ class ClientListHandler(tornado.web.RequestHandler):
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
+    @override
     def set_extra_headers(
         self,
-        path: str,  # noqa: ARG002
+        path: str,
     ) -> None:
         set_mopidy_headers(self)
 

--- a/src/mopidy/_exts/http/handlers.py
+++ b/src/mopidy/_exts/http/handlers.py
@@ -277,7 +277,6 @@ class JsonRpcHandler(tornado.web.RequestHandler):
     def set_cors_headers(self, origin: str) -> None:
         self.set_header("Access-Control-Allow-Origin", f"{origin}")
         self.set_header("Access-Control-Allow-Headers", "Content-Type")
-        self.set_header("Access-Control-Max-Age", "86400")
 
     def options(self) -> Awaitable[None] | None:  # ty:ignore[invalid-method-override]
         if self.csrf_protection:
@@ -288,6 +287,10 @@ class JsonRpcHandler(tornado.web.RequestHandler):
 
             assert origin
             self.set_cors_headers(origin)
+
+            # Let browsers cache this preflight response to avoid a preflight
+            # request before every request.
+            self.set_header("Access-Control-Max-Age", "7200")
 
         self.set_status(204)
         self.finish()

--- a/tests/_exts/http/test_handlers.py
+++ b/tests/_exts/http/test_handlers.py
@@ -151,9 +151,12 @@ class JsonRpcHandlerTestBase(tornado.testing.AsyncHTTPTestCase):
             "Access-Control-Allow-Headers",
             "Content-Type",
         )
+
+    def get_preflight_response_headers(self):
+        yield from self.get_cors_response_headers()
         yield (
             "Access-Control-Max-Age",
-            "86400",
+            "7200",
         )
 
     def test_head(self):
@@ -169,7 +172,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
         response = self.fetch("/rpc", method="OPTIONS", headers=self.headers)
 
         assert response.code == 204
-        for k, v in self.get_cors_response_headers():
+        for k, v in self.get_preflight_response_headers():
             assert response.headers[k] == v
 
     def test_options_bad_origin_forbidden(self):
@@ -178,7 +181,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
 
         assert response.code == 403
         assert response.reason == "Access denied for origin http://foo:6680"
-        for k, _ in self.get_cors_response_headers():
+        for k, _ in self.get_preflight_response_headers():
             assert k not in response.headers
 
     def test_options_no_origin_forbidden(self):
@@ -186,14 +189,14 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
 
         assert response.code == 403
         assert response.reason == "Access denied for origin None"
-        for k, _ in self.get_cors_response_headers():
+        for k, _ in self.get_preflight_response_headers():
             assert k not in response.headers
 
     def test_post_no_content_type_unsupported(self):
         response = self.fetch("/rpc", method="POST", body="hi", headers=self.headers)
 
         assert response.code == 415
-        for k, _ in self.get_cors_response_headers():
+        for k, _ in self.get_preflight_response_headers():
             assert k not in response.headers
 
     def test_post_wrong_content_type_unsupported(self):
@@ -202,7 +205,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
 
         assert response.code == 415
         assert response.reason == "Content-Type must be application/json"
-        for k, _ in self.get_cors_response_headers():
+        for k, _ in self.get_preflight_response_headers():
             assert k not in response.headers
 
     def test_post_no_origin_ok_but_doesnt_set_cors_headers(self):
@@ -210,7 +213,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
         response = self.fetch("/rpc", method="POST", body="hi", headers=self.headers)
 
         assert response.code == 200
-        for k, _ in self.get_cors_response_headers():
+        for k, _ in self.get_preflight_response_headers():
             assert k not in response.headers
 
     def test_post_with_origin_ok_sets_cors_headers(self):
@@ -223,6 +226,7 @@ class JsonRpcHandlerTestCSRFEnabled(JsonRpcHandlerTestBase):
         self.assert_extra_response_headers(response.headers)
         for k, v in self.get_cors_response_headers():
             assert response.headers[k] == v
+        assert "Access-Control-Max-Age" not in response.headers
 
 
 class JsonRpcHandlerTestCSRFDisabled(JsonRpcHandlerTestBase):
@@ -237,7 +241,7 @@ class JsonRpcHandlerTestCSRFDisabled(JsonRpcHandlerTestBase):
         response = self.fetch("/rpc", method="POST", body="hi", headers=self.headers)
 
         assert response.code == 200
-        for k, _ in self.get_cors_response_headers():
+        for k, _ in self.get_preflight_response_headers():
             assert k not in response.headers
 
 

--- a/tests/_exts/http/test_handlers.py
+++ b/tests/_exts/http/test_handlers.py
@@ -151,6 +151,10 @@ class JsonRpcHandlerTestBase(tornado.testing.AsyncHTTPTestCase):
             "Access-Control-Allow-Headers",
             "Content-Type",
         )
+        yield (
+            "Access-Control-Max-Age",
+            "86400",
+        )
 
     def test_head(self):
         response = self.fetch("/rpc", method="HEAD")

--- a/tests/_exts/http/test_server.py
+++ b/tests/_exts/http/test_server.py
@@ -217,6 +217,7 @@ class MopidyRPCHandlerNoCSRFProtectionTest(HttpServerTest):
 
         assert "Access-Control-Allow-Origin" not in response.headers
         assert "Access-Control-Allow-Headers" not in response.headers
+        assert "Access-Control-Max-Age" not in response.headers
 
 
 class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):


### PR DESCRIPTION
Closes #2043.

This PR adds the `Access-Control-Max-Age` CORS header to `mopidy`'s HTTP extension.

By setting `Access-Control-Max-Age: 86400`, we instruct browsers to cache the preflight response (OPTIONS request) for 24 hours (86400 seconds). This avoids unnecessary CORS preflighting on every single cross-origin request, improving overall API responsiveness and reducing server load.

### Changes
- Updated `set_cors_headers` in `mopidy/src/mopidy/_exts/http/handlers.py` to include `self.set_header("Access-Control-Max-Age", "86400")`.
- Updated test headers in `mopidy/tests/_exts/http/test_handlers.py` and `mopidy/tests/_exts/http/test_server.py` to assert the presence (and absence) of the new header correctly.
