### PR TITLE
Include http data in wheel builds

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -186,7 +186,7 @@ disable = [
 
 [tool.setuptools.package-data]
 "*" = ["*.conf"]
-"mopidy.http.data" = ["*"]
+"mopidy._exts.http.data" = ["*"]
 
 
 [tool.setuptools_scm]


### PR DESCRIPTION
Fixes #2292

With commit https://github.com/mopidy/mopidy/commit/5cf96b5c689f757573902ec16246c87ff1cd7244 only files under mopidy.http.data get included in the wheel build. However, with commit https://github.com/mopidy/mopidy/commit/a4f60138d316982c5aede428dde22d2c262b470d this path has been changed to mopidy._ext.http.data but line 181 of pyproject.toml has been left unaltered. This PR includes the required fix:

"mopidy.http.data" = [""] -> "mopidy._ext.http.data" = [""]