### PR TITLE
tests: assert plain text is not playable rather than that it errors

### DIFF
--- a/tests/audio/test_scan.py
+++ b/tests/audio/test_scan.py
@@ -112,10 +112,12 @@ class ScannerTest(unittest.TestCase):
         assert self.result[path].mime == "text/uri-list"
 
     def test_text_plain(self):
-        # GStreamer decode bin hardcodes bad handling of text plain :/
+        # GStreamer either fails to typefind plain text at all, or, since
+        # 1.28.5, types .txt as application/x-subtitle by extension.
+        # Neither outcome is playable.
         path = path_to_data_dir("scanner/plain.txt")
         self.scan([path])
-        assert path in self.errors
+        assert path in self.errors or not self.result[path].playable
 
     @unittest.SkipTest
     def test_song_without_time_is_handeled(self):


### PR DESCRIPTION
test_text_plain asserted that scanning a plain text file raises ScannerError. That pinned a GStreamer failure mode, not anything Mopidy promises.

GStreamer 1.28.5 dropped a filter from gst_type_find_helper_for_extension() in libs/gst/base/gsttypefindhelper.c (gstreamer!12020), so the extension fallback now also matches typefinders that have a typefind function. gst-plugins-base registers "txt" under application/x-subtitle (gst/subparse/gstsubparseelement.c, GST_RANK_MARGINAL).

tests/data/scanner/plain.txt is 49 bytes. utf8_type_find never peeks below 128 bytes, so content typefinding finds nothing and the extension fallback types the file as a subtitle. decodebin exposes a stream instead of erroring, and Scanner.scan() returns a result.

Nothing in Mopidy broke. The contract is that plain text is not playable, so assert that. Accepting both outcomes keeps the test passing on GStreamer before and after 1.28.5.

The old comment was also wrong. On GStreamer 1.28.4 the error came from typefind, "Could not determine type of stream", not from decodebin's text/plain handling.

Ubuntu bug: https://bugs.launchpad.net/ubuntu/+source/mopidy/+bug/2166077