### PR TITLE
fix: List all params in core.describe()

### DIFF
--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -18,6 +18,12 @@ For older releases, see:
   `package-data` config was not updated when the bundled extensions moved to
   `mopidy._exts`. (#2292, !2293)
 
+- HTTP extension: Fix `core.describe()` so that it lists all params of a method.
+  Keyword-only params, like `at_position` and `uris` on
+  [`core.tracklist.add()`][mopidy.core.TracklistController.add], were left out.
+  Deprecated methods were described with the `*args, **kwargs` of the wrapper
+  added by the `deprecated` decorator instead of their own params. (#2284, !2296)
+
 - Docs: Update the macOS install instructions for current Homebrew. (!2291)
 
 ## v4.0.2 (2026-08-19)

--- a/src/mopidy/_exts/http/jsonrpc.py
+++ b/src/mopidy/_exts/http/jsonrpc.py
@@ -15,7 +15,6 @@ from pydantic import (
     field_validator,
     model_serializer,
 )
-from pydantic_core import PydanticUndefined, PydanticUndefinedType
 
 from mopidy import models
 
@@ -462,26 +461,21 @@ class Inspector:
         self,
         method: Callable[..., Any],
     ) -> list[ParamDescription]:
-        argspec = inspect.getfullargspec(method)
-
-        with_defaults: list[Any] = list(argspec.defaults) if argspec.defaults else []
-        num_args_without_default = len(argspec.args) - len(with_defaults)
-        without_defaults: list[PydanticUndefinedType] = [
-            PydanticUndefined
-        ] * num_args_without_default
-        defaults = without_defaults + with_defaults
-
         params: list[ParamDescription] = []
 
-        for arg, default in zip(argspec.args, defaults, strict=True):
-            if arg == "self":
+        for name, param in inspect.signature(method).parameters.items():
+            if name == "self":
                 continue
-            params.append(ParamDescription(name=arg, default=default))
-
-        if argspec.varargs:
-            params.append(ParamDescription(name=argspec.varargs, varargs=True))
-
-        if argspec.varkw:
-            params.append(ParamDescription(name=argspec.varkw, kwargs=True))
+            match param.kind:
+                case inspect.Parameter.VAR_POSITIONAL:
+                    params.append(ParamDescription(name=name, varargs=True))
+                case inspect.Parameter.VAR_KEYWORD:
+                    params.append(ParamDescription(name=name, kwargs=True))
+                case _ if param.default is inspect.Parameter.empty:
+                    params.append(ParamDescription(name=name))
+                case _:
+                    params.append(
+                        ParamDescription(name=name, default=param.default),
+                    )
 
         return params

--- a/tests/_exts/http/test_jsonrpc.py
+++ b/tests/_exts/http/test_jsonrpc.py
@@ -43,6 +43,8 @@ class Calculator:
         b: Any,
         c: bool = True,
         *args: Any,
+        d: Any,
+        e: bool = False,
         **kwargs: Any,
     ) -> None:
         pass
@@ -683,10 +685,18 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
         assert params[3].varargs is True
         assert params[3].model_dump_json() == '{"name":"args","varargs":true}'
 
-        assert params[4].name == "kwargs"
+        assert params[4].name == "d"
         assert params[4].default is jsonrpc.Unset
-        assert params[4].kwargs is True
-        assert params[4].model_dump_json() == '{"name":"kwargs","kwargs":true}'
+        assert params[4].model_dump_json() == '{"name":"d"}'
+
+        assert params[5].name == "e"
+        assert params[5].default is False
+        assert params[5].model_dump_json() == '{"name":"e","default":false}'
+
+        assert params[6].name == "kwargs"
+        assert params[6].default is jsonrpc.Unset
+        assert params[6].kwargs is True
+        assert params[6].model_dump_json() == '{"name":"kwargs","kwargs":true}'
 
     def test_inspector_can_describe_a_bunch_of_large_classes(self) -> None:
         inspector = jsonrpc.Inspector(
@@ -715,3 +725,18 @@ class JsonRpcInspectorTest(JsonRpcTestBase):
 
         assert "core.tracklist.filter" in methods
         assert methods["core.tracklist.filter"].params[0].name == "criteria"
+
+        # Keyword-only params are described too
+        assert "core.tracklist.add" in methods
+        assert [p.name for p in methods["core.tracklist.add"].params] == [
+            "tracks",
+            "at_position",
+            "uris",
+        ]
+
+        # Deprecated methods are described with their own params, not with the
+        # params of the wrapper added by the `deprecated` decorator
+        assert "core.tracklist.eot_track" in methods
+        assert [p.name for p in methods["core.tracklist.eot_track"].params] == [
+            "tl_track",
+        ]


### PR DESCRIPTION
The JSON-RPC inspector used `inspect.getfullargspec()`, which ignores keyword-only params and does not follow the `__wrapped__` chain. Thus `core.describe()` left out the `at_position` and `uris` params of `core.tracklist.add()`, and described the deprecated methods with the `*args` and `**kwargs` of the wrapper added by the deprecated decorator.

Use `inspect.signature()` instead, which covers all param kinds and unwraps decorated methods.

Fixes #2284