### PR TITLE
Add CORS headers to static file responses

### DIFF
--- a/src/mopidy/_exts/http/actor.py
+++ b/src/mopidy/_exts/http/actor.py
@@ -200,13 +200,18 @@ class HttpServer(threading.Thread):
 
     def _get_static_request_handlers(self) -> list[RequestRule]:
         result = []
+        http_config = cast(HttpConfig, self.config[Extension.ext_name])
         for static in self.statics:
             result.append((f"/{static['name']}", handlers.AddSlashHandler))
             result.append(
                 (
                     f"/{static['name']}/(.*)",
                     handlers.StaticFileHandler,
-                    {"path": static["path"], "default_filename": "index.html"},
+                    {
+                        "path": static["path"],
+                        "default_filename": "index.html",
+                        "allowed_origins": http_config["allowed_origins"],
+                    },
                 ),
             )
             logger.debug("Loaded static HTTP extension: %s", static["name"])

--- a/src/mopidy/_exts/http/handlers.py
+++ b/src/mopidy/_exts/http/handlers.py
@@ -65,6 +65,7 @@ def make_mopidy_app_factory(
                 StaticFileHandler,
                 {
                     "path": str(Path(__file__).parent / "data"),
+                    "allowed_origins": http_config["allowed_origins"],
                 },
             ),
             (
@@ -198,7 +199,7 @@ def set_mopidy_headers(request_handler: tornado.web.RequestHandler) -> None:
 def check_origin(
     origin: str | None,
     request_headers: tornado.httputil.HTTPHeaders,
-    allowed_origins: set[str],
+    allowed_origins: set[str] | frozenset[str],
 ) -> bool:
     if origin is None:
         logger.warning("HTTP request denied for missing Origin header")
@@ -314,12 +315,26 @@ class ClientListHandler(tornado.web.RequestHandler):
 
 
 class StaticFileHandler(tornado.web.StaticFileHandler):
+    def initialize(
+        self,
+        path: str,
+        default_filename: str | None = None,
+        allowed_origins: set[str] | frozenset[str] = frozenset(),
+        ) -> None:
+        super().initialize(path, default_filename=default_filename)
+        self.allowed_origins = allowed_origins
     def set_extra_headers(
         self,
-        path: str,  # noqa: ARG002
-    ) -> None:
+        path: str, # noqa: ARG002
+        ) -> None:
         set_mopidy_headers(self)
-
+        origin = self.request.headers.get("Origin")
+        if origin is not None and check_origin(
+            origin,
+            self.request.headers,
+            self.allowed_origins,
+        ):
+            self.set_header("Access-Control-Allow-Origin", origin)
 
 class AddSlashHandler(tornado.web.RequestHandler):
     @tornado.web.addslash

--- a/tests/_exts/http/test_handlers.py
+++ b/tests/_exts/http/test_handlers.py
@@ -22,6 +22,7 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
                     {
                         "path": Path(__file__).parent,
                         "default_filename": "test_handlers.py",
+                        "allowed_origins": frozenset({"allowed.example"}),
                     },
                 ),
             ],
@@ -40,6 +41,18 @@ class StaticFileHandlerTest(tornado.testing.AsyncHTTPTestCase):
         assert response.code == 200
         assert response.headers["X-Mopidy-Version"] == mopidy.__version__
         assert response.headers["Cache-Control"] == "no-cache"
+    def test_static_handler_sets_cors_header_for_allowed_origin(self):
+        response = self.fetch(
+            "/test_handlers.py",
+            method="GET",
+            headers={
+                "Host": "localhost:8888",
+                "Origin": "http://allowed.example",
+            },
+        )
+
+        assert response.code == 200
+        assert response.headers["Access-Control-Allow-Origin"] == "http://allowed.example"
 
 
 class WebSocketHandlerTest(tornado.testing.AsyncHTTPTestCase):

--- a/tests/_exts/http/test_server.py
+++ b/tests/_exts/http/test_server.py
@@ -226,6 +226,7 @@ class HttpServerWithStaticFilesTest(tornado.testing.AsyncHTTPTestCase):
                 "hostname": "127.0.0.1",
                 "port": 6680,
                 "zeroconf": "",
+                "allowed_origins": frozenset(),
                 "default_app": "static",
             },
         }
@@ -366,6 +367,7 @@ class HttpServerWithStaticDefaultApp(tornado.testing.AsyncHTTPTestCase):
                 "hostname": "127.0.0.1",
                 "port": 6680,
                 "zeroconf": "",
+                "allowed_origins": frozenset(),
                 "default_app": "default_app",
             },
         }


### PR DESCRIPTION
Fixes #1953

This adds CORS headers to static file responses when the request origin is allowed by the HTTP configuration.

The change:

passes allowed_origins to static file handlers
validates the request origin using the existing check_origin() logic
adds Access-Control-Allow-Origin for allowed origins
adds test coverage for CORS headers on static file responses

Tests:

pytest tests/_exts/http/ (103 passed)
ruff check .
ty check src/mopidy/_exts/http/handlers.py
git diff --check