### PR TITLE
feat: Add Python 3.15 to the test matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,9 @@ jobs:
             python: "3.14"
             tox: "3.14"
             coverage: true
+          - name: "pytest (3.15)"
+            python: "3.15"
+            tox: "3.15"
           - name: "pyright"
             python: "3.14"
             tox: "pyright"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,26 +67,22 @@ jobs:
     container: ghcr.io/mopidy/ci:latest # zizmor: ignore[unpinned-images]
     permissions:
       contents: read # Check out the repository.
+    env:
+      PYTHON: ${{ matrix.python }}
+      TOX_ENV: ${{ matrix.tox }}
+      UV_PYTHON_PREFERENCE: only-managed
 
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - name: Fix home dir permissions to enable pip caching
-        run: chown -R root /github/home
-      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+      - uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d # v10.0.1
         with:
-          python-version: ${{ matrix.python }}
-          cache: pip
-          allow-prereleases: true
-      - run: python -m pip install tox tox-uv
-      - env:
-          TOX_ENV: ${{ matrix.tox }}
-        run: python -m tox -e "$TOX_ENV"
+          enable-cache: true
+      - run: uv python install "$PYTHON"
+      - run: uvx --python "$PYTHON" --with tox-uv tox -e "$TOX_ENV"
         if: ${{ ! matrix.coverage }}
-      - env:
-          TOX_ENV: ${{ matrix.tox }}
-        run: python -m tox -e "$TOX_ENV" -- --cov-report=xml
+      - run: uvx --python "$PYTHON" --with tox-uv tox -e "$TOX_ENV" -- --cov-report=xml
         if: ${{ matrix.coverage }}
       - uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         if: ${{ matrix.coverage }}

--- a/docs/changelog/index.md
+++ b/docs/changelog/index.md
@@ -26,6 +26,8 @@ For older releases, see:
 
 - Docs: Update the macOS install instructions for current Homebrew. (!2291)
 
+- Dev: Add Python 3.15 to the test matrix, in tox and in CI.
+
 ## v4.0.2 (2026-08-19)
 
 - Models: The `musicbrainz_id` fields on [`Album`][mopidy.models.Album],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,6 +197,7 @@ env_list = [
     "3.13-lowest",
     "3.13",
     "3.14",
+    "3.15",
     "pyright",
     "rumdl",
     "ruff-check",
@@ -221,6 +222,12 @@ commands = [
 [tool.tox.env."3.13-lowest"]
 base_python = ["python3.13"]
 uv_resolution = "lowest-direct"
+
+[tool.tox.env."3.15"]
+# Pydantic 2.13 pins pydantic-core 2.46, which has no cp315 wheels. The beta of
+# Pydantic 2.14 pins a pydantic-core version that has them.
+# TODO: Remove when Pydantic 2.14 is released.
+deps = ["pydantic >= 2.14.0b1"]
 
 [tool.tox.env.pyright]
 dependency_groups = ["typing"]


### PR DESCRIPTION
Switch to uv-installed Python, as our CI image doesn't include any Python versions newer than 3.14 and `actions/setup-python` only support installing extra Python versions on Ubuntu- and RHEL-based images.

The 3.15 env installs the Pydantic 2.14 beta. Pydantic 2.13 pins pydantic-core 2.46, which has no cp315 wheels, and the CI image has no Rust toolchain to build it from source.